### PR TITLE
feat: Add Reddit CLI, REST API, and chat tool wrappers

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -141,5 +141,22 @@ add_action( 'admin_enqueue_scripts', 'datamachine_socials_enqueue_assets' );
  */
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/PinterestCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/RedditCommand.php';
 	WP_CLI::add_command( 'datamachine-socials pinterest', \DataMachineSocials\Cli\Commands\PinterestCommand::class );
+	WP_CLI::add_command( 'datamachine-socials reddit', \DataMachineSocials\Cli\Commands\RedditCommand::class );
 }
+
+/**
+ * Register chat tools.
+ *
+ * Chat tools extend BaseTool from core and self-register via filters.
+ * Only load when Data Machine core's AI engine is available.
+ */
+function datamachine_socials_load_chat_tools() {
+	if ( ! class_exists( 'DataMachine\Engine\AI\Tools\BaseTool' ) ) {
+		return;
+	}
+
+	new \DataMachineSocials\Chat\Tools\FetchReddit();
+}
+add_action( 'plugins_loaded', 'datamachine_socials_load_chat_tools', 25 );

--- a/inc/Chat/Tools/FetchReddit.php
+++ b/inc/Chat/Tools/FetchReddit.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Fetch Reddit Chat Tool
+ *
+ * Chat tool for fetching Reddit posts. Wraps the datamachine/fetch-reddit
+ * ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class FetchReddit extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'fetch_reddit', array( $this, 'getToolDefinition' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Fetch a post from a Reddit subreddit. Returns the first eligible post matching filters (upvotes, comments, timeframe, keywords). Requires Reddit OAuth to be configured.',
+			'parameters'  => array(
+				'subreddit'         => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Subreddit name to fetch from (without "r/", e.g. "jambands", "festivals")',
+				),
+				'sort_by'           => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Sort order: hot, new, top, rising, controversial',
+					'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial' ),
+				),
+				'timeframe_limit'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Timeframe filter: all_time, 24_hours, 72_hours, 7_days, 30_days, 90_days, 6_months, 1_year',
+				),
+				'min_upvotes'       => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Minimum upvotes (score) required. 0 to disable.',
+				),
+				'min_comment_count' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Minimum comment count required. 0 to disable.',
+				),
+				'comment_count'     => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of top comments to include (0 = none).',
+				),
+				'search'            => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Comma-separated keywords to filter posts by title/content.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'fetch_reddit';
+
+		// Validate subreddit.
+		if ( empty( $parameters['subreddit'] ) ) {
+			return $this->buildErrorResponse( 'subreddit parameter is required', $tool_name );
+		}
+
+		// Get auth provider and valid token.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'reddit' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Reddit auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'reddit', 'status' => 'not_registered' ),
+				array(
+					'action'    => 'configure_reddit_auth',
+					'message'   => 'Reddit OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Reddit is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'reddit', 'status' => 'not_authenticated' ),
+				array(
+					'action'    => 'authenticate_reddit',
+					'message'   => 'Reddit OAuth needs to be connected. Go to Data Machine Settings > Auth > Reddit.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		$access_token = $provider->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Reddit access token expired and refresh failed',
+				'system',
+				$tool_name,
+				array( 'provider' => 'reddit', 'status' => 'token_expired' ),
+				array(
+					'action'  => 're_authenticate',
+					'message' => 'Reddit token refresh failed. User needs to re-authenticate via Settings.',
+				)
+			);
+		}
+
+		// Get the ability.
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $this->buildErrorResponse( 'WordPress Abilities API not available', $tool_name );
+		}
+
+		$ability = wp_get_ability( 'datamachine/fetch-reddit' );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse( 'datamachine/fetch-reddit ability not registered', $tool_name );
+		}
+
+		// Build ability input.
+		$input = array(
+			'subreddit'         => sanitize_text_field( $parameters['subreddit'] ),
+			'access_token'      => $access_token,
+			'sort_by'           => $parameters['sort_by'] ?? 'hot',
+			'timeframe_limit'   => $parameters['timeframe_limit'] ?? 'all_time',
+			'min_upvotes'       => absint( $parameters['min_upvotes'] ?? 0 ),
+			'min_comment_count' => absint( $parameters['min_comment_count'] ?? 0 ),
+			'comment_count'     => absint( $parameters['comment_count'] ?? 0 ),
+			'search'            => $parameters['search'] ?? '',
+			'processed_items'   => array(),
+			'fetch_batch_size'  => 100,
+			'max_pages'         => 5,
+			'download_images'   => false,
+		);
+
+		$result = $ability->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			$error = $this->getAbilityError( $result, 'Failed to fetch from Reddit' );
+			return $this->buildErrorResponse( $error, $tool_name );
+		}
+
+		if ( empty( $result['data'] ) ) {
+			return array(
+				'success'   => true,
+				'data'      => null,
+				'message'   => 'No eligible posts found in r/' . $input['subreddit'] . ' with the given filters.',
+				'tool_name' => $tool_name,
+				'guidance'  => array(
+					'status'    => 'empty_result',
+					'next_step' => 'Try broadening filters (lower min_upvotes, expand timeframe, remove search terms).',
+				),
+			);
+		}
+
+		return array(
+			'success'    => true,
+			'data'       => $result['data'],
+			'source_url' => $result['source_url'] ?? '',
+			'item_id'    => $result['item_id'] ?? '',
+			'tool_name'  => $tool_name,
+		);
+	}
+}

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * WP-CLI Reddit Command
+ *
+ * Provides CLI access to Reddit fetch operations and account management.
+ * Wraps the FetchRedditAbility and RedditAuth providers.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Reddit integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     # Fetch a post from a subreddit
+ *     wp datamachine-socials reddit fetch jambands
+ *
+ *     # Fetch with filters
+ *     wp datamachine-socials reddit fetch jambands --sort=top --min-upvotes=100
+ *
+ *     # Check Reddit auth status
+ *     wp datamachine-socials reddit status
+ */
+class RedditCommand {
+
+	/**
+	 * Fetch a post from a Reddit subreddit.
+	 *
+	 * Uses the datamachine/fetch-reddit ability to fetch the first eligible
+	 * post from the given subreddit, applying all configured filters.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <subreddit>
+	 * : The subreddit name (without "r/").
+	 *
+	 * [--sort=<sort>]
+	 * : Sort order for posts.
+	 * ---
+	 * default: hot
+	 * options:
+	 *   - hot
+	 *   - new
+	 *   - top
+	 *   - rising
+	 *   - controversial
+	 * ---
+	 *
+	 * [--timeframe=<timeframe>]
+	 * : Timeframe filter.
+	 * ---
+	 * default: all_time
+	 * options:
+	 *   - all_time
+	 *   - 24_hours
+	 *   - 72_hours
+	 *   - 7_days
+	 *   - 30_days
+	 *   - 90_days
+	 *   - 6_months
+	 *   - 1_year
+	 * ---
+	 *
+	 * [--min-upvotes=<min_upvotes>]
+	 * : Minimum upvotes required.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--min-comments=<min_comments>]
+	 * : Minimum comment count required.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--comments=<comments>]
+	 * : Number of top comments to fetch per post.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--search=<search>]
+	 * : Comma-separated search terms to filter posts.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit fetch jambands
+	 *     wp datamachine-socials reddit fetch festivals --sort=top --min-upvotes=50
+	 *     wp datamachine-socials reddit fetch bonnaroo --timeframe=7_days --comments=5
+	 *     wp datamachine-socials reddit fetch sxsw --format=json
+	 */
+	public function fetch( $args, $assoc_args ) {
+		$subreddit = $args[0];
+
+		// Get auth provider.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'reddit' );
+
+		if ( ! $provider ) {
+			WP_CLI::error( 'Reddit auth provider not found. Is data-machine-socials active?' );
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			WP_CLI::error( 'Reddit is not authenticated. Connect via Settings > Data Machine > Auth.' );
+		}
+
+		$access_token = $provider->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			WP_CLI::error( 'Failed to obtain a valid Reddit access token (expired and refresh failed).' );
+		}
+
+		// Build ability input.
+		$input = array(
+			'subreddit'         => $subreddit,
+			'access_token'      => $access_token,
+			'sort_by'           => $assoc_args['sort'] ?? 'hot',
+			'timeframe_limit'   => $assoc_args['timeframe'] ?? 'all_time',
+			'min_upvotes'       => absint( $assoc_args['min-upvotes'] ?? 0 ),
+			'min_comment_count' => absint( $assoc_args['min-comments'] ?? 0 ),
+			'comment_count'     => absint( $assoc_args['comments'] ?? 0 ),
+			'search'            => $assoc_args['search'] ?? '',
+			'processed_items'   => array(),
+			'fetch_batch_size'  => 100,
+			'max_pages'         => 5,
+			'download_images'   => false, // CLI doesn't download images by default.
+		);
+
+		WP_CLI::log( "Fetching from r/{$subreddit} (sort: {$input['sort_by']})..." );
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/fetch-reddit' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/fetch-reddit ability not registered.' );
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Reddit fetch failed.' );
+		}
+
+		if ( empty( $result['data'] ) ) {
+			WP_CLI::warning( 'No eligible posts found with the given filters.' );
+			return;
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$this->output_yaml( $data );
+			return;
+		}
+
+		// Table format: show key fields.
+		$metadata = $data['metadata'] ?? array();
+		WP_CLI::success( 'Fetched post from r/' . $subreddit );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Title:    ' . ( $data['title'] ?? '(none)' ) );
+		WP_CLI::log( 'Author:   ' . ( $metadata['author'] ?? 'unknown' ) );
+		WP_CLI::log( 'Upvotes:  ' . ( $metadata['upvotes'] ?? 0 ) );
+		WP_CLI::log( 'Comments: ' . ( $metadata['comment_count'] ?? 0 ) );
+		WP_CLI::log( 'Date:     ' . ( $metadata['original_date_gmt'] ?? 'unknown' ) );
+		WP_CLI::log( 'URL:      ' . ( $result['source_url'] ?? '' ) );
+
+		$content = $data['content'] ?? '';
+		if ( ! empty( $content ) ) {
+			WP_CLI::log( '' );
+			$preview = mb_substr( $content, 0, 500 );
+			if ( mb_strlen( $content ) > 500 ) {
+				$preview .= '...';
+			}
+			WP_CLI::log( 'Content:' );
+			WP_CLI::log( $preview );
+		}
+	}
+
+	/**
+	 * Show Reddit authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'reddit' );
+
+		WP_CLI::log( 'Reddit Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			WP_CLI::log( 'Authenticated: No' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		$details       = $provider->get_account_details();
+
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		if ( $details ) {
+			WP_CLI::log( 'Username:      ' . ( $details['username'] ?? 'unknown' ) );
+			WP_CLI::log( 'Scope:         ' . ( $details['scope'] ?? 'unknown' ) );
+
+			if ( ! empty( $details['token_expires_at'] ) ) {
+				$expires_at = intval( $details['token_expires_at'] );
+				$remaining  = $expires_at - time();
+
+				if ( $remaining > 0 ) {
+					$minutes = round( $remaining / 60 );
+					WP_CLI::log( "Token expires: in {$minutes} minutes" );
+				} else {
+					WP_CLI::log( 'Token expires: EXPIRED (will auto-refresh)' );
+				}
+			}
+
+			if ( ! empty( $details['last_refreshed_at'] ) ) {
+				WP_CLI::log( 'Last refresh:  ' . wp_date( 'Y-m-d H:i:s', intval( $details['last_refreshed_at'] ) ) );
+			}
+
+			$next_cron = wp_next_scheduled( 'datamachine_refresh_token_reddit' );
+			if ( $next_cron ) {
+				WP_CLI::log( 'Next cron:     ' . wp_date( 'Y-m-d H:i:s', $next_cron ) );
+			}
+		}
+	}
+
+	/**
+	 * Output data as YAML-like format.
+	 *
+	 * @param array $data Data to output.
+	 */
+	private function output_yaml( array $data, int $indent = 0 ): void {
+		$prefix = str_repeat( '  ', $indent );
+		foreach ( $data as $key => $value ) {
+			if ( is_array( $value ) ) {
+				WP_CLI::log( "{$prefix}{$key}:" );
+				$this->output_yaml( $value, $indent + 1 );
+			} else {
+				$display = is_bool( $value ) ? ( $value ? 'true' : 'false' ) : (string) $value;
+				WP_CLI::log( "{$prefix}{$key}: {$display}" );
+			}
+		}
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -144,7 +144,7 @@ class RestApi {
 
 		$statuses = array();
 
-		$platforms = array( 'instagram', 'twitter', 'facebook', 'bluesky', 'threads', 'pinterest' );
+		$platforms = array( 'instagram', 'twitter', 'facebook', 'bluesky', 'threads', 'pinterest', 'reddit' );
 
 		foreach ( $platforms as $platform ) {
 			$provider = $providers[ $platform ] ?? null;
@@ -212,6 +212,12 @@ class RestApi {
 				'defaultAspectRatio' => '2:3',
 				'charLimit'        => 500,
 				'supportsCarousel' => false,
+			),
+			'reddit'    => array(
+				'label'      => 'Reddit',
+				'type'       => 'fetch',
+				'charLimit'  => 40000,
+				'scopes'     => 'identity read',
 			),
 		);
 


### PR DESCRIPTION
## Summary

Adds the three consumer wrappers for the Reddit fetch ability so it's accessible from every interface — not just pipelines.

## What changed

### New files

**`inc/Cli/Commands/RedditCommand.php`** — WP-CLI command
```
wp datamachine-socials reddit fetch <subreddit> [--sort=hot] [--timeframe=all_time] [--min-upvotes=0] [--min-comments=0] [--comments=0] [--search=] [--format=table|json|yaml]
wp datamachine-socials reddit status
```

**`inc/Chat/Tools/FetchReddit.php`** — Chat tool extending `BaseTool`
- Registers as `fetch_reddit` tool for the chat agent
- Handles auth validation with diagnostic error responses + remediation hints
- Delegates to `datamachine/fetch-reddit` ability via `wp_get_ability()`

### Modified files

**`inc/RestApi.php`**
- `/auth/status` now includes `reddit` in the platform list
- `/platforms` returns Reddit with `type: fetch` metadata

**`data-machine-socials.php`**
- Registers `RedditCommand` CLI command
- Loads `FetchReddit` chat tool via `datamachine_socials_load_chat_tools()` at `plugins_loaded` priority 25

## Architecture

```
                    +-----------------+
                    |  FetchReddit    |
                    |  Ability (WP    |
                    |  Abilities API) |
                    +--------^--------+
                             |
          +------------------+------------------+
          |                  |                  |
  +-------+------+  +-------+------+  +--------+------+
  | CLI Command  |  | Chat Tool    |  | REST API      |
  | wp reddit    |  | fetch_reddit |  | /auth/status  |
  | fetch <sub>  |  | (BaseTool)   |  | /platforms    |
  +--------------+  +--------------+  +---------------+
          |                  |                  |
      Terminal           AI Agent          HTTP Client
```

All three wrappers delegate to the same `datamachine/fetch-reddit` ability as the universal primitive.

## Testing
- `homeboy test data-machine-socials` — **PASS**