### PR TITLE
feat: add read operations for all remaining platforms

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -48,19 +48,26 @@ function datamachine_socials_load_handlers() {
 
 	// Twitter
 	new \DataMachineSocials\Abilities\Twitter\TwitterPublishAbility();
+	new \DataMachineSocials\Abilities\Twitter\TwitterReadAbility();
 
 	// Facebook
 	new \DataMachineSocials\Abilities\Facebook\FacebookPublishAbility();
+	new \DataMachineSocials\Abilities\Facebook\FacebookReadAbility();
 
 	// Bluesky
 	new \DataMachineSocials\Abilities\Bluesky\BlueskyPublishAbility();
+	new \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility();
 
 	// Threads
 	new \DataMachineSocials\Abilities\Threads\ThreadsPublishAbility();
+	new \DataMachineSocials\Abilities\Threads\ThreadsReadAbility();
 
 	// Instagram
 	new \DataMachineSocials\Abilities\Instagram\InstagramPublishAbility();
 	new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
+
+	// Pinterest
+	new \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility();
 
 	// Reddit (Fetch)
 	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
@@ -144,9 +151,17 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/PinterestCommand.php';
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/RedditCommand.php';
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/InstagramCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/ThreadsCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/FacebookCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/TwitterCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/BlueskyCommand.php';
 	WP_CLI::add_command( 'datamachine-socials pinterest', \DataMachineSocials\Cli\Commands\PinterestCommand::class );
 	WP_CLI::add_command( 'datamachine-socials reddit', \DataMachineSocials\Cli\Commands\RedditCommand::class );
 	WP_CLI::add_command( 'datamachine-socials instagram', \DataMachineSocials\Cli\Commands\InstagramCommand::class );
+	WP_CLI::add_command( 'datamachine-socials threads', \DataMachineSocials\Cli\Commands\ThreadsCommand::class );
+	WP_CLI::add_command( 'datamachine-socials facebook', \DataMachineSocials\Cli\Commands\FacebookCommand::class );
+	WP_CLI::add_command( 'datamachine-socials twitter', \DataMachineSocials\Cli\Commands\TwitterCommand::class );
+	WP_CLI::add_command( 'datamachine-socials bluesky', \DataMachineSocials\Cli\Commands\BlueskyCommand::class );
 }
 
 /**
@@ -162,5 +177,10 @@ function datamachine_socials_load_chat_tools() {
 
 	new \DataMachineSocials\Chat\Tools\FetchReddit();
 	new \DataMachineSocials\Chat\Tools\ReadInstagram();
+	new \DataMachineSocials\Chat\Tools\ReadThreads();
+	new \DataMachineSocials\Chat\Tools\ReadFacebook();
+	new \DataMachineSocials\Chat\Tools\ReadTwitter();
+	new \DataMachineSocials\Chat\Tools\ReadBluesky();
+	new \DataMachineSocials\Chat\Tools\ReadPinterest();
 }
 add_action( 'plugins_loaded', 'datamachine_socials_load_chat_tools', 25 );

--- a/inc/Abilities/Bluesky/BlueskyReadAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyReadAbility.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Bluesky Read Ability
+ *
+ * Abilities API primitive for reading Bluesky posts via the AT Protocol.
+ * Uses session-based authentication (app password).
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Bluesky
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Bluesky;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class BlueskyReadAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/bluesky-read',
+				array(
+					'label'               => __( 'Read Bluesky Posts', 'data-machine-socials' ),
+					'description'         => __( 'List recent Bluesky posts, get a post thread, or view profile', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'enum'        => array( 'list', 'get', 'profile' ),
+								'default'     => 'list',
+								'description' => __( 'Action: list (author feed), get (post thread), profile (user profile)', 'data-machine-socials' ),
+							),
+							'post_uri' => array(
+								'type'        => 'string',
+								'description' => __( 'AT Protocol post URI (required for get action, e.g. at://did:plc:.../app.bsky.feed.post/...)', 'data-machine-socials' ),
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of posts to return (max 100)', 'data-machine-socials' ),
+							),
+							'cursor'   => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination cursor for next page', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'list';
+
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky auth provider not available',
+			);
+		}
+
+		$session = $auth->get_session();
+		if ( is_wp_error( $session ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky session creation failed: ' . $session->get_error_message(),
+			);
+		}
+
+		if ( empty( $session['accessJwt'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky authentication failed (no access token in session)',
+			);
+		}
+
+		$pds_url      = $session['pds_url'] ?? 'https://bsky.social';
+		$access_token = $session['accessJwt'];
+		$did          = $session['did'] ?? '';
+		$handle       = $session['handle'] ?? '';
+
+		switch ( $action ) {
+			case 'list':
+				return $this->listPosts( $pds_url, $access_token, $did ?: $handle, $input );
+
+			case 'get':
+				if ( empty( $input['post_uri'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'post_uri is required for the get action',
+					);
+				}
+				return $this->getPostThread( $pds_url, $access_token, $input['post_uri'] );
+
+			case 'profile':
+				return $this->getProfile( $pds_url, $access_token, $did ?: $handle );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use list, get, or profile.",
+				);
+		}
+	}
+
+	private function listPosts( string $pds_url, string $access_token, string $actor, array $input ): array {
+		if ( empty( $actor ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky DID/handle not available. Try re-authenticating.',
+			);
+		}
+
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'actor' => $actor,
+			'limit' => $limit,
+		);
+
+		if ( ! empty( $input['cursor'] ) ) {
+			$params['cursor'] = $input['cursor'];
+		}
+
+		$url    = $pds_url . '/xrpc/app.bsky.feed.getAuthorFeed?' . http_build_query( $params );
+		$result = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $access_token ),
+				'context' => 'Bluesky Read',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['message'] ?? $data['error'] ?? 'Failed to fetch Bluesky feed';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$feed   = $data['feed'] ?? array();
+		$cursor = $data['cursor'] ?? null;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'posts'    => $feed,
+				'count'    => count( $feed ),
+				'cursor'   => $cursor,
+				'has_next' => ! empty( $cursor ),
+			),
+		);
+	}
+
+	private function getPostThread( string $pds_url, string $access_token, string $post_uri ): array {
+		$params = array(
+			'uri'   => $post_uri,
+			'depth' => 6,
+		);
+
+		$url    = $pds_url . '/xrpc/app.bsky.feed.getPostThread?' . http_build_query( $params );
+		$result = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $access_token ),
+				'context' => 'Bluesky Read',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['message'] ?? $data['error'] ?? 'Failed to fetch post thread';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data['thread'] ?? $data,
+		);
+	}
+
+	private function getProfile( string $pds_url, string $access_token, string $actor ): array {
+		$params = array( 'actor' => $actor );
+
+		$url    = $pds_url . '/xrpc/app.bsky.actor.getProfile?' . http_build_query( $params );
+		$result = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $access_token ),
+				'context' => 'Bluesky Read',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['message'] ?? $data['error'] ?? 'Failed to fetch profile';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	private function getAuthProvider(): ?BlueskyAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'bluesky' );
+
+		if ( $provider instanceof BlueskyAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Abilities/Facebook/FacebookReadAbility.php
+++ b/inc/Abilities/Facebook/FacebookReadAbility.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Facebook Read Ability
+ *
+ * Abilities API primitive for reading Facebook Page posts and comments.
+ * Uses the page_access_token for page-level operations.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Facebook
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Facebook;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class FacebookReadAbility {
+
+	private static bool $registered = false;
+
+	const LIST_FIELDS = 'id,message,created_time,permalink_url,full_picture,shares,likes.summary(true),comments.summary(true)';
+
+	const DETAIL_FIELDS = 'id,message,created_time,permalink_url,full_picture,shares,likes.summary(true),comments.summary(true),type,status_type';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/facebook-read',
+				array(
+					'label'               => __( 'Read Facebook Page Posts', 'data-machine-socials' ),
+					'description'         => __( 'List recent Facebook Page posts or get details for a specific post', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'  => array(
+								'type'        => 'string',
+								'enum'        => array( 'list', 'get', 'comments' ),
+								'default'     => 'list',
+								'description' => __( 'Action: list (recent posts), get (single post), comments (post comments)', 'data-machine-socials' ),
+							),
+							'post_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Facebook post ID (required for get and comments actions)', 'data-machine-socials' ),
+							),
+							'limit'   => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of items to return (max 100)', 'data-machine-socials' ),
+							),
+							'after'   => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination cursor for next page', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'list';
+
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook auth provider not available',
+			);
+		}
+
+		// Facebook uses page_access_token for page operations.
+		$page_token = $auth->get_page_access_token();
+		if ( empty( $page_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook page access token unavailable (expired or refresh failed)',
+			);
+		}
+
+		switch ( $action ) {
+			case 'list':
+				return $this->listPosts( $auth, $page_token, $input );
+
+			case 'get':
+				if ( empty( $input['post_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'post_id is required for the get action',
+					);
+				}
+				return $this->getPost( $page_token, $input['post_id'] );
+
+			case 'comments':
+				if ( empty( $input['post_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'post_id is required for the comments action',
+					);
+				}
+				return $this->getComments( $page_token, $input['post_id'], $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use list, get, or comments.",
+				);
+		}
+	}
+
+	private function listPosts( FacebookAuth $auth, string $page_token, array $input ): array {
+		$page_id = $auth->get_page_id();
+		if ( empty( $page_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook Page ID not available. Try re-authenticating.',
+			);
+		}
+
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => self::LIST_FIELDS,
+			'limit'        => $limit,
+			'access_token' => $page_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = FacebookAuth::GRAPH_API_URL . "/{$page_id}/feed?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Facebook Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch Facebook posts';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$posts  = $data['data'] ?? array();
+		$paging = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'posts'    => $posts,
+				'count'    => count( $posts ),
+				'cursors'  => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	private function getPost( string $page_token, string $post_id ): array {
+		$params = array(
+			'fields'       => self::DETAIL_FIELDS,
+			'access_token' => $page_token,
+		);
+
+		$url    = FacebookAuth::GRAPH_API_URL . "/{$post_id}?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Facebook Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch Facebook post details';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	private function getComments( string $page_token, string $post_id, array $input ): array {
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => 'id,message,created_time,from,like_count',
+			'limit'        => $limit,
+			'access_token' => $page_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = FacebookAuth::GRAPH_API_URL . "/{$post_id}/comments?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Facebook Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch comments';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$comments = $data['data'] ?? array();
+		$paging   = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'comments' => $comments,
+				'count'    => count( $comments ),
+				'cursors'  => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	private function getAuthProvider(): ?FacebookAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'facebook' );
+
+		if ( $provider instanceof FacebookAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Abilities/Pinterest/PinterestReadAbility.php
+++ b/inc/Abilities/Pinterest/PinterestReadAbility.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Pinterest Read Ability
+ *
+ * Abilities API primitive for reading Pinterest pins, boards, and board pins.
+ * Uses static bearer token authentication.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Pinterest
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Pinterest;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class PinterestReadAbility {
+
+	private static bool $registered = false;
+
+	const API_URL = 'https://api.pinterest.com/v5';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/pinterest-read',
+				array(
+					'label'               => __( 'Read Pinterest Pins', 'data-machine-socials' ),
+					'description'         => __( 'List pins, get pin details, list boards, or list board pins', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'enum'        => array( 'pins', 'pin', 'boards', 'board_pins' ),
+								'default'     => 'pins',
+								'description' => __( 'Action: pins (user pins), pin (single pin), boards (list boards), board_pins (pins from a board)', 'data-machine-socials' ),
+							),
+							'pin_id'   => array(
+								'type'        => 'string',
+								'description' => __( 'Pinterest pin ID (required for pin action)', 'data-machine-socials' ),
+							),
+							'board_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Pinterest board ID (required for board_pins action)', 'data-machine-socials' ),
+							),
+							'bookmark' => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination bookmark for next page', 'data-machine-socials' ),
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of items to return (max 100)', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'pins';
+
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest auth provider not available',
+			);
+		}
+
+		// Pinterest uses a static bearer token stored in config.
+		$config = $auth->get_config();
+		$token  = $config['access_token'] ?? '';
+		if ( empty( $token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest access token not configured',
+			);
+		}
+
+		switch ( $action ) {
+			case 'pins':
+				return $this->listPins( $token, $input );
+
+			case 'pin':
+				if ( empty( $input['pin_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'pin_id is required for the pin action',
+					);
+				}
+				return $this->getPin( $token, $input['pin_id'] );
+
+			case 'boards':
+				return $this->listBoards( $token, $input );
+
+			case 'board_pins':
+				if ( empty( $input['board_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'board_id is required for the board_pins action',
+					);
+				}
+				return $this->getBoardPins( $token, $input['board_id'], $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use pins, pin, boards, or board_pins.",
+				);
+		}
+	}
+
+	private function listPins( string $token, array $input ): array {
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array( 'page_size' => $limit );
+
+		if ( ! empty( $input['bookmark'] ) ) {
+			$params['bookmark'] = $input['bookmark'];
+		}
+
+		return $this->apiGet( $token, '/pins?' . http_build_query( $params ), 'items', 'pins' );
+	}
+
+	private function getPin( string $token, string $pin_id ): array {
+		$url    = self::API_URL . "/pins/{$pin_id}";
+		$result = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
+				'context' => 'Pinterest Read',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['code'] ) ) {
+			$error_msg = $data['message'] ?? 'Failed to fetch pin details';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	private function listBoards( string $token, array $input ): array {
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array( 'page_size' => $limit );
+
+		if ( ! empty( $input['bookmark'] ) ) {
+			$params['bookmark'] = $input['bookmark'];
+		}
+
+		return $this->apiGet( $token, '/boards?' . http_build_query( $params ), 'items', 'boards' );
+	}
+
+	private function getBoardPins( string $token, string $board_id, array $input ): array {
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array( 'page_size' => $limit );
+
+		if ( ! empty( $input['bookmark'] ) ) {
+			$params['bookmark'] = $input['bookmark'];
+		}
+
+		return $this->apiGet( $token, "/boards/{$board_id}/pins?" . http_build_query( $params ), 'items', 'pins' );
+	}
+
+	/**
+	 * Generic Pinterest GET request that returns paginated results.
+	 *
+	 * @param string $token     Bearer token.
+	 * @param string $path      API path with query string.
+	 * @param string $data_key  Key in response containing items.
+	 * @param string $label     Label for the result array.
+	 * @return array
+	 */
+	private function apiGet( string $token, string $path, string $data_key, string $label ): array {
+		$url    = self::API_URL . $path;
+		$result = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
+				'context' => 'Pinterest Read',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['code'] ) ) {
+			$error_msg = $data['message'] ?? "Failed to fetch {$label}";
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$items    = $data[ $data_key ] ?? array();
+		$bookmark = $data['bookmark'] ?? null;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				$label     => $items,
+				'count'    => count( $items ),
+				'bookmark' => $bookmark,
+				'has_next' => ! empty( $bookmark ),
+			),
+		);
+	}
+
+	private function getAuthProvider(): ?PinterestAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'pinterest' );
+
+		if ( $provider instanceof PinterestAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Abilities/Threads/ThreadsReadAbility.php
+++ b/inc/Abilities/Threads/ThreadsReadAbility.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Threads Read Ability
+ *
+ * Abilities API primitive for reading Threads posts and replies.
+ * Supports listing recent threads and fetching single thread details.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Threads
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Threads;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Threads\ThreadsAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class ThreadsReadAbility {
+
+	private static bool $registered = false;
+
+	const API_URL = 'https://graph.threads.net/v1.0';
+
+	const LIST_FIELDS = 'id,text,timestamp,media_type,media_url,permalink,like_count,is_quote_post';
+
+	const DETAIL_FIELDS = 'id,text,timestamp,media_type,media_url,permalink,like_count,is_quote_post,shortcode';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/threads-read',
+				array(
+					'label'               => __( 'Read Threads Posts', 'data-machine-socials' ),
+					'description'         => __( 'List recent Threads posts or get details for a specific thread', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'    => array(
+								'type'        => 'string',
+								'enum'        => array( 'list', 'get', 'replies' ),
+								'default'     => 'list',
+								'description' => __( 'Action: list (recent threads), get (single thread), replies (thread replies)', 'data-machine-socials' ),
+							),
+							'thread_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Threads media ID (required for get and replies actions)', 'data-machine-socials' ),
+							),
+							'limit'     => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of items to return (max 100)', 'data-machine-socials' ),
+							),
+							'after'     => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination cursor for next page', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'list';
+
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads auth provider not available',
+			);
+		}
+
+		$access_token = $auth->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads access token unavailable (expired or refresh failed)',
+			);
+		}
+
+		switch ( $action ) {
+			case 'list':
+				return $this->listThreads( $auth, $access_token, $input );
+
+			case 'get':
+				if ( empty( $input['thread_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'thread_id is required for the get action',
+					);
+				}
+				return $this->getThread( $access_token, $input['thread_id'] );
+
+			case 'replies':
+				if ( empty( $input['thread_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'thread_id is required for the replies action',
+					);
+				}
+				return $this->getReplies( $access_token, $input['thread_id'], $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use list, get, or replies.",
+				);
+		}
+	}
+
+	private function listThreads( ThreadsAuth $auth, string $access_token, array $input ): array {
+		$user_id = $auth->get_page_id();
+		if ( empty( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads user ID not available. Try re-authenticating.',
+			);
+		}
+
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => self::LIST_FIELDS,
+			'limit'        => $limit,
+			'access_token' => $access_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = self::API_URL . "/{$user_id}/threads?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Threads Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch Threads posts';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$threads = $data['data'] ?? array();
+		$paging  = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'threads'  => $threads,
+				'count'    => count( $threads ),
+				'cursors'  => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	private function getThread( string $access_token, string $thread_id ): array {
+		$params = array(
+			'fields'       => self::DETAIL_FIELDS,
+			'access_token' => $access_token,
+		);
+
+		$url    = self::API_URL . "/{$thread_id}?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Threads Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch thread details';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	private function getReplies( string $access_token, string $thread_id, array $input ): array {
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'fields'       => 'id,text,timestamp,username,like_count',
+			'limit'        => $limit,
+			'access_token' => $access_token,
+		);
+
+		if ( ! empty( $input['after'] ) ) {
+			$params['after'] = $input['after'];
+		}
+
+		$url    = self::API_URL . "/{$thread_id}/replies?" . http_build_query( $params );
+		$result = HttpClient::get( $url, array( 'context' => 'Threads Read' ) );
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads API request failed: ' . ( $result['error'] ?? 'unknown' ),
+			);
+		}
+
+		$data      = json_decode( $result['data'], true );
+		$http_code = $result['status_code'];
+
+		if ( 200 !== $http_code || isset( $data['error'] ) ) {
+			$error_msg = $data['error']['message'] ?? 'Failed to fetch replies';
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$replies = $data['data'] ?? array();
+		$paging  = $data['paging'] ?? array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'replies'  => $replies,
+				'count'    => count( $replies ),
+				'cursors'  => $paging['cursors'] ?? null,
+				'has_next' => ! empty( $paging['next'] ),
+			),
+		);
+	}
+
+	private function getAuthProvider(): ?ThreadsAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'threads' );
+
+		if ( $provider instanceof ThreadsAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Abilities/Twitter/TwitterReadAbility.php
+++ b/inc/Abilities/Twitter/TwitterReadAbility.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Twitter Read Ability
+ *
+ * Abilities API primitive for reading tweets via Twitter API v2.
+ * Uses the TwitterOAuth library for authenticated requests.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Twitter
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Twitter;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Twitter\TwitterAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class TwitterReadAbility {
+
+	private static bool $registered = false;
+
+	const TWEET_FIELDS = 'id,text,created_at,public_metrics,source,lang,conversation_id';
+
+	const USER_FIELDS = 'id,name,username,profile_image_url,public_metrics,description';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/twitter-read',
+				array(
+					'label'               => __( 'Read Tweets', 'data-machine-socials' ),
+					'description'         => __( 'List recent tweets, get a specific tweet, or get mentions', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'enum'        => array( 'list', 'get', 'mentions' ),
+								'default'     => 'list',
+								'description' => __( 'Action: list (user timeline), get (single tweet), mentions (user mentions)', 'data-machine-socials' ),
+							),
+							'tweet_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Tweet ID (required for get action)', 'data-machine-socials' ),
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'default'     => 25,
+								'description' => __( 'Number of tweets to return (max 100)', 'data-machine-socials' ),
+							),
+							'pagination_token' => array(
+								'type'        => 'string',
+								'description' => __( 'Pagination token for next page', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$action = $input['action'] ?? 'list';
+
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter auth provider not available',
+			);
+		}
+
+		$connection = $auth->get_connection();
+		if ( is_wp_error( $connection ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter connection failed: ' . $connection->get_error_message(),
+			);
+		}
+
+		$connection->setApiVersion( '2' );
+
+		switch ( $action ) {
+			case 'list':
+				return $this->listTweets( $auth, $connection, $input );
+
+			case 'get':
+				if ( empty( $input['tweet_id'] ) ) {
+					return array(
+						'success' => false,
+						'error'   => 'tweet_id is required for the get action',
+					);
+				}
+				return $this->getTweet( $connection, $input['tweet_id'] );
+
+			case 'mentions':
+				return $this->getMentions( $auth, $connection, $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => "Unknown action: {$action}. Use list, get, or mentions.",
+				);
+		}
+	}
+
+	private function listTweets( TwitterAuth $auth, $connection, array $input ): array {
+		$account = $auth->get_account_details();
+		$user_id = $account['user_id'] ?? null;
+		if ( empty( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter user ID not available. Try re-authenticating.',
+			);
+		}
+
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'tweet.fields' => self::TWEET_FIELDS,
+			'max_results'  => max( $limit, 5 ), // Twitter API v2 minimum is 5.
+		);
+
+		if ( ! empty( $input['pagination_token'] ) ) {
+			$params['pagination_token'] = $input['pagination_token'];
+		}
+
+		$response  = $connection->get( "users/{$user_id}/tweets", $params );
+		$http_code = $connection->getLastHttpCode();
+
+		if ( 200 !== $http_code ) {
+			$error_msg = $this->extractError( $response, 'Failed to fetch tweets' );
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$response = (array) $response;
+		$tweets   = isset( $response['data'] ) ? array_map( function ( $t ) { return (array) $t; }, $response['data'] ) : array();
+		$meta     = isset( $response['meta'] ) ? (array) $response['meta'] : array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'tweets'           => $tweets,
+				'count'            => count( $tweets ),
+				'next_token'       => $meta['next_token'] ?? null,
+				'has_next'         => ! empty( $meta['next_token'] ),
+				'result_count'     => $meta['result_count'] ?? count( $tweets ),
+			),
+		);
+	}
+
+	private function getTweet( $connection, string $tweet_id ): array {
+		$params = array(
+			'tweet.fields' => self::TWEET_FIELDS,
+			'expansions'   => 'author_id',
+			'user.fields'  => self::USER_FIELDS,
+		);
+
+		$response  = $connection->get( "tweets/{$tweet_id}", $params );
+		$http_code = $connection->getLastHttpCode();
+
+		if ( 200 !== $http_code ) {
+			$error_msg = $this->extractError( $response, 'Failed to fetch tweet' );
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$response = (array) $response;
+		$data     = isset( $response['data'] ) ? (array) $response['data'] : array();
+
+		// Flatten public_metrics if present.
+		if ( isset( $data['public_metrics'] ) ) {
+			$data['public_metrics'] = (array) $data['public_metrics'];
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $data,
+		);
+	}
+
+	private function getMentions( TwitterAuth $auth, $connection, array $input ): array {
+		$account = $auth->get_account_details();
+		$user_id = $account['user_id'] ?? null;
+		if ( empty( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter user ID not available. Try re-authenticating.',
+			);
+		}
+
+		$limit  = min( absint( $input['limit'] ?? 25 ), 100 );
+		$params = array(
+			'tweet.fields' => self::TWEET_FIELDS,
+			'max_results'  => max( $limit, 5 ),
+			'expansions'   => 'author_id',
+			'user.fields'  => 'id,name,username',
+		);
+
+		if ( ! empty( $input['pagination_token'] ) ) {
+			$params['pagination_token'] = $input['pagination_token'];
+		}
+
+		$response  = $connection->get( "users/{$user_id}/mentions", $params );
+		$http_code = $connection->getLastHttpCode();
+
+		if ( 200 !== $http_code ) {
+			$error_msg = $this->extractError( $response, 'Failed to fetch mentions' );
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$response = (array) $response;
+		$tweets   = isset( $response['data'] ) ? array_map( function ( $t ) { return (array) $t; }, $response['data'] ) : array();
+		$meta     = isset( $response['meta'] ) ? (array) $response['meta'] : array();
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'mentions'     => $tweets,
+				'count'        => count( $tweets ),
+				'next_token'   => $meta['next_token'] ?? null,
+				'has_next'     => ! empty( $meta['next_token'] ),
+				'result_count' => $meta['result_count'] ?? count( $tweets ),
+			),
+		);
+	}
+
+	/**
+	 * Extract error message from Twitter API response.
+	 *
+	 * @param mixed  $response API response (stdClass or array).
+	 * @param string $fallback Fallback message.
+	 * @return string
+	 */
+	private function extractError( $response, string $fallback ): string {
+		$response = (array) $response;
+
+		if ( isset( $response['detail'] ) ) {
+			return $response['detail'];
+		}
+
+		if ( isset( $response['errors'] ) && is_array( $response['errors'] ) ) {
+			$first = (array) $response['errors'][0];
+			return $first['message'] ?? $fallback;
+		}
+
+		if ( isset( $response['title'] ) ) {
+			return $response['title'];
+		}
+
+		return $fallback;
+	}
+
+	private function getAuthProvider(): ?TwitterAuth {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'twitter' );
+
+		if ( $provider instanceof TwitterAuth ) {
+			return $provider;
+		}
+
+		return null;
+	}
+}

--- a/inc/Chat/Tools/ReadBluesky.php
+++ b/inc/Chat/Tools/ReadBluesky.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Read Bluesky Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadBluesky extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_bluesky', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read Bluesky posts. List recent posts from your feed, get a post thread, or view your profile. Requires Bluesky app password to be configured.',
+			'parameters'  => array(
+				'action'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action: "list" (author feed), "get" (post thread), "profile" (user profile). Defaults to "list".',
+					'enum'        => array( 'list', 'get', 'profile' ),
+				),
+				'post_uri' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'AT Protocol post URI (at://did:plc:.../app.bsky.feed.post/...). Required for "get" action.',
+				),
+				'limit'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of posts to return (max 100). Defaults to 25.',
+				),
+				'cursor'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination cursor for next page.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_bluesky';
+		$action    = $parameters['action'] ?? 'list';
+
+		if ( 'get' === $action && empty( $parameters['post_uri'] ) ) {
+			return $this->buildErrorResponse( 'post_uri is required for the get action', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'bluesky' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Bluesky auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'bluesky', 'status' => 'not_registered' ),
+				array( 'action' => 'configure_bluesky_auth', 'message' => 'Configure Bluesky app password in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Bluesky is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'bluesky', 'status' => 'not_authenticated' ),
+				array( 'action' => 'authenticate_bluesky', 'message' => 'Configure Bluesky handle and app password in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility();
+		$input            = array( 'action' => sanitize_text_field( $action ) );
+
+		if ( ! empty( $parameters['post_uri'] ) ) {
+			$input['post_uri'] = sanitize_text_field( $parameters['post_uri'] );
+		}
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+		if ( ! empty( $parameters['cursor'] ) ) {
+			$input['cursor'] = sanitize_text_field( $parameters['cursor'] );
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse( $this->getAbilityError( $result, 'Failed to read from Bluesky' ), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result['data'] ?? array(),
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/inc/Chat/Tools/ReadFacebook.php
+++ b/inc/Chat/Tools/ReadFacebook.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Read Facebook Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadFacebook extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_facebook', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read Facebook Page posts. List recent posts, get details for a specific post, or get comments. Requires Facebook OAuth to be configured.',
+			'parameters'  => array(
+				'action'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action: "list" (recent posts), "get" (single post), "comments" (post comments). Defaults to "list".',
+					'enum'        => array( 'list', 'get', 'comments' ),
+				),
+				'post_id' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Facebook post ID. Required for "get" and "comments" actions.',
+				),
+				'limit'   => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of items to return (max 100). Defaults to 25.',
+				),
+				'after'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination cursor for next page.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_facebook';
+		$action    = $parameters['action'] ?? 'list';
+
+		if ( in_array( $action, array( 'get', 'comments' ), true ) && empty( $parameters['post_id'] ) ) {
+			return $this->buildErrorResponse( "post_id is required for the {$action} action", $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'facebook' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Facebook auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'facebook', 'status' => 'not_registered' ),
+				array( 'action' => 'configure_facebook_auth', 'message' => 'Configure Facebook OAuth in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Facebook is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'facebook', 'status' => 'not_authenticated' ),
+				array( 'action' => 'authenticate_facebook', 'message' => 'Connect Facebook via Data Machine Settings > Auth > Facebook.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Facebook\FacebookReadAbility();
+		$input            = array( 'action' => sanitize_text_field( $action ) );
+
+		if ( ! empty( $parameters['post_id'] ) ) {
+			$input['post_id'] = sanitize_text_field( $parameters['post_id'] );
+		}
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+		if ( ! empty( $parameters['after'] ) ) {
+			$input['after'] = sanitize_text_field( $parameters['after'] );
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse( $this->getAbilityError( $result, 'Failed to read from Facebook' ), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result['data'] ?? array(),
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/inc/Chat/Tools/ReadPinterest.php
+++ b/inc/Chat/Tools/ReadPinterest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Read Pinterest Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadPinterest extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_pinterest', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read Pinterest pins and boards. List pins, get pin details, list boards, or list board pins. Requires Pinterest access token to be configured.',
+			'parameters'  => array(
+				'action'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action: "pins" (user pins), "pin" (single pin), "boards" (list boards), "board_pins" (board pins). Defaults to "pins".',
+					'enum'        => array( 'pins', 'pin', 'boards', 'board_pins' ),
+				),
+				'pin_id'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pinterest pin ID. Required for "pin" action.',
+				),
+				'board_id' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pinterest board ID. Required for "board_pins" action.',
+				),
+				'limit'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of items to return (max 100). Defaults to 25.',
+				),
+				'bookmark' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination bookmark for next page.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_pinterest';
+		$action    = $parameters['action'] ?? 'pins';
+
+		if ( 'pin' === $action && empty( $parameters['pin_id'] ) ) {
+			return $this->buildErrorResponse( 'pin_id is required for the pin action', $tool_name );
+		}
+		if ( 'board_pins' === $action && empty( $parameters['board_id'] ) ) {
+			return $this->buildErrorResponse( 'board_id is required for the board_pins action', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'pinterest' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Pinterest auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'pinterest', 'status' => 'not_registered' ),
+				array( 'action' => 'configure_pinterest_auth', 'message' => 'Configure Pinterest access token in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Pinterest is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'pinterest', 'status' => 'not_authenticated' ),
+				array( 'action' => 'authenticate_pinterest', 'message' => 'Set Pinterest access token in Data Machine Settings > Auth > Pinterest.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility();
+		$input            = array( 'action' => sanitize_text_field( $action ) );
+
+		if ( ! empty( $parameters['pin_id'] ) ) {
+			$input['pin_id'] = sanitize_text_field( $parameters['pin_id'] );
+		}
+		if ( ! empty( $parameters['board_id'] ) ) {
+			$input['board_id'] = sanitize_text_field( $parameters['board_id'] );
+		}
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+		if ( ! empty( $parameters['bookmark'] ) ) {
+			$input['bookmark'] = sanitize_text_field( $parameters['bookmark'] );
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse( $this->getAbilityError( $result, 'Failed to read from Pinterest' ), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result['data'] ?? array(),
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/inc/Chat/Tools/ReadThreads.php
+++ b/inc/Chat/Tools/ReadThreads.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Read Threads Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadThreads extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_threads', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read Threads posts. List recent threads, get details for a specific thread, or get replies. Requires Threads OAuth to be configured.',
+			'parameters'  => array(
+				'action'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action: "list" (recent threads), "get" (single thread), "replies" (thread replies). Defaults to "list".',
+					'enum'        => array( 'list', 'get', 'replies' ),
+				),
+				'thread_id' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Threads media ID. Required for "get" and "replies" actions.',
+				),
+				'limit'     => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of items to return (max 100). Defaults to 25.',
+				),
+				'after'     => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination cursor for next page.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_threads';
+		$action    = $parameters['action'] ?? 'list';
+
+		if ( in_array( $action, array( 'get', 'replies' ), true ) && empty( $parameters['thread_id'] ) ) {
+			return $this->buildErrorResponse( "thread_id is required for the {$action} action", $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'threads' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Threads auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'threads', 'status' => 'not_registered' ),
+				array( 'action' => 'configure_threads_auth', 'message' => 'Configure Threads OAuth in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Threads is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'threads', 'status' => 'not_authenticated' ),
+				array( 'action' => 'authenticate_threads', 'message' => 'Connect Threads via Data Machine Settings > Auth > Threads.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Threads\ThreadsReadAbility();
+		$input            = array( 'action' => sanitize_text_field( $action ) );
+
+		if ( ! empty( $parameters['thread_id'] ) ) {
+			$input['thread_id'] = sanitize_text_field( $parameters['thread_id'] );
+		}
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+		if ( ! empty( $parameters['after'] ) ) {
+			$input['after'] = sanitize_text_field( $parameters['after'] );
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse( $this->getAbilityError( $result, 'Failed to read from Threads' ), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result['data'] ?? array(),
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/inc/Chat/Tools/ReadTwitter.php
+++ b/inc/Chat/Tools/ReadTwitter.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Read Twitter Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadTwitter extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'read_twitter', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Read tweets from Twitter/X. List recent tweets, get a specific tweet, or view mentions. Requires Twitter OAuth to be configured.',
+			'parameters'  => array(
+				'action'           => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Action: "list" (user timeline), "get" (single tweet), "mentions" (user mentions). Defaults to "list".',
+					'enum'        => array( 'list', 'get', 'mentions' ),
+				),
+				'tweet_id'         => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Tweet ID. Required for "get" action.',
+				),
+				'limit'            => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Number of tweets to return (min 5, max 100). Defaults to 25.',
+				),
+				'pagination_token' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pagination token for next page.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'read_twitter';
+		$action    = $parameters['action'] ?? 'list';
+
+		if ( 'get' === $action && empty( $parameters['tweet_id'] ) ) {
+			return $this->buildErrorResponse( 'tweet_id is required for the get action', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'twitter' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Twitter auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'twitter', 'status' => 'not_registered' ),
+				array( 'action' => 'configure_twitter_auth', 'message' => 'Configure Twitter OAuth in Data Machine Settings > Auth.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Twitter is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'twitter', 'status' => 'not_authenticated' ),
+				array( 'action' => 'authenticate_twitter', 'message' => 'Connect Twitter via Data Machine Settings > Auth > Twitter.', 'tool_hint' => 'authenticate_handler' )
+			);
+		}
+
+		$ability_instance = new \DataMachineSocials\Abilities\Twitter\TwitterReadAbility();
+		$input            = array( 'action' => sanitize_text_field( $action ) );
+
+		if ( ! empty( $parameters['tweet_id'] ) ) {
+			$input['tweet_id'] = sanitize_text_field( $parameters['tweet_id'] );
+		}
+		if ( ! empty( $parameters['limit'] ) ) {
+			$input['limit'] = absint( $parameters['limit'] );
+		}
+		if ( ! empty( $parameters['pagination_token'] ) ) {
+			$input['pagination_token'] = sanitize_text_field( $parameters['pagination_token'] );
+		}
+
+		$result = $ability_instance->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse( $this->getAbilityError( $result, 'Failed to read from Twitter' ), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result['data'] ?? array(),
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/inc/Cli/Commands/BlueskyCommand.php
+++ b/inc/Cli/Commands/BlueskyCommand.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * WP-CLI Bluesky Command
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Bluesky integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     wp datamachine-socials bluesky posts
+ *     wp datamachine-socials bluesky thread at://did:plc:abc/app.bsky.feed.post/xyz
+ *     wp datamachine-socials bluesky profile
+ *     wp datamachine-socials bluesky status
+ */
+class BlueskyCommand {
+
+	/**
+	 * List recent Bluesky posts from your feed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--cursor=<cursor>]
+	 * : Pagination cursor for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function posts( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'list',
+			'limit'  => absint( $assoc_args['limit'] ?? 25 ),
+			'cursor' => $assoc_args['cursor'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$posts  = $data['posts'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $posts ) ) {
+			WP_CLI::warning( 'No posts found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} posts" );
+		WP_CLI::log( '' );
+
+		foreach ( $posts as $feed_item ) {
+			$post   = $feed_item['post'] ?? $feed_item;
+			$record = $post['record'] ?? array();
+			$text   = mb_substr( $record['text'] ?? '(no text)', 0, 60 );
+			if ( mb_strlen( $record['text'] ?? '' ) > 60 ) {
+				$text .= '...';
+			}
+			$likes   = $post['likeCount'] ?? 0;
+			$reposts = $post['repostCount'] ?? 0;
+			$date    = isset( $record['createdAt'] ) ? wp_date( 'Y-m-d', strtotime( $record['createdAt'] ) ) : '';
+			$uri     = $post['uri'] ?? '';
+
+			WP_CLI::log( sprintf( '  %s  %d likes  %d reposts  %s', $date, $likes, $reposts, $text ) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['cursor'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --cursor={$data['cursor']}" );
+		}
+	}
+
+	/**
+	 * Get a post thread.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_uri>
+	 * : The AT Protocol post URI (at://did:plc:.../app.bsky.feed.post/...).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function thread( $args, $assoc_args ) {
+		$post_uri = $args[0];
+		$ability  = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'get',
+			'post_uri' => $post_uri,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'json';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$post   = $data['post'] ?? $data;
+		$record = $post['record'] ?? array();
+
+		WP_CLI::success( 'Post thread' );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'URI:       ' . ( $post['uri'] ?? $post_uri ) );
+		WP_CLI::log( 'Author:    ' . ( $post['author']['handle'] ?? 'unknown' ) );
+		WP_CLI::log( 'Date:      ' . ( $record['createdAt'] ?? '' ) );
+		WP_CLI::log( 'Likes:     ' . ( $post['likeCount'] ?? 0 ) );
+		WP_CLI::log( 'Reposts:   ' . ( $post['repostCount'] ?? 0 ) );
+		WP_CLI::log( 'Replies:   ' . ( $post['replyCount'] ?? 0 ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Text:' );
+		WP_CLI::log( $record['text'] ?? '(no text)' );
+	}
+
+	/**
+	 * Show your Bluesky profile.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function profile( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array( 'action' => 'profile' ) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( 'Bluesky Profile' );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Handle:      ' . ( $data['handle'] ?? '' ) );
+		WP_CLI::log( 'Display:     ' . ( $data['displayName'] ?? '' ) );
+		WP_CLI::log( 'DID:         ' . ( $data['did'] ?? '' ) );
+		WP_CLI::log( 'Followers:   ' . ( $data['followersCount'] ?? 0 ) );
+		WP_CLI::log( 'Following:   ' . ( $data['followsCount'] ?? 0 ) );
+		WP_CLI::log( 'Posts:       ' . ( $data['postsCount'] ?? 0 ) );
+
+		if ( ! empty( $data['description'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Bio:' );
+			WP_CLI::log( $data['description'] );
+		}
+	}
+
+	/**
+	 * Show Bluesky authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials bluesky status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'bluesky' );
+
+		WP_CLI::log( 'Bluesky Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		$details = $provider->get_account_details();
+		if ( $details ) {
+			if ( ! empty( $details['username'] ) ) {
+				WP_CLI::log( 'Handle:        ' . $details['username'] );
+			}
+		}
+
+		WP_CLI::log( 'Auth type:     App Password (session-based, no stored tokens)' );
+	}
+
+	private function get_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/bluesky-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/bluesky-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility();
+	}
+}

--- a/inc/Cli/Commands/FacebookCommand.php
+++ b/inc/Cli/Commands/FacebookCommand.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * WP-CLI Facebook Command
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Facebook integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     wp datamachine-socials facebook posts
+ *     wp datamachine-socials facebook post 123456789
+ *     wp datamachine-socials facebook comments 123456789
+ *     wp datamachine-socials facebook status
+ */
+class FacebookCommand {
+
+	/**
+	 * List recent Facebook Page posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--after=<cursor>]
+	 * : Pagination cursor for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function posts( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'list',
+			'limit'  => absint( $assoc_args['limit'] ?? 25 ),
+			'after'  => $assoc_args['after'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$posts  = $data['posts'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $posts ) ) {
+			WP_CLI::warning( 'No posts found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} posts" );
+		WP_CLI::log( '' );
+
+		foreach ( $posts as $item ) {
+			$message = mb_substr( $item['message'] ?? '(no message)', 0, 60 );
+			if ( mb_strlen( $item['message'] ?? '' ) > 60 ) {
+				$message .= '...';
+			}
+			$likes    = $item['likes']['summary']['total_count'] ?? 0;
+			$comments = $item['comments']['summary']['total_count'] ?? 0;
+			$shares   = $item['shares']['count'] ?? 0;
+			$date     = isset( $item['created_time'] ) ? wp_date( 'Y-m-d', strtotime( $item['created_time'] ) ) : '';
+
+			WP_CLI::log( sprintf(
+				'  %s  %s  %d likes  %d comments  %d shares  %s',
+				$item['id'],
+				$date,
+				$likes,
+				$comments,
+				$shares,
+				$message
+			) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['cursors']['after'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --after={$data['cursors']['after']}" );
+		}
+	}
+
+	/**
+	 * Get details for a specific Facebook post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The Facebook post ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function post( $args, $assoc_args ) {
+		$post_id = $args[0];
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'  => 'get',
+			'post_id' => $post_id,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Post {$post_id}" );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'ID:        ' . ( $data['id'] ?? '' ) );
+		WP_CLI::log( 'Date:      ' . ( $data['created_time'] ?? '' ) );
+		WP_CLI::log( 'Likes:     ' . ( $data['likes']['summary']['total_count'] ?? 0 ) );
+		WP_CLI::log( 'Comments:  ' . ( $data['comments']['summary']['total_count'] ?? 0 ) );
+		WP_CLI::log( 'Shares:    ' . ( $data['shares']['count'] ?? 0 ) );
+		WP_CLI::log( 'Permalink: ' . ( $data['permalink_url'] ?? '' ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Message:' );
+		WP_CLI::log( $data['message'] ?? '(no message)' );
+	}
+
+	/**
+	 * Get comments on a Facebook post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The Facebook post ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Number of comments to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function comments( $args, $assoc_args ) {
+		$post_id = $args[0];
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'  => 'comments',
+			'post_id' => $post_id,
+			'limit'   => absint( $assoc_args['limit'] ?? 25 ),
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data     = $result['data'];
+		$comments = $data['comments'] ?? array();
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $comments ) ) {
+			WP_CLI::warning( 'No comments found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} comments" );
+		WP_CLI::log( '' );
+
+		foreach ( $comments as $comment ) {
+			$from = $comment['from']['name'] ?? 'unknown';
+			$text = $comment['message'] ?? '';
+			$date = isset( $comment['created_time'] ) ? wp_date( 'Y-m-d H:i', strtotime( $comment['created_time'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  %-20s %s  %s', $from, $date, $text ) );
+		}
+	}
+
+	/**
+	 * Show Facebook authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials facebook status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'facebook' );
+
+		WP_CLI::log( 'Facebook Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		if ( method_exists( $provider, 'get_page_id' ) ) {
+			$page_id = $provider->get_page_id();
+			if ( $page_id ) {
+				WP_CLI::log( 'Page ID:       ' . $page_id );
+			}
+		}
+
+		$details = $provider->get_account_details();
+		if ( $details ) {
+			if ( ! empty( $details['page_name'] ) ) {
+				WP_CLI::log( 'Page:          ' . $details['page_name'] );
+			}
+			if ( ! empty( $details['user_name'] ) ) {
+				WP_CLI::log( 'User:          ' . $details['user_name'] );
+			}
+		}
+
+		$next_cron = wp_next_scheduled( 'datamachine_refresh_token_facebook' );
+		if ( $next_cron ) {
+			WP_CLI::log( 'Next cron:     ' . wp_date( 'Y-m-d H:i:s', $next_cron ) );
+		}
+	}
+
+	private function get_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/facebook-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/facebook-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Facebook\FacebookReadAbility();
+	}
+}

--- a/inc/Cli/Commands/PinterestCommand.php
+++ b/inc/Cli/Commands/PinterestCommand.php
@@ -105,6 +105,196 @@ class PinterestCommand {
 	}
 
 	/**
+	 * List your recent pins.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of pins to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--bookmark=<bookmark>]
+	 * : Pagination bookmark for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials pinterest pins
+	 *     wp datamachine-socials pinterest pins --limit=10 --format=json
+	 */
+	public function pins( $args, $assoc_args ) {
+		$ability = $this->get_read_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'pins',
+			'limit'    => absint( $assoc_args['limit'] ?? 25 ),
+			'bookmark' => $assoc_args['bookmark'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$pins   = $data['pins'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $pins ) ) {
+			WP_CLI::warning( 'No pins found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} pins" );
+		WP_CLI::log( '' );
+
+		foreach ( $pins as $pin ) {
+			$title = mb_substr( $pin['title'] ?? '(no title)', 0, 50 );
+			$desc  = mb_substr( $pin['description'] ?? '', 0, 40 );
+			$id    = $pin['id'] ?? '';
+
+			WP_CLI::log( sprintf( '  %s  %s  %s', $id, $title, $desc ) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['bookmark'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --bookmark={$data['bookmark']}" );
+		}
+	}
+
+	/**
+	 * Get details for a specific pin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <pin_id>
+	 * : The Pinterest pin ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function pin( $args, $assoc_args ) {
+		$pin_id  = $args[0];
+		$ability = $this->get_read_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'pin',
+			'pin_id' => $pin_id,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		WP_CLI::log( wp_json_encode( $result['data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * List pins from a specific board.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <board_id>
+	 * : The Pinterest board ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Number of pins to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials pinterest board-pins 123456789
+	 *
+	 * @subcommand board-pins
+	 */
+	public function board_pins( $args, $assoc_args ) {
+		$board_id = $args[0];
+		$ability  = $this->get_read_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'board_pins',
+			'board_id' => $board_id,
+			'limit'    => absint( $assoc_args['limit'] ?? 25 ),
+			'bookmark' => $assoc_args['bookmark'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$pins = $data['pins'] ?? array();
+		if ( empty( $pins ) ) {
+			WP_CLI::warning( 'No pins found on this board.' );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} pins" );
+		WP_CLI::log( '' );
+
+		foreach ( $pins as $pin ) {
+			$title = mb_substr( $pin['title'] ?? '(no title)', 0, 50 );
+			WP_CLI::log( sprintf( '  %s  %s', $pin['id'] ?? '', $title ) );
+		}
+	}
+
+	/**
+	 * Get the Pinterest read ability.
+	 *
+	 * @return \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility
+	 */
+	private function get_read_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/pinterest-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/pinterest-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility();
+	}
+
+	/**
 	 * Format items for output.
 	 *
 	 * @param array  $items      Items to format.

--- a/inc/Cli/Commands/ThreadsCommand.php
+++ b/inc/Cli/Commands/ThreadsCommand.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * WP-CLI Threads Command
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Threads integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     wp datamachine-socials threads posts
+ *     wp datamachine-socials threads post 17891234567890
+ *     wp datamachine-socials threads replies 17891234567890
+ *     wp datamachine-socials threads status
+ */
+class ThreadsCommand {
+
+	/**
+	 * List recent Threads posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--after=<cursor>]
+	 * : Pagination cursor for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials threads posts
+	 *     wp datamachine-socials threads posts --limit=10 --format=json
+	 */
+	public function posts( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'list',
+			'limit'  => absint( $assoc_args['limit'] ?? 25 ),
+			'after'  => $assoc_args['after'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data    = $result['data'];
+		$threads = $data['threads'] ?? array();
+		$format  = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $threads ) ) {
+			WP_CLI::warning( 'No threads found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} threads" );
+		WP_CLI::log( '' );
+
+		foreach ( $threads as $item ) {
+			$text = mb_substr( $item['text'] ?? '(no text)', 0, 60 );
+			if ( mb_strlen( $item['text'] ?? '' ) > 60 ) {
+				$text .= '...';
+			}
+			$likes = $item['like_count'] ?? 0;
+			$type  = $item['media_type'] ?? 'TEXT';
+			$date  = isset( $item['timestamp'] ) ? wp_date( 'Y-m-d', strtotime( $item['timestamp'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  %s  %-12s  %s  %d likes  %s', $item['id'], $type, $date, $likes, $text ) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['cursors']['after'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --after={$data['cursors']['after']}" );
+		}
+	}
+
+	/**
+	 * Get details for a specific thread.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <thread_id>
+	 * : The Threads media ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function post( $args, $assoc_args ) {
+		$thread_id = $args[0];
+		$ability   = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'    => 'get',
+			'thread_id' => $thread_id,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Thread {$thread_id}" );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'ID:        ' . ( $data['id'] ?? '' ) );
+		WP_CLI::log( 'Type:      ' . ( $data['media_type'] ?? '' ) );
+		WP_CLI::log( 'Date:      ' . ( $data['timestamp'] ?? '' ) );
+		WP_CLI::log( 'Likes:     ' . ( $data['like_count'] ?? 0 ) );
+		WP_CLI::log( 'Permalink: ' . ( $data['permalink'] ?? '' ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Text:' );
+		WP_CLI::log( $data['text'] ?? '(no text)' );
+	}
+
+	/**
+	 * Get replies on a thread.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <thread_id>
+	 * : The Threads media ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Number of replies to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function replies( $args, $assoc_args ) {
+		$thread_id = $args[0];
+		$ability   = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'    => 'replies',
+			'thread_id' => $thread_id,
+			'limit'     => absint( $assoc_args['limit'] ?? 25 ),
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data    = $result['data'];
+		$replies = $data['replies'] ?? array();
+		$format  = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $replies ) ) {
+			WP_CLI::warning( 'No replies found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} replies" );
+		WP_CLI::log( '' );
+
+		foreach ( $replies as $reply ) {
+			$username = $reply['username'] ?? 'unknown';
+			$text     = $reply['text'] ?? '';
+			$likes    = $reply['like_count'] ?? 0;
+			$date     = isset( $reply['timestamp'] ) ? wp_date( 'Y-m-d H:i', strtotime( $reply['timestamp'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  @%-20s %s  (%d likes)  %s', $username, $date, $likes, $text ) );
+		}
+	}
+
+	/**
+	 * Show Threads authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials threads status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'threads' );
+
+		WP_CLI::log( 'Threads Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		if ( method_exists( $provider, 'get_page_id' ) ) {
+			$page_id = $provider->get_page_id();
+			if ( $page_id ) {
+				WP_CLI::log( 'User ID:       ' . $page_id );
+			}
+		}
+
+		$details = $provider->get_account_details();
+		if ( $details && ! empty( $details['token_expires_at'] ) ) {
+			$expires_at = intval( $details['token_expires_at'] );
+			$remaining  = $expires_at - time();
+
+			if ( $remaining > 0 ) {
+				$days = round( $remaining / DAY_IN_SECONDS );
+				WP_CLI::log( "Token expires: in {$days} days" );
+			} else {
+				WP_CLI::log( 'Token expires: EXPIRED (will auto-refresh)' );
+			}
+		}
+
+		$next_cron = wp_next_scheduled( 'datamachine_refresh_token_threads' );
+		if ( $next_cron ) {
+			WP_CLI::log( 'Next cron:     ' . wp_date( 'Y-m-d H:i:s', $next_cron ) );
+		}
+	}
+
+	private function get_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/threads-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/threads-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Threads\ThreadsReadAbility();
+	}
+}

--- a/inc/Cli/Commands/TwitterCommand.php
+++ b/inc/Cli/Commands/TwitterCommand.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * WP-CLI Twitter Command
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Twitter/X integration for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     wp datamachine-socials twitter tweets
+ *     wp datamachine-socials twitter tweet 1234567890
+ *     wp datamachine-socials twitter mentions
+ *     wp datamachine-socials twitter status
+ */
+class TwitterCommand {
+
+	/**
+	 * List recent tweets from your timeline.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of tweets to return (min 5, max 100).
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--pagination-token=<token>]
+	 * : Pagination token for next page.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function tweets( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'           => 'list',
+			'limit'            => absint( $assoc_args['limit'] ?? 25 ),
+			'pagination_token' => $assoc_args['pagination-token'] ?? '',
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$tweets = $data['tweets'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $tweets ) ) {
+			WP_CLI::warning( 'No tweets found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} tweets" );
+		WP_CLI::log( '' );
+
+		foreach ( $tweets as $tweet ) {
+			$text = mb_substr( $tweet['text'] ?? '', 0, 60 );
+			if ( mb_strlen( $tweet['text'] ?? '' ) > 60 ) {
+				$text .= '...';
+			}
+			$metrics = $tweet['public_metrics'] ?? array();
+			$likes   = $metrics['like_count'] ?? 0;
+			$rts     = $metrics['retweet_count'] ?? 0;
+			$date    = isset( $tweet['created_at'] ) ? wp_date( 'Y-m-d', strtotime( $tweet['created_at'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  %s  %s  %d likes  %d RTs  %s', $tweet['id'], $date, $likes, $rts, $text ) );
+		}
+
+		if ( $data['has_next'] && ! empty( $data['next_token'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( "Next page: --pagination-token={$data['next_token']}" );
+		}
+	}
+
+	/**
+	 * Get details for a specific tweet.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <tweet_id>
+	 * : The tweet ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function tweet( $args, $assoc_args ) {
+		$tweet_id = $args[0];
+		$ability  = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action'   => 'get',
+			'tweet_id' => $tweet_id,
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data   = $result['data'];
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$metrics = $data['public_metrics'] ?? array();
+
+		WP_CLI::success( "Tweet {$tweet_id}" );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'ID:         ' . ( $data['id'] ?? '' ) );
+		WP_CLI::log( 'Date:       ' . ( $data['created_at'] ?? '' ) );
+		WP_CLI::log( 'Likes:      ' . ( $metrics['like_count'] ?? 0 ) );
+		WP_CLI::log( 'Retweets:   ' . ( $metrics['retweet_count'] ?? 0 ) );
+		WP_CLI::log( 'Replies:    ' . ( $metrics['reply_count'] ?? 0 ) );
+		WP_CLI::log( 'Impressions:' . ( $metrics['impression_count'] ?? 0 ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Text:' );
+		WP_CLI::log( $data['text'] ?? '' );
+	}
+
+	/**
+	 * List recent mentions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of mentions to return (min 5, max 100).
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function mentions( $args, $assoc_args ) {
+		$ability = $this->get_ability();
+
+		$result = $ability->execute( array(
+			'action' => 'mentions',
+			'limit'  => absint( $assoc_args['limit'] ?? 25 ),
+		) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		$data     = $result['data'];
+		$mentions = $data['mentions'] ?? array();
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $mentions ) ) {
+			WP_CLI::warning( 'No mentions found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( "Found {$data['count']} mentions" );
+		WP_CLI::log( '' );
+
+		foreach ( $mentions as $tweet ) {
+			$text = mb_substr( $tweet['text'] ?? '', 0, 60 );
+			if ( mb_strlen( $tweet['text'] ?? '' ) > 60 ) {
+				$text .= '...';
+			}
+			$date = isset( $tweet['created_at'] ) ? wp_date( 'Y-m-d', strtotime( $tweet['created_at'] ) ) : '';
+
+			WP_CLI::log( sprintf( '  %s  %s  %s', $tweet['id'], $date, $text ) );
+		}
+	}
+
+	/**
+	 * Show Twitter authentication status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials twitter status
+	 */
+	public function status( $args, $assoc_args ) {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'twitter' );
+
+		WP_CLI::log( 'Twitter / X Integration Status' );
+		WP_CLI::log( '---' );
+
+		if ( ! $provider ) {
+			WP_CLI::log( 'Provider:      Not found' );
+			return;
+		}
+
+		$authenticated = $provider->is_authenticated();
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes' : 'No' ) );
+
+		$details = $provider->get_account_details();
+		if ( $details ) {
+			if ( ! empty( $details['screen_name'] ) ) {
+				WP_CLI::log( 'Handle:        @' . $details['screen_name'] );
+			}
+			if ( ! empty( $details['user_id'] ) ) {
+				WP_CLI::log( 'User ID:       ' . $details['user_id'] );
+			}
+		}
+
+		WP_CLI::log( 'Auth type:     OAuth 1.0a (tokens do not expire)' );
+	}
+
+	private function get_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/twitter-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/twitter-read ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Twitter\TwitterReadAbility();
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -113,37 +113,114 @@ class RestApi {
 			)
 		);
 
-		// Instagram: list media or get single post
-		register_rest_route(
-			self::NAMESPACE,
-			'/instagram/media',
-			array(
-				'methods'             => 'GET',
-				'callback'            => array( __CLASS__, 'instagram_read' ),
-				'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
-				'args'                => array(
-					'action'   => array(
-						'type'              => 'string',
-						'default'           => 'list',
-						'enum'              => array( 'list', 'get', 'comments' ),
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'media_id' => array(
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'limit'    => array(
-						'type'              => 'integer',
-						'default'           => 25,
-						'sanitize_callback' => 'absint',
-					),
-					'after'    => array(
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-			)
+		// =====================================================================
+		// Platform Read Endpoints
+		// =====================================================================
+
+		register_rest_route( self::NAMESPACE, '/instagram/media', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => self::read_endpoint_args( array( 'list', 'get', 'comments' ), 'media_id' ),
+		) );
+
+		register_rest_route( self::NAMESPACE, '/threads/posts', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => self::read_endpoint_args( array( 'list', 'get', 'replies' ), 'thread_id' ),
+		) );
+
+		register_rest_route( self::NAMESPACE, '/facebook/posts', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => self::read_endpoint_args( array( 'list', 'get', 'comments' ), 'post_id' ),
+		) );
+
+		register_rest_route( self::NAMESPACE, '/twitter/tweets', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => array(
+				'action'           => array( 'type' => 'string', 'default' => 'list', 'enum' => array( 'list', 'get', 'mentions' ), 'sanitize_callback' => 'sanitize_text_field' ),
+				'tweet_id'         => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+				'limit'            => array( 'type' => 'integer', 'default' => 25, 'sanitize_callback' => 'absint' ),
+				'pagination_token' => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+			),
+		) );
+
+		register_rest_route( self::NAMESPACE, '/bluesky/posts', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => array(
+				'action'   => array( 'type' => 'string', 'default' => 'list', 'enum' => array( 'list', 'get', 'profile' ), 'sanitize_callback' => 'sanitize_text_field' ),
+				'post_uri' => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+				'limit'    => array( 'type' => 'integer', 'default' => 25, 'sanitize_callback' => 'absint' ),
+				'cursor'   => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+			),
+		) );
+
+		register_rest_route( self::NAMESPACE, '/pinterest/read', array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'platform_read' ),
+			'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			'args'                => array(
+				'action'   => array( 'type' => 'string', 'default' => 'pins', 'enum' => array( 'pins', 'pin', 'boards', 'board_pins' ), 'sanitize_callback' => 'sanitize_text_field' ),
+				'pin_id'   => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+				'board_id' => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+				'limit'    => array( 'type' => 'integer', 'default' => 25, 'sanitize_callback' => 'absint' ),
+				'bookmark' => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+			),
+		) );
+	}
+
+	/**
+	 * Standard args for read endpoints with cursor-based pagination.
+	 */
+	private static function read_endpoint_args( array $actions, string $id_param ): array {
+		return array(
+			'action'  => array( 'type' => 'string', 'default' => $actions[0], 'enum' => $actions, 'sanitize_callback' => 'sanitize_text_field' ),
+			$id_param => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
+			'limit'   => array( 'type' => 'integer', 'default' => 25, 'sanitize_callback' => 'absint' ),
+			'after'   => array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ),
 		);
+	}
+
+	/**
+	 * Generic platform read handler — routes to the correct ability by URL.
+	 */
+	public static function platform_read( \WP_REST_Request $request ) {
+		$route = $request->get_route();
+		$params = $request->get_params();
+
+		$ability_map = array(
+			'instagram' => \DataMachineSocials\Abilities\Instagram\InstagramReadAbility::class,
+			'threads'   => \DataMachineSocials\Abilities\Threads\ThreadsReadAbility::class,
+			'facebook'  => \DataMachineSocials\Abilities\Facebook\FacebookReadAbility::class,
+			'twitter'   => \DataMachineSocials\Abilities\Twitter\TwitterReadAbility::class,
+			'bluesky'   => \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility::class,
+			'pinterest' => \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility::class,
+		);
+
+		$platform = null;
+		foreach ( $ability_map as $key => $class ) {
+			if ( strpos( $route, "/{$key}/" ) !== false ) {
+				$platform = $key;
+				break;
+			}
+		}
+
+		if ( ! $platform || ! isset( $ability_map[ $platform ] ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'error' => 'Unknown platform' ), 400 );
+		}
+
+		$ability = new $ability_map[ $platform ]();
+		$input   = array_filter( $params, function ( $v ) { return '' !== $v && null !== $v; } );
+		$result  = $ability->execute( $input );
+
+		return new \WP_REST_Response( $result, $result['success'] ? 200 : 500 );
 	}
 
 	/**
@@ -444,54 +521,6 @@ class RestApi {
 		$url = $upload_dir['baseurl'] . '/dms-temp/' . $filename;
 
 		return new \WP_REST_Response( array( 'url' => $url ) );
-	}
-
-	/**
-	 * Instagram read: list media, get single post, or get comments.
-	 *
-	 * Delegates to the datamachine/instagram-read ability.
-	 */
-	public static function instagram_read( \WP_REST_Request $request ) {
-		$action   = $request->get_param( 'action' ) ?? 'list';
-		$media_id = $request->get_param( 'media_id' );
-
-		// Validate action-specific requirements.
-		if ( in_array( $action, array( 'get', 'comments' ), true ) && empty( $media_id ) ) {
-			return new \WP_REST_Response(
-				array(
-					'success' => false,
-					'error'   => "media_id is required for the {$action} action",
-				),
-				400
-			);
-		}
-
-		$ability_instance = new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
-		$input            = array(
-			'action' => $action,
-		);
-
-		if ( ! empty( $media_id ) ) {
-			$input['media_id'] = $media_id;
-		}
-
-		$limit = $request->get_param( 'limit' );
-		if ( $limit ) {
-			$input['limit'] = absint( $limit );
-		}
-
-		$after = $request->get_param( 'after' );
-		if ( $after ) {
-			$input['after'] = $after;
-		}
-
-		$result = $ability_instance->execute( $input );
-
-		if ( ! $result['success'] ) {
-			return new \WP_REST_Response( $result, 500 );
-		}
-
-		return new \WP_REST_Response( $result );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds complete read (fetch) operations for all remaining social platforms:

- **Threads** — list posts, get single post, replies
- **Facebook** — list posts, get single post, comments (uses page_access_token)
- **Twitter** — list tweets, get single tweet, mentions (uses TwitterOAuth v2)
- **Bluesky** — list posts, get thread, profile (session-based AT Protocol)
- **Pinterest** — list pins, get pin, boards, board pins (static bearer token)

## Changes

### New Abilities (5)
- `ThreadsReadAbility`
- `FacebookReadAbility`
- `TwitterReadAbility`
- `BlueskyReadAbility`
- `PinterestReadAbility`

### New CLI Commands (5)
- `ThreadsCommand` — posts, post, replies, status
- `FacebookCommand` — posts, post, comments, status
- `TwitterCommand` — tweets, tweet, mentions, status
- `BlueskyCommand` — posts, thread, profile, status
- `PinterestCommand` — extended with pins, pin, board-pins

### New Chat Tools (5)
- `ReadThreads`
- `ReadFacebook`
- `ReadTwitter`
- `ReadBluesky`
- `ReadPinterest`

### REST API
- Generic `platform_read()` handler now routes all 6 platforms (Instagram + 5 new)

### Tests
- InstagramReadAbilityTest (20 tests) — merged in PR #25
- **Note**: Tests for the 5 new abilities to be added in follow-up

## Verification

All tests pass: `homeboy test data-machine-socials`