### PR TITLE
Wire up do_refresh_token() overrides for Instagram, Threads, and Facebook

### DIFF
--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -203,7 +203,7 @@ class InstagramPublishAbility {
 		}
 
 		$user_id = $provider->get_user_id();
-		$access_token = $provider->get_access_token();
+		$access_token = $provider->get_valid_access_token();
 
 		if ( empty( $user_id ) || empty( $access_token ) ) {
 			return array(

--- a/inc/Abilities/Threads/ThreadsPublishAbility.php
+++ b/inc/Abilities/Threads/ThreadsPublishAbility.php
@@ -151,7 +151,7 @@ class ThreadsPublishAbility {
 		}
 
 		$user_id = $provider->get_user_id();
-		$access_token = $provider->get_access_token();
+		$access_token = $provider->get_valid_access_token();
 
 		if ( empty( $user_id ) || empty( $access_token ) ) {
 			return array(

--- a/inc/Handlers/Facebook/FacebookAuth.php
+++ b/inc/Handlers/Facebook/FacebookAuth.php
@@ -63,7 +63,10 @@ class FacebookAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	* Check if admin has valid Facebook authentication
+	* Check if admin has valid Facebook authentication.
+	*
+	* Facebook uses a dual token system (user + page), so we override
+	* the base class to check both tokens exist.
 	*
 	* @return bool True if authenticated
 	*/
@@ -85,17 +88,158 @@ class FacebookAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	* Get stored Page access token (Facebook-specific)
+	* Perform Facebook-specific token refresh.
+	*
+	* Facebook long-lived user tokens are refreshed via the fb_exchange_token grant,
+	* which requires client_id and client_secret. After refreshing the user token,
+	* we also re-fetch page credentials since the page token depends on the user token.
+	*
+	* Note: The base class calls this with the `access_token` key from stored data.
+	* Facebook stores user token as `user_access_token`, so we override
+	* get_valid_access_token() to bridge the key difference.
+	*
+	* @since 0.3.0
+	* @param string $current_token The current user access token to refresh.
+	* @return array|\WP_Error|null Token data on success, WP_Error on failure.
+	*/
+	protected function do_refresh_token( string $current_token ): array|\WP_Error|null {
+		$config = $this->get_config();
+		if ( empty( $config['app_id'] ) || empty( $config['app_secret'] ) ) {
+			return new \WP_Error( 'facebook_refresh_missing_config', 'Facebook OAuth configuration is incomplete.' );
+		}
+
+		$params = array(
+			'grant_type'        => 'fb_exchange_token',
+			'client_id'         => $config['app_id'],
+			'client_secret'     => $config['app_secret'],
+			'fb_exchange_token' => $current_token,
+		);
+		$url = self::TOKEN_URL . '?' . http_build_query( $params );
+
+		$result = HttpClient::get( $url, array( 'context' => 'Facebook OAuth' ) );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error( 'facebook_refresh_http_error', $result['error'] );
+		}
+
+		$body      = $result['data'];
+		$data      = json_decode( $body, true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || empty( $data['access_token'] ) ) {
+			$error_message = $data['error']['message'] ?? $data['error_description'] ?? 'Failed to refresh Facebook access token.';
+			return new \WP_Error( 'facebook_refresh_api_error', $error_message, $data );
+		}
+
+		$new_user_token = $data['access_token'];
+		$expires_in     = $data['expires_in'] ?? 3600 * 24 * 60;
+		$expires_at     = time() + intval( $expires_in );
+
+		// Re-fetch page credentials with the new user token.
+		$page_credentials = $this->get_page_credentials( $new_user_token );
+		if ( is_wp_error( $page_credentials ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Facebook: Page credential refresh failed after user token refresh',
+				array( 'error' => $page_credentials->get_error_message() )
+			);
+			// Return the refreshed user token even if page refresh fails — page token may still work.
+		}
+
+		// Build return data — the base class will store access_token + expires_at.
+		// We also need to update the Facebook-specific fields, so we do a full
+		// account update here rather than relying solely on the base class.
+		$account = $this->get_account();
+		$account['user_access_token'] = $new_user_token;
+		$account['token_expires_at']  = $expires_at;
+		$account['last_refreshed_at'] = time();
+
+		if ( ! is_wp_error( $page_credentials ) ) {
+			$account['page_access_token'] = $page_credentials['access_token'];
+			$account['page_id']           = $page_credentials['id'];
+			$account['page_name']         = $page_credentials['name'];
+		}
+
+		$this->save_account( $account );
+		$this->schedule_proactive_refresh();
+
+		return array(
+			'access_token' => $new_user_token,
+			'expires_at'   => $expires_at,
+		);
+	}
+
+	/**
+	* Get a valid user access token, refreshing if close to expiry.
+	*
+	* Overrides the base class because Facebook stores the user token as
+	* `user_access_token` instead of the standard `access_token` key.
+	*
+	* @since 0.3.0
+	* @return string|null Valid user access token, or null if unavailable/expired.
+	*/
+	public function get_valid_user_access_token(): ?string {
+		$account = $this->get_account();
+		if ( empty( $account ) || ! is_array( $account ) || empty( $account['user_access_token'] ) ) {
+			return null;
+		}
+
+		$current_token = $account['user_access_token'];
+		$needs_refresh = false;
+
+		if ( isset( $account['token_expires_at'] ) ) {
+			$expiry_timestamp = intval( $account['token_expires_at'] );
+			$buffer           = $this->get_refresh_buffer_seconds();
+
+			if ( time() > $expiry_timestamp ) {
+				$needs_refresh = true;
+			} elseif ( ( $expiry_timestamp - time() ) < $buffer ) {
+				$needs_refresh = true;
+			}
+		}
+
+		if ( $needs_refresh ) {
+			$refreshed = $this->do_refresh_token( $current_token );
+
+			if ( null === $refreshed ) {
+				if ( isset( $account['token_expires_at'] ) && time() > intval( $account['token_expires_at'] ) ) {
+					return null;
+				}
+				return $current_token;
+			}
+
+			if ( ! is_wp_error( $refreshed ) && ! empty( $refreshed['access_token'] ) ) {
+				return $refreshed['access_token'];
+			}
+
+			// Refresh failed — return current if not hard-expired.
+			if ( isset( $account['token_expires_at'] ) && time() > intval( $account['token_expires_at'] ) ) {
+				return null;
+			}
+			return $current_token;
+		}
+
+		return $current_token;
+	}
+
+	/**
+	* Get a valid page access token, refreshing the user token if needed.
+	*
+	* If the user token needs refresh, do_refresh_token() will also re-fetch
+	* the page token. After refresh, the stored page_access_token is current.
 	*
 	* @return string|null Page access token or null
 	*/
 	public function get_page_access_token(): ?string {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) || empty( $account['page_access_token'] ) ) {
+		// Trigger user token refresh if needed (which also refreshes page token).
+		$user_token = $this->get_valid_user_access_token();
+		if ( null === $user_token ) {
 			return null;
 		}
 
-		if ( isset( $account['token_expires_at'] ) && time() > $account['token_expires_at'] ) {
+		$account = $this->get_account();
+		if ( empty( $account ) || ! is_array( $account ) || empty( $account['page_access_token'] ) ) {
 			return null;
 		}
 
@@ -103,21 +247,12 @@ class FacebookAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	* Get stored User access token (Facebook-specific)
+	* Get a valid user access token with automatic refresh.
 	*
 	* @return string|null User access token or null
 	*/
 	public function get_user_access_token(): ?string {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) || empty( $account['user_access_token'] ) ) {
-			return null;
-		}
-
-		if ( isset( $account['token_expires_at'] ) && time() > $account['token_expires_at'] ) {
-			return null;
-		}
-
-		return $account['user_access_token'];
+		return $this->get_valid_user_access_token();
 	}
 
 	/**
@@ -211,7 +346,10 @@ class FacebookAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					$config
 				);
 			},
-			array( $this, 'save_account' )
+			function ( $account_data ) {
+				$this->save_account( $account_data );
+				$this->schedule_proactive_refresh();
+			}
 		);
 	}
 

--- a/inc/Handlers/Instagram/InstagramAuth.php
+++ b/inc/Handlers/Instagram/InstagramAuth.php
@@ -62,68 +62,45 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Check if admin has valid Instagram authentication
+	 * Perform Instagram-specific token refresh.
 	 *
-	 * @return bool True if authenticated
-	 */
-	public function is_authenticated(): bool {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) ) {
-			return false;
-		}
-
-		if ( empty( $account['access_token'] ) ) {
-			return false;
-		}
-
-		if ( isset( $account['token_expires_at'] ) && time() > $account['token_expires_at'] ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Get access token with automatic refresh (Instagram-specific)
+	 * Instagram long-lived tokens are refreshed via the ig_refresh_token grant.
+	 * Delegates to BaseOAuth2Provider::get_valid_access_token() for on-demand
+	 * refresh with 7-day buffer (inherited default).
 	 *
-	 * @return string|null Access token or null
+	 * @since 0.3.0
+	 * @param string $current_token The current access token to refresh.
+	 * @return array|\WP_Error|null Token data on success, WP_Error on failure.
 	 */
-	public function get_access_token(): ?string {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) || empty( $account['access_token'] ) ) {
-			return null;
+	protected function do_refresh_token( string $current_token ): array|\WP_Error|null {
+		$url    = self::GRAPH_API_URL . '/refresh_access_token';
+		$params = array(
+			'grant_type'   => 'ig_refresh_token',
+			'access_token' => $current_token,
+		);
+
+		$result = HttpClient::get( $url . '?' . http_build_query( $params ), array( 'context' => 'Instagram OAuth' ) );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error( 'instagram_refresh_http_error', $result['error'] );
 		}
 
-		// Check if token needs refresh (expires within the next 7 days)
-		$needs_refresh = false;
-		if ( isset( $account['token_expires_at'] ) ) {
-			$expiry_timestamp = intval( $account['token_expires_at'] );
-			$seven_days_in_seconds = 7 * 24 * 60 * 60;
-			if ( time() > $expiry_timestamp ) {
-				$needs_refresh = true;
-			} elseif ( ( $expiry_timestamp - time() ) < $seven_days_in_seconds ) {
-				$needs_refresh = true;
-			}
+		$body      = $result['data'];
+		$data      = json_decode( $body, true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || empty( $data['access_token'] ) ) {
+			$error_message = $data['error']['message'] ?? $data['error_description'] ?? 'Failed to refresh Instagram access token.';
+			return new \WP_Error( 'instagram_refresh_api_error', $error_message, $data );
 		}
 
-		$current_token = $account['access_token'];
+		$expires_in = $data['expires_in'] ?? 3600 * 24 * 60;
+		$expires_at = time() + intval( $expires_in );
 
-		if ( $needs_refresh ) {
-			$refreshed_data = $this->refresh_access_token( $current_token );
-			if ( ! is_wp_error( $refreshed_data ) ) {
-				$account['access_token'] = $refreshed_data['access_token'];
-				$account['token_expires_at'] = $refreshed_data['expires_at'];
-				$this->save_account( $account );
-				return $refreshed_data['access_token'];
-			} else {
-				if ( isset( $account['token_expires_at'] ) && time() > intval( $account['token_expires_at'] ) ) {
-					return null;
-				}
-				return $current_token;
-			}
-		}
-
-		return $current_token;
+		return array(
+			'access_token' => $data['access_token'],
+			'expires_at'   => $expires_at,
+		);
 	}
 
 	/**
@@ -202,7 +179,10 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 				);
 			},
 			null, // No token transform needed after exchange
-			array( $this, 'save_account' )
+			function ( $account_data ) {
+				$this->save_account( $account_data );
+				$this->schedule_proactive_refresh();
+			}
 		);
 	}
 
@@ -262,10 +242,10 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		do_action( 'datamachine_log', 'debug', 'Instagram OAuth: Successfully exchanged for long-lived token', array( 'user_id' => $user_id ) );
 
 		return array(
-			'access_token' => $long_lived_token,
-			'user_id' => $user_id,
-			'username' => $username,
-			'expires_at' => $expires_at,
+			'access_token'    => $long_lived_token,
+			'user_id'         => $user_id,
+			'username'        => $username,
+			'token_expires_at' => $expires_at,
 		);
 	}
 
@@ -310,43 +290,6 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		}
 
 		return $data['username'] ?? '';
-	}
-
-	/**
-	 * Refresh long-lived Instagram access token (Instagram-specific)
-	 *
-	 * @param string $access_token Current long-lived token
-	 * @return array|\WP_Error ['access_token' => ..., 'expires_at' => ...] or error
-	 */
-	private function refresh_access_token( string $access_token ): array|\WP_Error {
-		$url = self::GRAPH_API_URL . '/refresh_access_token';
-		$params = array(
-			'grant_type' => 'ig_refresh_token',
-			'access_token' => $access_token,
-		);
-
-		$result = HttpClient::get( $url . '?' . http_build_query( $params ), array( 'context' => 'Instagram OAuth' ) );
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error( 'instagram_refresh_http_error', $result['error'] );
-		}
-
-		$body = $result['data'];
-		$data = json_decode( $body, true );
-		$http_code = $result['status_code'];
-
-		if ( 200 !== $http_code || empty( $data['access_token'] ) ) {
-			$error_message = $data['error']['message'] ?? $data['error_description'] ?? 'Failed to refresh Instagram access token.';
-			return new \WP_Error( 'instagram_refresh_api_error', $error_message, $data );
-		}
-
-		$expires_in = $data['expires_in'] ?? 3600 * 24 * 60;
-		$expires_at = time() + intval( $expires_in );
-
-		return array(
-			'access_token' => $data['access_token'],
-			'expires_at' => $expires_at,
-		);
 	}
 
 	/**

--- a/inc/Handlers/Threads/ThreadsAuth.php
+++ b/inc/Handlers/Threads/ThreadsAuth.php
@@ -62,68 +62,45 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	* Check if admin has valid Threads authentication
+	* Perform Threads-specific token refresh.
 	*
-	* @return bool True if authenticated
-	*/
-	public function is_authenticated(): bool {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) ) {
-			return false;
-		}
-
-		if ( empty( $account['access_token'] ) ) {
-			return false;
-		}
-
-		if ( isset( $account['token_expires_at'] ) && time() > $account['token_expires_at'] ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	* Get access token with automatic refresh (Threads-specific)
+	* Threads long-lived tokens are refreshed via the th_refresh_token grant.
+	* Delegates to BaseOAuth2Provider::get_valid_access_token() for on-demand
+	* refresh with 7-day buffer (inherited default).
 	*
-	* @return string|null Access token or null
+	* @since 0.3.0
+	* @param string $current_token The current access token to refresh.
+	* @return array|\WP_Error|null Token data on success, WP_Error on failure.
 	*/
-	public function get_access_token(): ?string {
-		$account = $this->get_account();
-		if ( empty( $account ) || ! is_array( $account ) || empty( $account['access_token'] ) ) {
-			return null;
+	protected function do_refresh_token( string $current_token ): array|\WP_Error|null {
+		$params = array(
+			'grant_type'   => 'th_refresh_token',
+			'access_token' => $current_token,
+		);
+		$url = self::REFRESH_URL . '?' . http_build_query( $params );
+
+		$result = HttpClient::get( $url, array( 'context' => 'Threads OAuth' ) );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error( 'threads_refresh_http_error', $result['error'] );
 		}
 
-		// Check if token needs refresh (expires within the next 7 days)
-		$needs_refresh = false;
-		if ( isset( $account['token_expires_at'] ) ) {
-			$expiry_timestamp = intval( $account['token_expires_at'] );
-			$seven_days_in_seconds = 7 * 24 * 60 * 60;
-			if ( time() > $expiry_timestamp ) {
-				$needs_refresh = true;
-			} elseif ( ( $expiry_timestamp - time() ) < $seven_days_in_seconds ) {
-				$needs_refresh = true;
-			}
+		$body      = $result['data'];
+		$data      = json_decode( $body, true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || empty( $data['access_token'] ) ) {
+			$error_message = $data['error']['message'] ?? $data['error_description'] ?? 'Failed to refresh Threads access token.';
+			return new \WP_Error( 'threads_refresh_api_error', $error_message, $data );
 		}
 
-		$current_token = $account['access_token'];
+		$expires_in = $data['expires_in'] ?? 3600 * 24 * 60;
+		$expires_at = time() + intval( $expires_in );
 
-		if ( $needs_refresh ) {
-			$refreshed_data = $this->refresh_access_token( $current_token );
-			if ( ! is_wp_error( $refreshed_data ) ) {
-				$account['access_token'] = $refreshed_data['access_token'];
-				$account['token_expires_at'] = $refreshed_data['expires_at'];
-				$this->save_account( $account );
-				return $refreshed_data['access_token'];
-			} else {
-				if ( isset( $account['token_expires_at'] ) && time() > intval( $account['token_expires_at'] ) ) {
-					return null;
-				}
-				return $current_token;
-			}
-		}
-
-		return $current_token;
+		return array(
+			'access_token' => $data['access_token'],
+			'expires_at'   => $expires_at,
+		);
 	}
 
 	/**
@@ -180,7 +157,7 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			),
 			function ( $long_lived_token_data ) {
 				// Build account data from long-lived token
-				$access_token = $long_lived_token_data['access_token'];
+				$access_token     = $long_lived_token_data['access_token'];
 				$token_expires_at = $long_lived_token_data['expires_at'];
 
 				// Fetch posting entity info
@@ -193,10 +170,10 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 				}
 
 				return array(
-					'access_token' => $access_token,
-					'token_type' => 'bearer',
-					'page_id' => $posting_entity_info['id'],
-					'page_name' => $posting_entity_info['name'] ?? 'Unknown Page/User',
+					'access_token'     => $access_token,
+					'token_type'       => 'bearer',
+					'page_id'          => $posting_entity_info['id'],
+					'page_name'        => $posting_entity_info['name'] ?? 'Unknown Page/User',
 					'authenticated_at' => time(),
 					'token_expires_at' => $token_expires_at,
 				);
@@ -208,7 +185,10 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					$config
 				);
 			},
-			array( $this, 'save_account' )
+			function ( $account_data ) {
+				$this->save_account( $account_data );
+				$this->schedule_proactive_refresh();
+			}
 		);
 	}
 
@@ -320,43 +300,6 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
 		do_action( 'datamachine_log', 'debug', 'Threads OAuth: Profile fetched successfully', array( 'profile_id' => $data['id'] ) );
 		return $data;
-	}
-
-	/**
-	* Refresh long-lived Threads access token (Threads-specific)
-	*
-	* @param string $access_token Current long-lived token
-	* @return array|\WP_Error ['access_token' => ..., 'expires_at' => ...] or error
-	*/
-	private function refresh_access_token( string $access_token ): array|\WP_Error {
-		$params = array(
-			'grant_type' => 'th_refresh_token',
-			'access_token' => $access_token,
-		);
-		$url = self::REFRESH_URL . '?' . http_build_query( $params );
-
-		$result = HttpClient::get( $url, array( 'context' => 'Threads OAuth' ) );
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error( 'threads_refresh_http_error', $result['error'] );
-		}
-
-		$body = $result['data'];
-		$data = json_decode( $body, true );
-		$http_code = $result['status_code'];
-
-		if ( 200 !== $http_code || empty( $data['access_token'] ) ) {
-			$error_message = $data['error']['message'] ?? $data['error_description'] ?? 'Failed to refresh Threads access token.';
-			return new \WP_Error( 'threads_refresh_api_error', $error_message, $data );
-		}
-
-		$expires_in = $data['expires_in'] ?? 3600 * 24 * 60;
-		$expires_at = time() + intval( $expires_in );
-
-		return array(
-			'access_token' => $data['access_token'],
-			'expires_at' => $expires_at,
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **InstagramAuth**: Replaced duplicated `is_authenticated()`, `get_access_token()`, and `refresh_access_token()` with a single `do_refresh_token()` override. The base class `get_valid_access_token()` now handles on-demand refresh with 7-day buffer.
- **ThreadsAuth**: Same pattern — replaced duplicated methods with `do_refresh_token()` override using `th_refresh_token` grant.
- **FacebookAuth**: Added `do_refresh_token()` using `fb_exchange_token` grant (requires client credentials). Added `get_valid_user_access_token()` to bridge Facebook's `user_access_token` key vs base class `access_token`. `get_page_access_token()` and `get_user_access_token()` now auto-refresh. Re-fetches page credentials on user token refresh.
- All three OAuth callbacks now call `schedule_proactive_refresh()` after `save_account()` for WP-Cron background refresh.
- `InstagramPublishAbility` and `ThreadsPublishAbility` updated to use `get_valid_access_token()`.

## Depends on

- data-machine PR #439 (`feature/oauth2-token-lifecycle`) — adds `BaseOAuth2Provider::get_valid_access_token()`, `do_refresh_token()`, `schedule_proactive_refresh()`, and cron infrastructure.

## What changed

| File | Change |
|------|--------|
| `InstagramAuth.php` | -86 lines: removed `is_authenticated()`, `get_access_token()`, `refresh_access_token()`. Added `do_refresh_token()` override. |
| `ThreadsAuth.php` | -88 lines: same pattern as Instagram. |
| `FacebookAuth.php` | +138 lines: added `do_refresh_token()`, `get_valid_user_access_token()`, updated `get_page_access_token()` and `get_user_access_token()` to auto-refresh. |
| `InstagramPublishAbility.php` | `get_access_token()` → `get_valid_access_token()` |
| `ThreadsPublishAbility.php` | `get_access_token()` → `get_valid_access_token()` |

Net: 231 additions, 207 deletions.

Resolves provider override work from data-machine#435.