### PR TITLE
feat: QuoteCard image template for Instagram quote graphics

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -79,6 +79,22 @@ function datamachine_socials_load_handlers() {
 // Hook into plugins_loaded to ensure Data Machine core is loaded first
 add_action( 'plugins_loaded', 'datamachine_socials_load_handlers', 20 );
 
+/**
+ * Register image generation templates with Data Machine core.
+ *
+ * Templates are registered via filter so core's TemplateRegistry can
+ * discover and instantiate them. Runs on plugins_loaded after handlers.
+ */
+function datamachine_socials_register_image_templates() {
+	add_filter( 'datamachine/image_generation/templates', function ( array $templates ): array {
+		$templates['quote_card'] = \DataMachineSocials\ImageGeneration\Templates\QuoteCard::class;
+		$templates['chart']     = \DataMachineSocials\ImageGeneration\Templates\ChartTemplate::class;
+		$templates['diagram']   = \DataMachineSocials\ImageGeneration\Templates\DiagramTemplate::class;
+		return $templates;
+	} );
+}
+add_action( 'plugins_loaded', 'datamachine_socials_register_image_templates', 21 );
+
 // Register REST API
 require_once DATAMACHINE_SOCIALS_PATH . 'inc/RestApi.php';
 add_action( 'plugins_loaded', array( 'DataMachineSocials\RestApi', 'register' ), 25 );

--- a/inc/ImageGeneration/Templates/ChartTemplate.php
+++ b/inc/ImageGeneration/Templates/ChartTemplate.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Chart Template
+ *
+ * Generates chart images from structured data — bar, line, and pie charts.
+ * Useful for analytics visualizations, statistics, and data-driven social content.
+ *
+ * @package DataMachineSocials\ImageGeneration\Templates
+ * @since 0.2.0
+ */
+
+namespace DataMachineSocials\ImageGeneration\Templates;
+
+use DataMachine\Abilities\Media\GDRenderer;
+use DataMachine\Abilities\Media\TemplateInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ChartTemplate implements TemplateInterface {
+
+	/**
+	 * Layout constants.
+	 */
+	private const PADDING       = 60;
+	private const CHART_MARGIN = 40;
+	private const LEGEND_SIZE   = 24;
+
+	/**
+	 * Default colors — brand-consistent palette.
+	 */
+	private const COLORS = array(
+		'background'  => array( 255, 255, 255 ),
+		'title'       => array( 26, 26, 26 ),
+		'axis'        => array( 180, 180, 180 ),
+		'axis_label'  => array( 100, 100, 100 ),
+		'grid'        => array( 230, 230, 230 ),
+		'legend'      => array( 60, 60, 60 ),
+	);
+
+	public function get_id(): string {
+		return 'chart';
+	}
+
+	public function get_name(): string {
+		return 'Chart';
+	}
+
+	public function get_description(): string {
+		return 'Generate bar, line, or pie charts from structured data. Useful for analytics and statistics.';
+	}
+
+	public function get_fields(): array {
+		return array(
+			'chart_type' => array(
+				'label'    => 'Chart Type',
+				'type'     => 'string',
+				'required' => true,
+			),
+			'title'      => array(
+				'label'    => 'Chart Title',
+				'type'     => 'string',
+				'required' => false,
+			),
+			'labels'     => array(
+				'label'    => 'Labels',
+				'type'     => 'array',
+				'required' => true,
+			),
+			'values'     => array(
+				'label'    => 'Values',
+				'type'     => 'array',
+				'required' => true,
+			),
+			'dataset_label' => array(
+				'label'    => 'Dataset Label',
+				'type'     => 'string',
+				'required' => false,
+			),
+		);
+	}
+
+	public function get_default_preset(): string {
+		return 'instagram_feed_portrait';
+	}
+
+	/**
+	 * Render a chart.
+	 *
+	 * @param array      $data     Chart data.
+	 * @param GDRenderer $renderer GD renderer instance.
+	 * @param array      $options  Render options.
+	 * @return string[] Generated image file paths.
+	 */
+	public function render( array $data, GDRenderer $renderer, array $options = array() ): array {
+		$chart_type = $data['chart_type'] ?? 'bar';
+		$title      = $data['title'] ?? '';
+		$labels     = $data['labels'] ?? array();
+		$values     = $data['values'] ?? array();
+		$preset     = $options['preset'] ?? $this->get_default_preset();
+		$format     = $options['format'] ?? 'png';
+		$context    = $options['context'] ?? array();
+
+		if ( empty( $values ) ) {
+			return array();
+		}
+
+		$renderer->create_canvas( $preset );
+
+		if ( ! $renderer->get_image() ) {
+			return array();
+		}
+
+		$renderer->register_font( 'title', 'WilcoLoftSans-Treble.ttf' );
+		$renderer->register_font( 'body', 'helvetica.ttf' );
+
+		// Allocate colors.
+		$bg_color     = $renderer->color_rgb( 'background', self::COLORS['background'] );
+		$title_color  = $renderer->color_rgb( 'title', self::COLORS['title'] );
+		$axis_color   = $renderer->color_rgb( 'axis', self::COLORS['axis'] );
+		$grid_color   = $renderer->color_rgb( 'grid', self::COLORS['grid'] );
+		$label_color  = $renderer->color_rgb( 'axis_label', self::COLORS['axis_label'] );
+
+		$renderer->fill( $bg_color );
+
+		$width  = $renderer->get_width();
+		$height = $renderer->get_height();
+
+		$y = self::PADDING;
+
+		// Draw title.
+		if ( $title ) {
+			$renderer->draw_text_centered( $title, 28, $y + 28, $title_color, 'title' );
+			$y += 60;
+		}
+
+		$chart_area = array(
+			'x'      => self::PADDING,
+			'y'      => $y + 20,
+			'width'  => $width - ( self::PADDING * 2 ),
+			'height' => $height - $y - self::PADDING - 80,
+		);
+
+		// Route to chart-specific rendering.
+		$path = match ( $chart_type ) {
+			'line'   => $this->render_line_chart( $renderer, $labels, $values, $chart_area, $grid_color, $label_color ),
+			'pie'    => $this->render_pie_chart( $renderer, $labels, $values, $chart_area ),
+			default  => $this->render_bar_chart( $renderer, $labels, $values, $chart_area, $grid_color, $label_color ),
+		};
+
+		if ( ! $path ) {
+			$filename = 'chart.' . ( 'jpeg' === $format ? 'jpg' : 'png' );
+
+			if ( ! empty( $context ) ) {
+				$path = $renderer->save_to_repository( $filename, $context, $format );
+			} else {
+				$path = $renderer->save_temp( $format );
+			}
+		}
+
+		$renderer->destroy();
+
+		return $path ? array( $path ) : array();
+	}
+
+	/**
+	 * Render a bar chart.
+	 */
+	private function render_bar_chart( GDRenderer $renderer, array $labels, array $values, array $area, int $grid_color, int $label_color ): ?string {
+		$count   = count( $values );
+		$max_val = max( $values ) > 0 ? max( $values ) : 1;
+
+		$bar_width = (int) ( ( $area['width'] - ( $count - 1 ) * 10 ) / $count );
+		$bar_gap   = 10;
+
+		// Draw grid lines.
+		$grid_lines = 5;
+		for ( $i = 0; $i <= $grid_lines; $i++ ) {
+			$y = $area['y'] + (int) ( $area['height'] * $i / $grid_lines );
+			$renderer->draw_line( $area['x'], $y, $area['x'] + $area['width'], $y, $grid_color, 1 );
+		}
+
+		// Draw bars.
+		$colors = $renderer->get_chart_palette( $count );
+		$baseline = $area['y'] + $area['height'];
+
+		foreach ( $values as $i => $val ) {
+			$bar_height = (int) ( ( $val / $max_val ) * $area['height'] );
+			$x          = $area['x'] + $i * ( $bar_width + $bar_gap );
+
+			$renderer->draw_bar( $x, 0, $bar_width, $bar_height, $colors[ $i ], $baseline );
+
+			// Label.
+			$label = $labels[ $i ] ?? '';
+			if ( $label ) {
+				$label_x = $x + (int) ( $bar_width / 2 );
+				$renderer->draw_text_centered( $label, 12, $baseline + 20, $label_color, 'body' );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Render a line chart.
+	 */
+	private function render_line_chart( GDRenderer $renderer, array $labels, array $values, array $area, int $grid_color, int $label_color ): ?string {
+		$count   = count( $values );
+		$max_val = max( $values ) > 0 ? max( $values ) : 1;
+
+		// Draw grid lines.
+		$grid_lines = 5;
+		for ( $i = 0; $i <= $grid_lines; $i++ ) {
+			$y = $area['y'] + (int) ( $area['height'] * $i / $grid_lines );
+			$renderer->draw_line( $area['x'], $y, $area['x'] + $area['width'], $y, $grid_color, 1 );
+		}
+
+		// Calculate points.
+		$points = array();
+		$step_x = $area['width'] / ( $count > 1 ? $count - 1 : 1 );
+
+		foreach ( $values as $i => $val ) {
+			$x = $area['x'] + (int) ( $i * $step_x );
+			$y = $area['y'] + $area['height'] - (int) ( ( $val / $max_val ) * $area['height'] );
+			$points[] = array( $x, $y );
+		}
+
+		// Draw lines between points.
+		$line_color = $renderer->color( 'line', 83, 148, 11 ); // Brand green.
+		for ( $i = 0; $i < count( $points ) - 1; $i++ ) {
+			$renderer->draw_line( $points[ $i ][0], $points[ $i ][1], $points[ $i + 1 ][0], $points[ $i + 1 ][1], $line_color, 3 );
+		}
+
+		// Draw points.
+		foreach ( $points as $point ) {
+			$renderer->draw_point( $point[0], $point[1], $line_color, 5 );
+		}
+
+		// Labels.
+		$baseline = $area['y'] + $area['height'];
+		foreach ( $labels as $i => $label ) {
+			$x = $area['x'] + (int) ( $i * $step_x );
+			$renderer->draw_text_centered( $label, 12, $baseline + 20, $label_color, 'body' );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Render a pie chart.
+	 */
+	private function render_pie_chart( GDRenderer $renderer, array $labels, array $values, array $area ): ?string {
+		$total   = array_sum( $values );
+		$count   = count( $values );
+		$colors  = $renderer->get_chart_palette( $count );
+
+		$center_x = $area['x'] + (int) ( $area['width'] / 2 );
+		$center_y = $area['y'] + (int) ( $area['height'] / 2 );
+		$radius   = min( $area['width'], $area['height'] ) / 2 - 20;
+
+		// Draw pie slices manually using filled arcs.
+		$start_angle = 0;
+
+		foreach ( $values as $i => $val ) {
+			$sweep_angle = $total > 0 ? ( $val / $total ) * 360 : 0;
+
+			// Draw filled arc slice.
+			$this->draw_pie_slice( $renderer, $center_x, $center_y, $radius, $start_angle, $sweep_angle, $colors[ $i ] );
+
+			$start_angle += $sweep_angle;
+		}
+
+		// Draw legend.
+		$legend_y = $area['y'] + $area['height'] + 30;
+		$legend_x = self::PADDING;
+
+		foreach ( $labels as $i => $label ) {
+			$val_str = $values[ $i ] ?? 0;
+			$legend_text = "{$label}: {$val_str}";
+
+			$renderer->filled_rect( $legend_x, $legend_y - 12, $legend_x + 12, $legend_y, $colors[ $i ], true );
+			$renderer->draw_text( $legend_text, 12, $legend_x + 18, $legend_y, $colors[ $i ], 'body' );
+
+			$legend_x += $renderer->measure_text_width( $legend_text, 12, 'body' ) + 30;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Draw a filled pie slice.
+	 */
+	private function draw_pie_slice( GDRenderer $renderer, int $cx, int $cy, int $radius, float $start_deg, float $sweep_deg, int $color ): void {
+		if ( ! $renderer->get_image() ) {
+			return;
+		}
+
+		$image = $renderer->get_image();
+		$steps = max( 36, (int) ( abs( $sweep_deg ) / 5 ) );
+
+		// Draw the slice as a polygon.
+		$points = array();
+		$points[] = $cx;
+		$points[] = $cy;
+
+		for ( $i = 0; $i <= $steps; $i++ ) {
+			$angle = deg2rad( $start_deg + ( $sweep_deg * $i / $steps ) );
+			$points[] = $cx + (int) ( $radius * cos( $angle ) );
+			$points[] = $cy + (int) ( $radius * sin( $angle ) );
+		}
+
+		imagefilledpolygon( $image, $points, count( $points ) / 2, $color );
+		imagedashedline( $image, $cx, $cy, $cx + (int) ( $radius * cos( deg2rad( $start_deg ) ) ), $cy + (int) ( $radius * sin( deg2rad( $start_deg ) ) ), $color );
+	}
+}

--- a/inc/ImageGeneration/Templates/DiagramTemplate.php
+++ b/inc/ImageGeneration/Templates/DiagramTemplate.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Diagram Template
+ *
+ * Generates diagram images from structured data — flowcharts, process flows.
+ * Supports different node types: rectangle (process), diamond (decision), oval (start/end).
+ *
+ * @package DataMachineSocials\ImageGeneration\Templates
+ * @since 0.2.0
+ */
+
+namespace DataMachineSocials\ImageGeneration\Templates;
+
+use DataMachine\Abilities\Media\GDRenderer;
+use DataMachine\Abilities\Media\TemplateInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class DiagramTemplate implements TemplateInterface {
+
+	/**
+	 * Layout constants.
+	 */
+	private const PADDING    = 40;
+	private const NODE_WIDTH = 160;
+	private const NODE_HEIGHT = 60;
+	private const NODE_GAP_X  = 60;
+	private const NODE_GAP_Y  = 50;
+
+	/**
+	 * Default colors.
+	 */
+	private const COLORS = array(
+		'background' => array( 255, 255, 255 ),
+		'node_fill'  => array( 250, 250, 250 ),
+		'node_stroke' => array( 60, 60, 60 ),
+		'text'       => array( 40, 40, 40 ),
+		'start'      => array( 83, 148, 11 ),   // Green.
+		'end'        => array( 255, 59, 48 ),  // Red.
+		'decision'   => array( 255, 204, 5 ),   // Yellow.
+		'connector'  => array( 100, 100, 100 ),
+	);
+
+	public function get_id(): string {
+		return 'diagram';
+	}
+
+	public function get_name(): string {
+		return 'Diagram';
+	}
+
+	public function get_description(): string {
+		return 'Generate flowcharts and process diagrams from structured data. Supports process, decision, start, and end nodes.';
+	}
+
+	public function get_fields(): array {
+		return array(
+			'title'       => array(
+				'label'    => 'Diagram Title',
+				'type'     => 'string',
+				'required' => false,
+			),
+			'nodes'       => array(
+				'label'    => 'Nodes',
+				'type'     => 'array',
+				'required' => true,
+			),
+			'connections' => array(
+				'label'    => 'Connections',
+				'type'     => 'array',
+				'required' => false,
+			),
+		);
+	}
+
+	public function get_default_preset(): string {
+		return 'instagram_feed_portrait';
+	}
+
+	/**
+	 * Render a diagram.
+	 *
+	 * @param array      $data     Diagram data.
+	 * @param GDRenderer $renderer GD renderer instance.
+	 * @param array      $options  Render options.
+	 * @return string[] Generated image file paths.
+	 */
+	public function render( array $data, GDRenderer $renderer, array $options = array() ): array {
+		$title       = $data['title'] ?? '';
+		$nodes       = $data['nodes'] ?? array();
+		$connections = $data['connections'] ?? array();
+		$preset      = $options['preset'] ?? $this->get_default_preset();
+		$format      = $options['format'] ?? 'png';
+		$context     = $options['context'] ?? array();
+
+		if ( empty( $nodes ) ) {
+			return array();
+		}
+
+		$renderer->create_canvas( $preset );
+
+		if ( ! $renderer->get_image() ) {
+			return array();
+		}
+
+		$renderer->register_font( 'body', 'helvetica.ttf' );
+
+		// Allocate colors.
+		$bg_color       = $renderer->color_rgb( 'background', self::COLORS['background'] );
+		$node_fill      = $renderer->color_rgb( 'node_fill', self::COLORS['node_fill'] );
+		$node_stroke    = $renderer->color_rgb( 'node_stroke', self::COLORS['node_stroke'] );
+		$text_color     = $renderer->color_rgb( 'text', self::COLORS['text'] );
+		$connector_color = $renderer->color_rgb( 'connector', self::COLORS['connector'] );
+
+		$renderer->fill( $bg_color );
+
+		$width  = $renderer->get_width();
+		$height = $renderer->get_height();
+
+		// Draw title.
+		if ( $title ) {
+			$renderer->draw_text_centered( $title, 24, 40, $text_color, 'body' );
+		}
+
+		// Calculate layout.
+		$layout = $this->calculate_layout( $nodes, $width, $height );
+
+		// Draw connections first (behind nodes).
+		foreach ( $connections as $conn ) {
+			$from_id = $conn['from'] ?? null;
+			$to_id   = $conn['to'] ?? null;
+			$label   = $conn['label'] ?? '';
+
+			if ( ! isset( $layout[ $from_id ] ) || ! isset( $layout[ $to_id ] ) ) {
+				continue;
+			}
+
+			$from = $layout[ $from_id ];
+			$to   = $layout[ $to_id ];
+
+			// Calculate connection points (edge to edge).
+			$start = $this->get_edge_point( $from, $to );
+			$end   = $this->get_edge_point( $to, $from );
+
+			$renderer->draw_arrow( $start['x'], $start['y'], $end['x'], $end['y'], $connector_color, 2 );
+
+			// Connection label.
+			if ( $label ) {
+				$label_x = (int) ( ( $start['x'] + $end['x'] ) / 2 );
+				$label_y = (int) ( ( $start['y'] + $end['y'] ) / 2 ) - 10;
+				$renderer->draw_text_centered( $label, 10, $label_y, $text_color, 'body' );
+			}
+		}
+
+		// Draw nodes.
+		foreach ( $nodes as $node ) {
+			$id    = $node['id'] ?? '';
+			$label = $node['label'] ?? '';
+			$type  = $node['type'] ?? 'process';
+
+			if ( ! isset( $layout[ $id ] ) ) {
+				continue;
+			}
+
+			$pos = $layout[ $id ];
+			$this->draw_node( $renderer, $pos, $label, $type, $text_color );
+		}
+
+		$filename = 'diagram.' . ( 'jpeg' === $format ? 'jpg' : 'png' );
+
+		$path = null;
+		if ( ! empty( $context ) ) {
+			$path = $renderer->save_to_repository( $filename, $context, $format );
+		} else {
+			$path = $renderer->save_temp( $format );
+		}
+
+		$renderer->destroy();
+
+		return $path ? array( $path ) : array();
+	}
+
+	/**
+	 * Calculate node positions using simple grid layout.
+	 */
+	private function calculate_layout( array $nodes, int $canvas_width, int $canvas_height ): array {
+		$layout    = array();
+		$cols      = 3; // Max columns.
+		$start_x   = self::PADDING + 40;
+		$start_y   = 100;
+		$col       = 0;
+		$row       = 0;
+
+		foreach ( $nodes as $node ) {
+			$x = $start_x + $col * ( self::NODE_WIDTH + self::NODE_GAP_X );
+			$y = $start_y + $row * ( self::NODE_HEIGHT + self::NODE_GAP_Y );
+
+			$layout[ $node['id'] ?? 'node_' . count( $layout ) ] = array(
+				'x'      => $x,
+				'y'      => $y,
+				'width'  => self::NODE_WIDTH,
+				'height' => self::NODE_HEIGHT,
+				'center_x' => $x + (int) ( self::NODE_WIDTH / 2 ),
+				'center_y' => $y + (int) ( self::NODE_HEIGHT / 2 ),
+			);
+
+			$col++;
+			if ( $col >= $cols ) {
+				$col = 0;
+				$row++;
+			}
+		}
+
+		return $layout;
+	}
+
+	/**
+	 * Draw a single node.
+	 */
+	private function draw_node( GDRenderer $renderer, array $pos, string $label, string $type, int $text_color ): void {
+		$x      = $pos['x'];
+		$y      = $pos['y'];
+		$width  = $pos['width'];
+		$height = $pos['height'];
+		$center_x = $pos['center_x'];
+		$center_y = $pos['center_y'];
+
+		$fill_color = $renderer->color_rgb( 'node_fill', self::COLORS['node_fill'] );
+		$stroke_color = $renderer->color_rgb( 'node_stroke', self::COLORS['node_stroke'] );
+
+		// Node type styling.
+		$node_colors = array(
+			'start'    => self::COLORS['start'],
+			'end'      => self::COLORS['end'],
+			'decision' => self::COLORS['decision'],
+			'process'  => self::COLORS['node_fill'],
+		);
+
+		$bg_rgb = $node_colors[ $type ] ?? $node_colors['process'];
+		$bg_color = $renderer->color_rgb( 'node_bg', $bg_rgb );
+
+		match ( $type ) {
+			'start', 'end' => $renderer->draw_ellipse( $center_x, $center_y, $width, $height, $bg_color, true ),
+			'decision' => $renderer->draw_diamond( $center_x, $center_y, $width, $height, $bg_color, true ),
+			default    => $renderer->draw_rounded_rect( $x, $y, $width, $height, $bg_color, 8 ),
+		};
+
+		// Border.
+		match ( $type ) {
+			'start', 'end' => $renderer->draw_ellipse( $center_x, $center_y, $width, $height, $stroke_color, false ),
+			'decision' => $renderer->draw_diamond( $center_x, $center_y, $width, $height, $stroke_color, false ),
+			default    => $renderer->draw_rect( $x, $y, $x + $width, $y + $height, $stroke_color, false ),
+		};
+
+		// Label - split on pipe for multiline.
+		$lines = explode( '|', $label );
+		$line_height = 16;
+		$start_y = $center_y - ( count( $lines ) - 1 ) * ( $line_height / 2 );
+
+		foreach ( $lines as $i => $line ) {
+			$ly = $start_y + $i * $line_height;
+			$renderer->draw_text_centered( trim( $line ), 12, $ly, $text_color, 'body' );
+		}
+	}
+
+	/**
+	 * Get the point where a line from one node to another should start/end (at the edge).
+	 */
+	private function get_edge_point( array $from, array $to ): array {
+		$dx     = $to['center_x'] - $from['center_x'];
+		$dy     = $to['center_y'] - $from['center_y'];
+		$angle  = atan2( $dy, $dx );
+
+		// Calculate intersection with node boundary.
+		$from_half_w = $from['width'] / 2;
+		$from_half_h = $from['height'] / 2;
+
+		// Simple box intersection - check which edge the line hits.
+		if ( $dx == 0 ) {
+			// Vertical line - hit top or bottom.
+			$from['center_y'] += ( $dy > 0 ? $from_half_h : -$from_half_h );
+		} elseif ( $dy == 0 ) {
+			// Horizontal line - hit left or right.
+			$from['center_x'] += ( $dx > 0 ? $from_half_w : -$from_half_w );
+		} else {
+			// Diagonal - calculate which edge is closer.
+			$tan_angle = abs( tan( $angle ) );
+			$slope_x = $from_half_w;
+			$slope_y = $from_half_h * $tan_angle;
+
+			if ( $slope_y < $slope_x ) {
+				// Intersects left or right edge.
+				$from['center_x'] += ( $dx > 0 ? $from_half_w : -$from_half_w );
+			} else {
+				// Intersects top or bottom edge.
+				$from['center_y'] += ( $dy > 0 ? $from_half_h : -$from_half_h );
+			}
+		}
+
+		return array(
+			'x' => $from['center_x'],
+			'y' => $from['center_y'],
+		);
+	}
+}

--- a/inc/ImageGeneration/Templates/QuoteCard.php
+++ b/inc/ImageGeneration/Templates/QuoteCard.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Quote Card Template
+ *
+ * Generates Instagram-friendly quote graphics from interview content.
+ * Renders quote text, attribution, and branding onto a branded canvas.
+ *
+ * Auto-scales font size based on quote length for optimal readability.
+ * Supports multiple quotes per interview (generates one image per quote).
+ *
+ * @package DataMachineSocials\ImageGeneration\Templates
+ * @since 0.2.0
+ */
+
+namespace DataMachineSocials\ImageGeneration\Templates;
+
+use DataMachine\Abilities\Media\GDRenderer;
+use DataMachine\Abilities\Media\TemplateInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QuoteCard implements TemplateInterface {
+
+	/**
+	 * Layout constants.
+	 */
+	private const PADDING         = 80;
+	private const QUOTE_MARK_SIZE = 120;
+
+	/**
+	 * Font size ranges for auto-scaling.
+	 * Longer quotes get smaller text.
+	 */
+	private const FONT_SIZES = array(
+		'short'  => 48, // Under 80 chars.
+		'medium' => 40, // 80-160 chars.
+		'long'   => 32, // 160-280 chars.
+		'extra'  => 26, // 280+ chars.
+	);
+
+	/**
+	 * Color palette — Extra Chill brand.
+	 */
+	private const COLORS = array(
+		'background'  => array( 26, 26, 26 ),      // #1a1a1a — dark.
+		'quote_text'  => array( 245, 245, 245 ),    // #f5f5f5 — near-white.
+		'attribution' => array( 176, 176, 176 ),    // #b0b0b0 — muted.
+		'accent'      => array( 83, 148, 11 ),      // #53940b — EC green.
+		'quote_mark'  => array( 83, 148, 11 ),      // #53940b — EC green.
+		'branding'    => array( 120, 120, 120 ),    // #787878 — subtle.
+	);
+
+	public function get_id(): string {
+		return 'quote_card';
+	}
+
+	public function get_name(): string {
+		return 'Quote Card';
+	}
+
+	public function get_description(): string {
+		return 'Instagram-friendly quote graphic from interview content. Renders quote text with attribution and Extra Chill branding.';
+	}
+
+	public function get_fields(): array {
+		return array(
+			'quote_text'   => array(
+				'label'    => 'Quote Text',
+				'type'     => 'string',
+				'required' => true,
+			),
+			'attribution'  => array(
+				'label'    => 'Attribution',
+				'type'     => 'string',
+				'required' => true,
+			),
+			'source_title' => array(
+				'label'    => 'Source Title',
+				'type'     => 'string',
+				'required' => false,
+			),
+			'branding'     => array(
+				'label'    => 'Branding Text',
+				'type'     => 'string',
+				'required' => false,
+			),
+		);
+	}
+
+	public function get_default_preset(): string {
+		return 'instagram_feed_portrait';
+	}
+
+	/**
+	 * Render quote card(s).
+	 *
+	 * If `data['quotes']` is provided (array of {quote_text, attribution}),
+	 * generates one image per quote. Otherwise generates a single image
+	 * from the top-level data fields.
+	 *
+	 * @param array      $data     Quote data.
+	 * @param GDRenderer $renderer GD renderer instance.
+	 * @param array      $options  Render options.
+	 * @return string[] Generated image file paths.
+	 */
+	public function render( array $data, GDRenderer $renderer, array $options = array() ): array {
+		// Support batch mode: array of quotes.
+		$quotes = $data['quotes'] ?? array();
+		if ( empty( $quotes ) ) {
+			$quotes = array(
+				array(
+					'quote_text'   => $data['quote_text'] ?? '',
+					'attribution'  => $data['attribution'] ?? '',
+					'source_title' => $data['source_title'] ?? '',
+				),
+			);
+		}
+
+		$branding = $data['branding'] ?? 'extrachill.com';
+		$preset   = $options['preset'] ?? $this->get_default_preset();
+		$format   = $options['format'] ?? 'png';
+		$context  = $options['context'] ?? array();
+
+		$file_paths = array();
+
+		foreach ( $quotes as $index => $quote ) {
+			$quote_text   = trim( $quote['quote_text'] ?? '' );
+			$attribution  = trim( $quote['attribution'] ?? '' );
+			$source_title = trim( $quote['source_title'] ?? $data['source_title'] ?? '' );
+
+			if ( empty( $quote_text ) || empty( $attribution ) ) {
+				continue;
+			}
+
+			$path = $this->render_single(
+				$renderer,
+				$quote_text,
+				$attribution,
+				$source_title,
+				$branding,
+				$preset,
+				$format,
+				$context,
+				$index + 1
+			);
+
+			if ( $path ) {
+				$file_paths[] = $path;
+			}
+		}
+
+		return $file_paths;
+	}
+
+	/**
+	 * Render a single quote card image.
+	 *
+	 * @param GDRenderer $renderer     GD renderer.
+	 * @param string     $quote_text   The quote.
+	 * @param string     $attribution  Who said it.
+	 * @param string     $source_title Interview/article title.
+	 * @param string     $branding     Branding text (e.g. extrachill.com).
+	 * @param string     $preset       Platform preset name.
+	 * @param string     $format       Output format (png/jpeg).
+	 * @param array      $context      Storage context for repository.
+	 * @param int        $index        Quote index (for filename).
+	 * @return string|null File path on success.
+	 */
+	private function render_single(
+		GDRenderer $renderer,
+		string $quote_text,
+		string $attribution,
+		string $source_title,
+		string $branding,
+		string $preset,
+		string $format,
+		array $context,
+		int $index
+	): ?string {
+		// Create canvas.
+		$renderer->create_canvas( $preset );
+
+		if ( ! $renderer->get_image() ) {
+			return null;
+		}
+
+		// Register fonts.
+		$renderer->register_font( 'header', 'WilcoLoftSans-Treble.ttf' );
+		$renderer->register_font( 'body', 'helvetica.ttf' );
+
+		// Allocate colors.
+		$bg_color          = $renderer->color_rgb( 'background', self::COLORS['background'] );
+		$quote_text_color  = $renderer->color_rgb( 'quote_text', self::COLORS['quote_text'] );
+		$attribution_color = $renderer->color_rgb( 'attribution', self::COLORS['attribution'] );
+		$accent_color      = $renderer->color_rgb( 'accent', self::COLORS['accent'] );
+		$quote_mark_color  = $renderer->color_rgb( 'quote_mark', self::COLORS['quote_mark'] );
+		$branding_color    = $renderer->color_rgb( 'branding', self::COLORS['branding'] );
+
+		// Fill background.
+		$renderer->fill( $bg_color );
+
+		$width     = $renderer->get_width();
+		$height    = $renderer->get_height();
+		$max_width = $width - ( self::PADDING * 2 );
+
+		// Determine font size based on quote length.
+		$font_size = $this->get_quote_font_size( $quote_text );
+
+		// --- Layout calculation (vertical centering) ---
+
+		// Measure all text blocks.
+		$quote_mark_height  = self::QUOTE_MARK_SIZE + 20; // Mark + gap.
+		$quote_text_height  = $renderer->measure_text_height( $quote_text, $font_size, 'body', $max_width, 1.5 );
+		$accent_line_height = 2 + 30; // Line + gap.
+
+		$attribution_size   = 22;
+		$attribution_line   = "\xe2\x80\x94 " . $attribution; // Em dash prefix.
+		$attribution_height = $renderer->measure_text_height( $attribution_line, $attribution_size, 'header', $max_width );
+
+		$source_height = 0;
+		if ( $source_title ) {
+			$source_height = $renderer->measure_text_height( $source_title, 18, 'body', $max_width ) + 10;
+		}
+
+		$branding_height = 0;
+		if ( $branding ) {
+			$branding_height = 50; // Fixed space at bottom.
+		}
+
+		$total_content_height = $quote_mark_height + $quote_text_height + $accent_line_height + $attribution_height + $source_height;
+		$available_height     = $height - $branding_height;
+		$y_start              = max( self::PADDING, (int) ( ( $available_height - $total_content_height ) / 2 ) );
+
+		$y = $y_start;
+
+		// --- Render quote mark ---
+		$renderer->draw_text(
+			"\xe2\x80\x9c", // Left double quotation mark.
+			self::QUOTE_MARK_SIZE,
+			self::PADDING,
+			$y + self::QUOTE_MARK_SIZE,
+			$quote_mark_color,
+			'header'
+		);
+		$y += $quote_mark_height;
+
+		// --- Render quote text ---
+		$y = $renderer->draw_text_wrapped(
+			$quote_text,
+			$font_size,
+			self::PADDING,
+			$y,
+			$quote_text_color,
+			'body',
+			$max_width,
+			1.5,
+			'left'
+		);
+
+		$y += 15;
+
+		// --- Accent line ---
+		$renderer->filled_rect(
+			self::PADDING,
+			$y,
+			self::PADDING + 60,
+			$y + 2,
+			$accent_color
+		);
+		$y += 30;
+
+		// --- Attribution ---
+		$y = $renderer->draw_text_wrapped(
+			$attribution_line,
+			$attribution_size,
+			self::PADDING,
+			$y,
+			$attribution_color,
+			'header',
+			$max_width
+		);
+
+		// --- Source title ---
+		if ( $source_title ) {
+			$y += 10;
+			$renderer->draw_text_wrapped(
+				$source_title,
+				18,
+				self::PADDING,
+				$y,
+				$branding_color,
+				'body',
+				$max_width
+			);
+		}
+
+		// --- Branding (bottom) ---
+		if ( $branding ) {
+			$renderer->draw_text_centered(
+				$branding,
+				16,
+				$height - 40,
+				$branding_color,
+				'body'
+			);
+		}
+
+		// --- Save ---
+		$filename = sprintf( 'quote-card-%d.%s', $index, 'jpeg' === $format ? 'jpg' : 'png' );
+
+		if ( ! empty( $context ) ) {
+			$path = $renderer->save_to_repository( $filename, $context, $format );
+		} else {
+			$path = $renderer->save_temp( $format );
+		}
+
+		$renderer->destroy();
+
+		return $path;
+	}
+
+	/**
+	 * Determine quote font size based on character length.
+	 *
+	 * @param string $quote_text Quote text.
+	 * @return int Font size in points.
+	 */
+	private function get_quote_font_size( string $quote_text ): int {
+		$length = mb_strlen( $quote_text );
+
+		if ( $length < 80 ) {
+			return self::FONT_SIZES['short'];
+		}
+
+		if ( $length < 160 ) {
+			return self::FONT_SIZES['medium'];
+		}
+
+		if ( $length < 280 ) {
+			return self::FONT_SIZES['long'];
+		}
+
+		return self::FONT_SIZES['extra'];
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the **QuoteCard** template — the first image generation template registered with Data Machine core's new GD template engine
- Generates Instagram-friendly quote graphics from interview content with auto-scaling font sizes, brand colors, and Extra Chill typography
- Supports single and batch mode (multiple quotes per interview = carousel)

## How It Works

```php
// Socials registers the template via filter
add_filter('datamachine/image_generation/templates', function($templates) {
    $templates['quote_card'] = QuoteCard::class;
    return $templates;
});
```

## QuoteCard Features

- **Auto-scaling font size**: short quotes (< 80 chars) get 48pt, long quotes (280+) get 26pt
- **Brand consistent**: EC dark background (#1a1a1a), green accent (#53940b), WilcoLoftSans headers, Helvetica body
- **Batch mode**: pass `quotes` array to generate a carousel (one image per quote)
- **Platform presets**: defaults to `instagram_feed_portrait` (1080x1350)
- **Layout**: large quotation mark, quote text, accent line, em-dash attribution, source title, branding footer

## Template Fields

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `quote_text` | string | Yes | The quote |
| `attribution` | string | Yes | Who said it |
| `source_title` | string | No | Interview/article title |
| `branding` | string | No | Footer text (default: extrachill.com) |

## Testing

Rendered test images via WP-CLI — see attached screenshots in the Discord thread.

## Depends On

- Extra-Chill/data-machine#448 (GD template engine in core) — must merge first
- Issue: #23