### PR TITLE
feat: Instagram read operations — ability, CLI, chat tool, REST API

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -60,6 +60,7 @@ function datamachine_socials_load_handlers() {
 
 	// Instagram
 	new \DataMachineSocials\Abilities\Instagram\InstagramPublishAbility();
+	new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
 
 	// Reddit (Fetch)
 	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
@@ -142,8 +143,10 @@ add_action( 'admin_enqueue_scripts', 'datamachine_socials_enqueue_assets' );
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/PinterestCommand.php';
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/RedditCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/InstagramCommand.php';
 	WP_CLI::add_command( 'datamachine-socials pinterest', \DataMachineSocials\Cli\Commands\PinterestCommand::class );
 	WP_CLI::add_command( 'datamachine-socials reddit', \DataMachineSocials\Cli\Commands\RedditCommand::class );
+	WP_CLI::add_command( 'datamachine-socials instagram', \DataMachineSocials\Cli\Commands\InstagramCommand::class );
 }
 
 /**
@@ -158,5 +161,6 @@ function datamachine_socials_load_chat_tools() {
 	}
 
 	new \DataMachineSocials\Chat\Tools\FetchReddit();
+	new \DataMachineSocials\Chat\Tools\ReadInstagram();
 }
 add_action( 'plugins_loaded', 'datamachine_socials_load_chat_tools', 25 );

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * Instagram Read Ability
+ *
+ * Abilities API primitive for reading Instagram media (posts, reels, carousels).
+ * Supports listing recent media and fetching single post details with engagement metrics.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Instagram
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Instagram;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class InstagramReadAbility {
+
+	private static bool $registered = false;
+
+	const GRAPH_API_URL = 'https://graph.instagram.com';
+
+	/**
+	 * Fields to request when listing media.
+	 */
+	const LIST_FIELDS = 'id,caption,media_type,media_url,thumbnail_url,permalink,timestamp,like_count,comments_count';
+
+	/**
+	 * Fields to request for single media detail.
+	 */
+	const DETAIL_FIELDS = 'id,caption,media_type,media_url,thumbnail_url,permalink,timestamp,like_count,comments_count,media_product_type,is_shared_to_feed';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			// List media ability.
+			wp_register_ability(
+				'datamachine/instagram-read',
+				array(
+					'label'               => __( 'Read Instagram Media', 'data-machine-socials' ),
+					'description'         => __( 'List recent Instagram posts or get details for a specific post', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'enum'        => array( 'list', 'get', 'comments' ),
+								'default'     => 'list',
+								'description' => __( 'Action: list (recent posts), get (single post), comments (post comments)', 'data-machine-socials' ),
+							),
+							'media_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Instagram media ID (required for get and comments actions)', 'data-machine-socials' ),
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of items to return (max 100)', 'data-machine-socials' ),
+							),
+							'after'    => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination cursor for next page', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return bool
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute the read ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result.
+	 */
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'list';
+
+		// Get auth provider.
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram auth provider not available',
+			);
+		}
+
+		$access_token = $auth->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram access token unavailable (expired or refresh failed)',
+			);
+		}
+
+		switch ( $action ) {
+			case 'list':
+				return $this->listMedia( $auth, $access_token, $input );
+
+			case 'get':
+				if ( empty( $input['media_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'media_id is required for the get action',
+					);
+				}
+				return $this->getMedia( $access_token, $input['media_id'] );
+
+			case 'comments':
+				if ( empty( $input['media_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'media_id is required for the comments action',
+					);
+				}
+				return $this->getComments( $access_token, $input['media_id'], $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use list, get, or comments.",
+				);
+		}
+	}
+
+	/**
+	 * List recent media for the authenticated user.
+	 *
+	 * @param InstagramAuth $auth         Auth provider.
+	 * @param string        $access_token Valid access token.
+	 * @param array         $input        Input parameters.
+	 * @return array Result.
+	 */
+	private function listMedia( InstagramAuth $auth, string $access_token, array $input ): array {
+		$user_id = $auth->get_user_id();
+		if ( empty( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram user ID not available. Try re-authenticating.',
+			);
+		}
+
+		$limit = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => self::LIST_FIELDS,
+			'limit'        => $limit,
+			'access_token' => $access_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = self::GRAPH_API_URL . "/{$user_id}/media?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Instagram Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch Instagram media';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$media = $data['data'] ?? array();
+		$paging = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'media'   => $media,
+				'count'   => count( $media ),
+				'cursors' => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	/**
+	 * Get details for a single media item.
+	 *
+	 * @param string $access_token Valid access token.
+	 * @param string $media_id     Instagram media ID.
+	 * @return array Result.
+	 */
+	private function getMedia( string $access_token, string $media_id ): array {
+		$params = array(
+			'fields'       => self::DETAIL_FIELDS,
+			'access_token' => $access_token,
+		);
+
+		$url    = self::GRAPH_API_URL . "/{$media_id}?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Instagram Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch Instagram media details';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	/**
+	 * Get comments for a media item.
+	 *
+	 * @param string $access_token Valid access token.
+	 * @param string $media_id     Instagram media ID.
+	 * @param array  $input        Input parameters.
+	 * @return array Result.
+	 */
+	private function getComments( string $access_token, string $media_id, array $input ): array {
+		$limit = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => 'id,text,timestamp,username,like_count',
+			'limit'        => $limit,
+			'access_token' => $access_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = self::GRAPH_API_URL . "/{$media_id}/comments?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Instagram Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch comments';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$comments = $data['data'] ?? array();
+		$paging   = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'comments' => $comments,
+				'count'    => count( $comments ),
+				'cursors'  => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	/**
+	 * Get the Instagram auth provider.
+	 *
+	 * @return InstagramAuth|null
+	 */
+	private function getAuthProvider(): ?InstagramAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'instagram' );
+
+		if ( $provider instanceof InstagramAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Chat/Tools/ReadInstagram.php
+++ b/inc/Chat/Tools/ReadInstagram.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Read Instagram Chat Tool
+ *
+ * Chat tool for reading Instagram media (posts, reels, carousels) and comments.
+ * Wraps the datamachine/instagram-read ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadInstagram extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_instagram', array( $this, 'getToolDefinition' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read Instagram media. List recent posts, get details for a specific post, or get comments on a post. Requires Instagram OAuth to be configured.',
+			'parameters'  => array(
+				'action'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action to perform: "list" (recent posts), "get" (single post details), "comments" (post comments). Defaults to "list".',
+					'enum'        => array( 'list', 'get', 'comments' ),
+				),
+				'media_id' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Instagram media ID. Required for "get" and "comments" actions.',
+				),
+				'limit'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of items to return (max 100). Defaults to 25.',
+				),
+				'after'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination cursor for fetching the next page of results.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_instagram';
+		$action    = $parameters['action'] ?? 'list';
+
+		// Validate action-specific requirements.
+		if ( in_array( $action, array( 'get', 'comments' ), true ) && empty( $parameters['media_id'] ) ) {
+			return $this->buildErrorResponse( "media_id is required for the {$action} action", $tool_name );
+		}
+
+		// Get auth provider and valid token.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'instagram' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Instagram auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'instagram', 'status' => 'not_registered' ),
+				array(
+					'action'    => 'configure_instagram_auth',
+					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Instagram is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'instagram', 'status' => 'not_authenticated' ),
+				array(
+					'action'    => 'authenticate_instagram',
+					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Get the ability.
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $this->buildErrorResponse( 'WordPress Abilities API not available', $tool_name );
+		}
+
+		$ability = wp_get_ability( 'datamachine/instagram-read' );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse( 'datamachine/instagram-read ability not registered', $tool_name );
+		}
+
+		// Build ability input.
+		$input = array(
+			'action' => sanitize_text_field( $action ),
+		);
+
+		if ( ! empty( $parameters['media_id'] ) ) {
+			$input['media_id'] = sanitize_text_field( $parameters['media_id'] );
+		}
+
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+
+		if ( ! empty( $parameters['after'] ) ) {
+			$input['after'] = sanitize_text_field( $parameters['after'] );
+		}
+
+		// Execute via ability (which handles token retrieval internally).
+		$ability_instance = new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
+		$result           = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			$error = $this->getAbilityError( $result, 'Failed to read from Instagram' );
+			return $this->buildErrorResponse( $error, $tool_name );
+		}
+
+		$data = $result['data'] ?? array();
+
+		// Format response based on action.
+		switch ( $action ) {
+			case 'list':
+				$media = $data['media'] ?? array();
+				if ( empty( $media ) ) {
+					return array(
+						'success'   => true,
+						'data'      => null,
+						'message'   => 'No Instagram posts found.',
+						'tool_name' => $tool_name,
+						'guidance'  => array(
+							'status'    => 'empty_result',
+							'next_step' => 'The Instagram account may have no posts, or try adjusting pagination.',
+						),
+					);
+				}
+
+				return array(
+					'success'   => true,
+					'data'      => $data,
+					'message'   => sprintf( 'Found %d Instagram posts.', $data['count'] ?? count( $media ) ),
+					'tool_name' => $tool_name,
+					'guidance'  => array(
+						'has_next'  => $data['has_next'] ?? false,
+						'next_step' => ! empty( $data['has_next'] )
+							? 'Use the "after" cursor to get the next page: ' . ( $data['cursors']['after'] ?? '' )
+							: 'All available posts have been returned.',
+					),
+				);
+
+			case 'get':
+				return array(
+					'success'   => true,
+					'data'      => $data,
+					'tool_name' => $tool_name,
+				);
+
+			case 'comments':
+				$comments = $data['comments'] ?? array();
+				if ( empty( $comments ) ) {
+					return array(
+						'success'   => true,
+						'data'      => null,
+						'message'   => 'No comments found on this post.',
+						'tool_name' => $tool_name,
+					);
+				}
+
+				return array(
+					'success'   => true,
+					'data'      => $data,
+					'message'   => sprintf( 'Found %d comments.', $data['count'] ?? count( $comments ) ),
+					'tool_name' => $tool_name,
+					'guidance'  => array(
+						'has_next'  => $data['has_next'] ?? false,
+						'next_step' => ! empty( $data['has_next'] )
+							? 'Use the "after" cursor to get the next page: ' . ( $data['cursors']['after'] ?? '' )
+							: 'All available comments have been returned.',
+					),
+				);
+
+			default:
+				return array(
+					'success'   => true,
+					'data'      => $data,
+					'tool_name' => $tool_name,
+				);
+		}
+	}
+}

--- a/inc/Cli/Commands/InstagramCommand.php
+++ b/inc/Cli/Commands/InstagramCommand.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * WP-CLI Instagram Command
+ *
+ * Provides CLI access to Instagram read operations and account management.
+ * Wraps the InstagramReadAbility and InstagramAuth providers.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Instagram integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     # List recent posts
+ *     wp datamachine-socials instagram posts
+ *
+ *     # Get details for a specific post
+ *     wp datamachine-socials instagram post 17891234567890
+ *
+ *     # Get comments on a post
+ *     wp datamachine-socials instagram comments 17891234567890
+ *
+ *     # Check auth status
+ *     wp datamachine-socials instagram status
+ */
+class InstagramCommand {
+
+	/**
+	 * List recent Instagram posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--after=<cursor>]
+	 * : Pagination cursor for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials instagram posts
+	 *     wp datamachine-socials instagram posts --limit=10
+	 *     wp datamachine-socials instagram posts --format=json
+	 */
+	public function posts( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'list',
+			'limit'  => absint( $assoc_args['limit'] ?? 25 ),
+			'after'  => $assoc_args['after'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$media  = $data['media'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $media ) ) {
+			WP_CLI::warning( 'No posts found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		// Table format.
+		WP_CLI::success( "Found {$data['count']} posts" );
+		WP_CLI::log( '' );
+
+		foreach ( $media as $item ) {
+			$caption = $item['caption'] ?? '(no caption)';
+			$caption = mb_substr( $caption, 0, 60 );
+			if ( mb_strlen( $item['caption'] ?? '' ) > 60 ) {
+				$caption .= '...';
+			}
+
+			$likes    = $item['like_count'] ?? 0;
+			$comments = $item['comments_count'] ?? 0;
+			$type     = $item['media_type'] ?? 'UNKNOWN';
+			$date     = isset( $item['timestamp'] ) ? wp_date( 'Y-m-d', strtotime( $item['timestamp'] ) ) : '';
+
+			WP_CLI::log( sprintf(
+				'  %s  %-12s  %s  %d likes  %d comments  %s',
+				$item['id'],
+				$type,
+				$date,
+				$likes,
+				$comments,
+				$caption
+			) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['cursors']['after'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --after={$data['cursors']['after']}" );
+		}
+	}
+
+	/**
+	 * Get details for a specific Instagram post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <media_id>
+	 * : The Instagram media ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials instagram post 17891234567890
+	 *     wp datamachine-socials instagram post 17891234567890 --format=json
+	 */
+	public function post( $args, $assoc_args ) {
+		$media_id = $args[0];
+		$ability  = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'get',
+			'media_id' => $media_id,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Post {$media_id}" );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'ID:        ' . ( $data['id'] ?? '' ) );
+		WP_CLI::log( 'Type:      ' . ( $data['media_type'] ?? '' ) );
+		WP_CLI::log( 'Date:      ' . ( $data['timestamp'] ?? '' ) );
+		WP_CLI::log( 'Likes:     ' . ( $data['like_count'] ?? 0 ) );
+		WP_CLI::log( 'Comments:  ' . ( $data['comments_count'] ?? 0 ) );
+		WP_CLI::log( 'Permalink: ' . ( $data['permalink'] ?? '' ) );
+
+		$caption = $data['caption'] ?? '(no caption)';
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Caption:' );
+		WP_CLI::log( $caption );
+	}
+
+	/**
+	 * Get comments on an Instagram post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <media_id>
+	 * : The Instagram media ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Number of comments to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials instagram comments 17891234567890
+	 *     wp datamachine-socials instagram comments 17891234567890 --limit=10
+	 */
+	public function comments( $args, $assoc_args ) {
+		$media_id = $args[0];
+		$ability  = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'comments',
+			'media_id' => $media_id,
+			'limit'    => absint( $assoc_args['limit'] ?? 25 ),
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data     = $result['data'];
+		$comments = $data['comments'] ?? array();
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $comments ) ) {
+			WP_CLI::warning( 'No comments found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} comments" );
+		WP_CLI::log( '' );
+
+		foreach ( $comments as $comment ) {
+			$username = $comment['username'] ?? 'unknown';
+			$text     = $comment['text'] ?? '';
+			$likes    = $comment['like_count'] ?? 0;
+			$date     = isset( $comment['timestamp'] ) ? wp_date( 'Y-m-d H:i', strtotime( $comment['timestamp'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  @%-20s %s  (%d likes)  %s', $username, $date, $likes, $text ) );
+		}
+	}
+
+	/**
+	 * Show Instagram authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials instagram status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'instagram' );
+
+		WP_CLI::log( 'Instagram Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		if ( method_exists( $provider, 'is_configured' ) ) {
+			WP_CLI::log( 'Configured:    ' . ( $provider->is_configured() ? 'Yes' : 'No' ) );
+		}
+
+		if ( method_exists( $provider, 'get_username' ) ) {
+			$username = $provider->get_username();
+			if ( $username ) {
+				WP_CLI::log( 'Username:      @' . $username );
+			}
+		}
+
+		if ( method_exists( $provider, 'get_user_id' ) ) {
+			$user_id = $provider->get_user_id();
+			if ( $user_id ) {
+				WP_CLI::log( 'User ID:       ' . $user_id );
+			}
+		}
+
+		$details = $provider->get_account_details();
+		if ( $details && ! empty( $details['token_expires_at'] ) ) {
+			$expires_at = intval( $details['token_expires_at'] );
+			$remaining  = $expires_at - time();
+
+			if ( $remaining > 0 ) {
+				$days = round( $remaining / DAY_IN_SECONDS );
+				WP_CLI::log( "Token expires: in {$days} days" );
+			} else {
+				WP_CLI::log( 'Token expires: EXPIRED (will auto-refresh)' );
+			}
+		}
+
+		$next_cron = wp_next_scheduled( 'datamachine_refresh_token_instagram' );
+		if ( $next_cron ) {
+			WP_CLI::log( 'Next cron:     ' . wp_date( 'Y-m-d H:i:s', $next_cron ) );
+		}
+	}
+
+	/**
+	 * Get the Instagram read ability.
+	 *
+	 * @return \DataMachineSocials\Abilities\Instagram\InstagramReadAbility
+	 */
+	private function get_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/instagram-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/instagram-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -112,6 +112,38 @@ class RestApi {
 				'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
 			)
 		);
+
+		// Instagram: list media or get single post
+		register_rest_route(
+			self::NAMESPACE,
+			'/instagram/media',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'instagram_read' ),
+				'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+				'args'                => array(
+					'action'   => array(
+						'type'              => 'string',
+						'default'           => 'list',
+						'enum'              => array( 'list', 'get', 'comments' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'media_id' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'limit'    => array(
+						'type'              => 'integer',
+						'default'           => 25,
+						'sanitize_callback' => 'absint',
+					),
+					'after'    => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -412,6 +444,54 @@ class RestApi {
 		$url = $upload_dir['baseurl'] . '/dms-temp/' . $filename;
 
 		return new \WP_REST_Response( array( 'url' => $url ) );
+	}
+
+	/**
+	 * Instagram read: list media, get single post, or get comments.
+	 *
+	 * Delegates to the datamachine/instagram-read ability.
+	 */
+	public static function instagram_read( \WP_REST_Request $request ) {
+		$action   = $request->get_param( 'action' ) ?? 'list';
+		$media_id = $request->get_param( 'media_id' );
+
+		// Validate action-specific requirements.
+		if ( in_array( $action, array( 'get', 'comments' ), true ) && empty( $media_id ) ) {
+			return new \WP_REST_Response(
+				array(
+					'success' => false,
+					'error'   => "media_id is required for the {$action} action",
+				),
+				400
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
+		$input            = array(
+			'action' => $action,
+		);
+
+		if ( ! empty( $media_id ) ) {
+			$input['media_id'] = $media_id;
+		}
+
+		$limit = $request->get_param( 'limit' );
+		if ( $limit ) {
+			$input['limit'] = absint( $limit );
+		}
+
+		$after = $request->get_param( 'after' );
+		if ( $after ) {
+			$input['after'] = $after;
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $result['success'] ) {
+			return new \WP_REST_Response( $result, 500 );
+		}
+
+		return new \WP_REST_Response( $result );
 	}
 
 	/**

--- a/tests/Unit/Abilities/Instagram/InstagramReadAbilityTest.php
+++ b/tests/Unit/Abilities/Instagram/InstagramReadAbilityTest.php
@@ -1,0 +1,468 @@
+<?php
+/**
+ * InstagramReadAbility Tests
+ *
+ * Tests for Instagram read ability: listing media, getting single posts,
+ * fetching comments, error handling, and pagination.
+ *
+ * @package DataMachineSocials\Tests\Unit\Abilities\Instagram
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities\Instagram;
+
+use DataMachineSocials\Abilities\Instagram\InstagramReadAbility;
+use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+use WP_UnitTestCase;
+
+class InstagramReadAbilityTest extends WP_UnitTestCase {
+
+	private InstagramReadAbility $ability;
+	private InstagramAuth $auth;
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_site_option( 'datamachine_auth_data' );
+
+		$this->auth = new InstagramAuth();
+
+		// Register the auth provider via filter so AuthAbilities can find it.
+		\DataMachine\Abilities\AuthAbilities::clearCache();
+		add_filter( 'datamachine_auth_providers', function ( $providers ) {
+			$providers['instagram'] = $this->auth;
+			return $providers;
+		} );
+
+		$this->ability = new InstagramReadAbility();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'datamachine_auth_providers' );
+		\DataMachine\Abilities\AuthAbilities::clearCache();
+		delete_site_option( 'datamachine_auth_data' );
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helper: set up authenticated provider
+	// -------------------------------------------------------------------------
+
+	private function authenticate( string $token = 'ig_test_tok', string $user_id = '12345' ): void {
+		$this->auth->save_account( array(
+			'access_token'     => $token,
+			'user_id'          => $user_id,
+			'username'         => 'extrachill',
+			'token_expires_at' => time() + ( 30 * DAY_IN_SECONDS ),
+		) );
+	}
+
+	private function mock_api_response( int $status_code, array $body ): void {
+		add_filter( 'pre_http_request', function () use ( $status_code, $body ) {
+			return array(
+				'response' => array( 'code' => $status_code ),
+				'body'     => wp_json_encode( $body ),
+			);
+		} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Action: list
+	// -------------------------------------------------------------------------
+
+	public function test_list_returns_media_on_success(): void {
+		$this->authenticate();
+
+		$media_items = array(
+			array(
+				'id'             => '111',
+				'caption'        => 'Test post 1',
+				'media_type'     => 'IMAGE',
+				'permalink'      => 'https://www.instagram.com/p/abc/',
+				'timestamp'      => '2026-02-20T12:00:00+0000',
+				'like_count'     => 42,
+				'comments_count' => 5,
+			),
+			array(
+				'id'             => '222',
+				'caption'        => 'Test post 2',
+				'media_type'     => 'CAROUSEL_ALBUM',
+				'permalink'      => 'https://www.instagram.com/p/def/',
+				'timestamp'      => '2026-02-19T12:00:00+0000',
+				'like_count'     => 100,
+				'comments_count' => 12,
+			),
+		);
+
+		$this->mock_api_response( 200, array(
+			'data'   => $media_items,
+			'paging' => array(
+				'cursors' => array( 'after' => 'cursor_abc' ),
+				'next'    => 'https://graph.instagram.com/12345/media?after=cursor_abc',
+			),
+		) );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 2, $result['data']['media'] );
+		$this->assertSame( 2, $result['data']['count'] );
+		$this->assertTrue( $result['data']['has_next'] );
+		$this->assertSame( 'cursor_abc', $result['data']['cursors']['after'] );
+	}
+
+	public function test_list_defaults_action_to_list(): void {
+		$this->authenticate();
+
+		$this->mock_api_response( 200, array(
+			'data'   => array(),
+			'paging' => array(),
+		) );
+
+		$result = $this->ability->execute( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertEmpty( $result['data']['media'] );
+		$this->assertSame( 0, $result['data']['count'] );
+	}
+
+	public function test_list_respects_limit_parameter(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'data' => array(), 'paging' => array() ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'list', 'limit' => 10 ) );
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'limit=10', $captured_url );
+	}
+
+	public function test_list_caps_limit_at_100(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'data' => array(), 'paging' => array() ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'list', 'limit' => 500 ) );
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'limit=100', $captured_url );
+	}
+
+	public function test_list_passes_after_cursor(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'data' => array(), 'paging' => array() ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'list', 'after' => 'cursor_xyz' ) );
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'after=cursor_xyz', $captured_url );
+	}
+
+	public function test_list_has_next_false_without_next_page(): void {
+		$this->authenticate();
+
+		$this->mock_api_response( 200, array(
+			'data'   => array( array( 'id' => '111' ) ),
+			'paging' => array(
+				'cursors' => array( 'after' => 'end' ),
+			),
+		) );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['data']['has_next'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Action: get
+	// -------------------------------------------------------------------------
+
+	public function test_get_returns_single_post_details(): void {
+		$this->authenticate();
+
+		$post_data = array(
+			'id'                 => '111',
+			'caption'            => 'A beautiful sunset',
+			'media_type'         => 'IMAGE',
+			'media_url'          => 'https://scontent.cdninstagram.com/v/img.jpg',
+			'permalink'          => 'https://www.instagram.com/p/abc/',
+			'timestamp'          => '2026-02-20T12:00:00+0000',
+			'like_count'         => 42,
+			'comments_count'     => 5,
+			'media_product_type' => 'FEED',
+			'is_shared_to_feed'  => true,
+		);
+
+		$this->mock_api_response( 200, $post_data );
+
+		$result = $this->ability->execute( array(
+			'action'   => 'get',
+			'media_id' => '111',
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( '111', $result['data']['id'] );
+		$this->assertSame( 'A beautiful sunset', $result['data']['caption'] );
+		$this->assertSame( 42, $result['data']['like_count'] );
+	}
+
+	public function test_get_requires_media_id(): void {
+		$this->authenticate();
+
+		$result = $this->ability->execute( array( 'action' => 'get' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'media_id is required', $result['error'] );
+	}
+
+	public function test_get_sends_detail_fields(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'id' => '111' ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'get', 'media_id' => '111' ) );
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'media_product_type', $captured_url );
+		$this->assertStringContainsString( 'is_shared_to_feed', $captured_url );
+	}
+
+	// -------------------------------------------------------------------------
+	// Action: comments
+	// -------------------------------------------------------------------------
+
+	public function test_comments_returns_post_comments(): void {
+		$this->authenticate();
+
+		$comments = array(
+			array(
+				'id'         => 'c1',
+				'text'       => 'Great post!',
+				'timestamp'  => '2026-02-20T13:00:00+0000',
+				'username'   => 'fan123',
+				'like_count' => 3,
+			),
+			array(
+				'id'         => 'c2',
+				'text'       => 'Love this!',
+				'timestamp'  => '2026-02-20T14:00:00+0000',
+				'username'   => 'musiclover',
+				'like_count' => 1,
+			),
+		);
+
+		$this->mock_api_response( 200, array(
+			'data'   => $comments,
+			'paging' => array(
+				'cursors' => array( 'after' => 'comment_cursor' ),
+				'next'    => 'https://graph.instagram.com/111/comments?after=comment_cursor',
+			),
+		) );
+
+		$result = $this->ability->execute( array(
+			'action'   => 'comments',
+			'media_id' => '111',
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 2, $result['data']['comments'] );
+		$this->assertSame( 2, $result['data']['count'] );
+		$this->assertTrue( $result['data']['has_next'] );
+	}
+
+	public function test_comments_requires_media_id(): void {
+		$this->authenticate();
+
+		$result = $this->ability->execute( array( 'action' => 'comments' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'media_id is required', $result['error'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Auth errors
+	// -------------------------------------------------------------------------
+
+	public function test_returns_error_when_not_authenticated(): void {
+		// No call to authenticate() — provider has no token.
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'access token', strtolower( $result['error'] ) );
+	}
+
+	public function test_returns_error_when_token_expired_and_refresh_fails(): void {
+		// Set expired token with no refresh mock (will fail).
+		$this->auth->save_account( array(
+			'access_token'     => 'ig_expired_tok',
+			'user_id'          => '12345',
+			'token_expires_at' => time() - 100,
+		) );
+
+		// Mock failed refresh.
+		$this->mock_api_response( 400, array(
+			'error' => array( 'message' => 'Token is invalid' ),
+		) );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'access token', strtolower( $result['error'] ) );
+	}
+
+	public function test_returns_error_when_user_id_missing(): void {
+		// Authenticated but no user_id.
+		$this->auth->save_account( array(
+			'access_token'     => 'ig_test_tok',
+			'token_expires_at' => time() + ( 30 * DAY_IN_SECONDS ),
+		) );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'user ID', $result['error'] );
+	}
+
+	public function test_returns_error_when_provider_unavailable(): void {
+		// Remove the provider filter.
+		remove_all_filters( 'datamachine_auth_providers' );
+		\DataMachine\Abilities\AuthAbilities::clearCache();
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'auth provider', strtolower( $result['error'] ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// API error handling
+	// -------------------------------------------------------------------------
+
+	public function test_handles_api_http_error(): void {
+		$this->authenticate();
+
+		add_filter( 'pre_http_request', function () {
+			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+		} );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'failed', strtolower( $result['error'] ) );
+	}
+
+	public function test_handles_api_error_response(): void {
+		$this->authenticate();
+
+		$this->mock_api_response( 400, array(
+			'error' => array(
+				'message' => 'Invalid user id',
+				'type'    => 'OAuthException',
+				'code'    => 110,
+			),
+		) );
+
+		$result = $this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Invalid user id', $result['error'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Unknown action
+	// -------------------------------------------------------------------------
+
+	public function test_returns_error_for_unknown_action(): void {
+		$this->authenticate();
+
+		$result = $this->ability->execute( array( 'action' => 'delete' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Unknown action', $result['error'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// API URL construction
+	// -------------------------------------------------------------------------
+
+	public function test_list_calls_correct_api_url(): void {
+		$this->authenticate( 'ig_tok_url_test', '99999' );
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'data' => array(), 'paging' => array() ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'list' ) );
+
+		$this->assertStringContainsString( 'graph.instagram.com/99999/media', $captured_url );
+		$this->assertStringContainsString( 'access_token=ig_tok_url_test', $captured_url );
+	}
+
+	public function test_get_calls_correct_api_url(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'id' => '777' ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'get', 'media_id' => '777' ) );
+
+		$this->assertStringContainsString( 'graph.instagram.com/777', $captured_url );
+	}
+
+	public function test_comments_calls_correct_api_url(): void {
+		$this->authenticate();
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'data' => array(), 'paging' => array() ) ),
+			);
+		}, 10, 3 );
+
+		$this->ability->execute( array( 'action' => 'comments', 'media_id' => '888' ) );
+
+		$this->assertStringContainsString( 'graph.instagram.com/888/comments', $captured_url );
+	}
+}


### PR DESCRIPTION
## Summary

Completes Instagram read operations across all four consumer interfaces, following the same pattern established by the Reddit fetch implementation.

### What's new

- **InstagramReadAbility** — Abilities API primitive supporting `list`, `get`, and `comments` actions with pagination
- **InstagramCommand CLI** — `wp datamachine-socials instagram posts|post|comments|status` subcommands
- **ReadInstagram chat tool** — `read_instagram` tool for the Data Machine AI agent with diagnostic error responses
- **REST endpoint** — `GET /datamachine-socials/v1/instagram/media?action=list|get|comments`
- **20 unit tests** — covering all actions, auth errors, API failures, URL construction, pagination

### Architecture

All four interfaces delegate to the same `InstagramReadAbility` primitive:
```
InstagramReadAbility (universal primitive)
  ├── InstagramCommand (WP_CLI)
  ├── ReadInstagram (Chat Tool → BaseTool)
  └── RestApi::instagram_read (REST endpoint)
```

### Files changed

| File | Change |
|------|--------|
| `inc/Abilities/Instagram/InstagramReadAbility.php` | New — ability with list/get/comments actions |
| `inc/Cli/Commands/InstagramCommand.php` | New — CLI with posts, post, comments, status |
| `inc/Chat/Tools/ReadInstagram.php` | New — chat tool extending BaseTool |
| `inc/RestApi.php` | Added `/instagram/media` endpoint |
| `data-machine-socials.php` | Registered ability, CLI command, and chat tool |
| `tests/Unit/Abilities/Instagram/InstagramReadAbilityTest.php` | New — 20 tests |

Partially addresses #14 (Instagram read complete; other platforms still need read operations).