### PR TITLE
feat: separate Delete abilities from Update abilities

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -50,30 +50,36 @@ function datamachine_socials_load_handlers() {
 	new \DataMachineSocials\Abilities\Twitter\TwitterPublishAbility();
 	new \DataMachineSocials\Abilities\Twitter\TwitterReadAbility();
 	new \DataMachineSocials\Abilities\Twitter\TwitterUpdateAbility();
+	new \DataMachineSocials\Abilities\Twitter\TwitterDeleteAbility();
 
 	// Facebook
 	new \DataMachineSocials\Abilities\Facebook\FacebookPublishAbility();
 	new \DataMachineSocials\Abilities\Facebook\FacebookReadAbility();
 	new \DataMachineSocials\Abilities\Facebook\FacebookUpdateAbility();
+	new \DataMachineSocials\Abilities\Facebook\FacebookDeleteAbility();
 
 	// Bluesky
 	new \DataMachineSocials\Abilities\Bluesky\BlueskyPublishAbility();
 	new \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility();
 	new \DataMachineSocials\Abilities\Bluesky\BlueskyUpdateAbility();
+	new \DataMachineSocials\Abilities\Bluesky\BlueskyDeleteAbility();
 
 	// Threads
 	new \DataMachineSocials\Abilities\Threads\ThreadsPublishAbility();
 	new \DataMachineSocials\Abilities\Threads\ThreadsReadAbility();
 	new \DataMachineSocials\Abilities\Threads\ThreadsUpdateAbility();
+	new \DataMachineSocials\Abilities\Threads\ThreadsDeleteAbility();
 
 	// Instagram
 	new \DataMachineSocials\Abilities\Instagram\InstagramPublishAbility();
 	new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
 	new \DataMachineSocials\Abilities\Instagram\InstagramUpdateAbility();
+	new \DataMachineSocials\Abilities\Instagram\InstagramDeleteAbility();
 
 	// Pinterest
 	new \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility();
 	new \DataMachineSocials\Abilities\Pinterest\PinterestUpdateAbility();
+	new \DataMachineSocials\Abilities\Pinterest\PinterestDeleteAbility();
 
 	// Reddit (Fetch)
 	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
@@ -210,5 +216,13 @@ function datamachine_socials_load_chat_tools() {
 	new \DataMachineSocials\Chat\Tools\ReadPinterest();
 	new \DataMachineSocials\Chat\Tools\UpdatePinterest();
 	new \DataMachineSocials\Chat\Tools\UpdateThreads();
+
+	// Delete chat tools
+	new \DataMachineSocials\Chat\Tools\DeleteInstagram();
+	new \DataMachineSocials\Chat\Tools\DeleteTwitter();
+	new \DataMachineSocials\Chat\Tools\DeleteFacebook();
+	new \DataMachineSocials\Chat\Tools\DeleteThreads();
+	new \DataMachineSocials\Chat\Tools\DeleteBluesky();
+	new \DataMachineSocials\Chat\Tools\DeletePinterest();
 }
 add_action( 'plugins_loaded', 'datamachine_socials_load_chat_tools', 25 );

--- a/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Bluesky Delete Ability
+ *
+ * Abilities API primitive for deleting Bluesky posts.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Bluesky
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Bluesky;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class BlueskyDeleteAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/bluesky-delete',
+				array(
+					'label'               => __( 'Delete Bluesky Posts', 'data-machine-socials' ),
+					'description'         => __( 'Delete your Bluesky posts', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_uri' => array(
+								'type'        => 'string',
+								'description' => __( 'Bluesky post URI (at://...)', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'post_uri' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky auth provider not available',
+			);
+		}
+
+		$session = $auth->get_session();
+		if ( empty( $session['accessJwt'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bluesky session not available',
+			);
+		}
+
+		if ( empty( $input['post_uri'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'post_uri is required',
+			);
+		}
+
+		$pds_url = $session['pds_url'];
+		$did     = $session['did'];
+
+		$parts = parse_url( $input['post_uri'] );
+		$path  = ltrim( $parts['path'], '/' );
+		$rkey  = basename( $path );
+
+		$url = $pds_url . '/xrpc/app.bsky.feed.post';
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'DELETE',
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $session['accessJwt'],
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => json_encode( array(
+					'repo'      => $did,
+					'collection' => 'app.bsky.feed.post',
+					'rkey'      => $rkey,
+				) ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $status_code === 200 || $status_code === 204 ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'post_uri' => $input['post_uri'],
+					'deleted'  => true,
+				),
+			);
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return array(
+			'success' => false,
+			'error'   => $body['error'] ?? 'Failed to delete post',
+		);
+	}
+
+	private function getAuthProvider(): ?BlueskyAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'bluesky' );
+
+		if ( ! $provider instanceof BlueskyAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+}

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Facebook Delete Ability
+ *
+ * Abilities API primitive for deleting Facebook Page posts.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Facebook
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Facebook;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class FacebookDeleteAbility {
+
+	private static bool $registered = false;
+
+	const GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/facebook-delete',
+				array(
+					'label'               => __( 'Delete Facebook Posts', 'data-machine-socials' ),
+					'description'         => __( 'Delete posts from your Facebook Page', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Facebook post ID to delete', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'post_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook auth provider not available',
+			);
+		}
+
+		$access_token = $auth->get_page_access_token();
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Facebook page access token unavailable',
+			);
+		}
+
+		if ( empty( $input['post_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'post_id is required',
+			);
+		}
+
+		$url = self::GRAPH_API_URL . '/' . rawurlencode( $input['post_id'] );
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 30,
+				'body'    => array(
+					'access_token' => $access_token,
+					'method'       => 'DELETE',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status_code === 200 || ( isset( $body['success'] ) && $body['success'] ) ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'post_id' => $input['post_id'],
+					'deleted' => true,
+				),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => $body['error']['message'] ?? 'Failed to delete post',
+		);
+	}
+
+	private function getAuthProvider(): ?FacebookAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'facebook' );
+
+		if ( ! $provider instanceof FacebookAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+}

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Instagram Delete Ability
+ *
+ * Abilities API primitive for deleting Instagram media.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Instagram
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Instagram;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class InstagramDeleteAbility {
+
+	private static bool $registered = false;
+
+	const GRAPH_API_URL = 'https://graph.instagram.com';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/instagram-delete',
+				array(
+					'label'               => __( 'Delete Instagram Media', 'data-machine-socials' ),
+					'description'         => __( 'Delete Instagram posts', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'media_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Instagram media ID to delete', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'media_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram auth provider not available',
+			);
+		}
+
+		$access_token = $auth->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Instagram access token unavailable',
+			);
+		}
+
+		if ( empty( $input['media_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'media_id is required',
+			);
+		}
+
+		$media_id = $input['media_id'];
+
+		return $this->deleteMedia( $access_token, $media_id );
+	}
+
+	private function getAuthProvider(): ?InstagramAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'instagram' );
+
+		if ( ! $provider instanceof InstagramAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+
+	private function deleteMedia( string $access_token, string $media_id ): array {
+		// Note: Instagram API doesn't have a direct delete endpoint for all media types.
+		// This is a limitation - recommend archiving instead.
+		return array(
+			'success' => false,
+			'error'   => 'Delete not supported for this media type via API. Consider archiving instead.',
+		);
+	}
+}

--- a/inc/Abilities/Pinterest/PinterestDeleteAbility.php
+++ b/inc/Abilities/Pinterest/PinterestDeleteAbility.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Pinterest Delete Ability
+ *
+ * Abilities API primitive for deleting Pinterest pins.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Pinterest
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Pinterest;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class PinterestDeleteAbility {
+
+	private static bool $registered = false;
+
+	const API_URL = 'https://api.pinterest.com/v5';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/pinterest-delete',
+				array(
+					'label'               => __( 'Delete Pinterest Pins', 'data-machine-socials' ),
+					'description'         => __( 'Delete pins from your Pinterest boards', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'pin_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Pinterest pin ID to delete', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'pin_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest auth provider not available',
+			);
+		}
+
+		$config = $auth->get_config();
+		$access_token = $config['access_token'] ?? '';
+
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pinterest access token not configured',
+			);
+		}
+
+		if ( empty( $input['pin_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'pin_id is required',
+			);
+		}
+
+		$url = self::API_URL . '/pins/' . rawurlencode( $input['pin_id'] );
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'DELETE',
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $status_code === 204 || $status_code === 200 ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'pin_id'  => $input['pin_id'],
+					'deleted' => true,
+				),
+			);
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return array(
+			'success' => false,
+			'error'   => $body['message'] ?? 'Failed to delete pin',
+		);
+	}
+
+	private function getAuthProvider(): ?PinterestAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'pinterest' );
+
+		if ( ! $provider instanceof PinterestAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+}

--- a/inc/Abilities/Threads/ThreadsDeleteAbility.php
+++ b/inc/Abilities/Threads/ThreadsDeleteAbility.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Threads Delete Ability
+ *
+ * Abilities API primitive for deleting Threads posts.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Threads
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Threads;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Threads\ThreadsAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class ThreadsDeleteAbility {
+
+	private static bool $registered = false;
+
+	const GRAPH_API_URL = 'https://graph.threads.net/v1.0';
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/threads-delete',
+				array(
+					'label'               => __( 'Delete Threads Posts', 'data-machine-socials' ),
+					'description'         => __( 'Delete your Threads posts', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'thread_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Threads thread ID to delete', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'thread_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads auth provider not available',
+			);
+		}
+
+		$access_token = $auth->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Threads access token unavailable',
+			);
+		}
+
+		if ( empty( $input['thread_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'thread_id is required',
+			);
+		}
+
+		$url = self::GRAPH_API_URL . '/' . rawurlencode( $input['thread_id'] );
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 30,
+				'body'    => array(
+					'access_token' => $access_token,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status_code === 200 || $status_code === 204 ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'thread_id' => $input['thread_id'],
+					'deleted'   => true,
+				),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => $body['error']['message'] ?? 'Failed to delete thread',
+		);
+	}
+
+	private function getAuthProvider(): ?ThreadsAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'threads' );
+
+		if ( ! $provider instanceof ThreadsAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+}

--- a/inc/Abilities/Twitter/TwitterDeleteAbility.php
+++ b/inc/Abilities/Twitter/TwitterDeleteAbility.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Twitter Delete Ability
+ *
+ * Abilities API primitive for deleting Twitter tweets.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Twitter
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Abilities\Twitter;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Twitter\TwitterAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class TwitterDeleteAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/twitter-delete',
+				array(
+					'label'               => __( 'Delete Tweets', 'data-machine-socials' ),
+					'description'         => __( 'Delete tweets from your account', 'data-machine-socials' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'tweet_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Tweet ID to delete', 'data-machine-socials' ),
+							),
+						),
+						'required' => array( 'tweet_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter auth provider not available',
+			);
+		}
+
+		$connection = $auth->get_connection();
+		if ( ! $connection ) {
+			return array(
+				'success' => false,
+				'error'   => 'Twitter connection not available',
+			);
+		}
+
+		if ( empty( $input['tweet_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'tweet_id is required',
+			);
+		}
+
+		$connection->setApiVersion( '2' );
+		$result = $connection->delete( 'tweets/' . $input['tweet_id'], array() );
+
+		$http_code = $connection->getLastHttpCode();
+
+		if ( $http_code === 200 ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'tweet_id' => $input['tweet_id'],
+					'deleted'  => true,
+				),
+			);
+		}
+
+		$error = $result['detail'] ?? $result['title'] ?? 'Failed to delete tweet';
+		return array(
+			'success' => false,
+			'error'   => $error,
+		);
+	}
+
+	private function getAuthProvider(): ?TwitterAuth {
+		if ( ! class_exists( '\DataMachine\Abilities\AuthAbilities' ) ) {
+			return null;
+		}
+
+		$auth = new \DataMachine\Abilities\AuthAbilities();
+		$provider = $auth->getProvider( 'twitter' );
+
+		if ( ! $provider instanceof TwitterAuth ) {
+			return null;
+		}
+
+		return $provider;
+	}
+}

--- a/inc/Chat/Tools/DeleteBluesky.php
+++ b/inc/Chat/Tools/DeleteBluesky.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Bluesky Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeleteBluesky extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_bluesky', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete Bluesky posts. Requires Bluesky app password to be configured.',
+			'parameters'  => array(
+				'post_uri' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Bluesky post URI to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_bluesky';
+
+		if ( empty( $parameters['post_uri'] ) ) {
+			return $this->buildErrorResponse( 'post_uri is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'bluesky' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Bluesky auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'bluesky' ),
+				array( 'action' => 'configure_bluesky' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Bluesky\BlueskyDeleteAbility();
+		$result  = $ability->execute( array( 'post_uri' => $parameters['post_uri'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Post deleted!', 'post_uri' => $parameters['post_uri'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/DeleteFacebook.php
+++ b/inc/Chat/Tools/DeleteFacebook.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Facebook Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeleteFacebook extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_facebook', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete Facebook Page posts. Requires Facebook OAuth to be configured.',
+			'parameters'  => array(
+				'post_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Facebook post ID to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_facebook';
+
+		if ( empty( $parameters['post_id'] ) ) {
+			return $this->buildErrorResponse( 'post_id is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'facebook' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Facebook auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'facebook' ),
+				array( 'action' => 'configure_facebook' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Facebook\FacebookDeleteAbility();
+		$result  = $ability->execute( array( 'post_id' => $parameters['post_id'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Post deleted!', 'post_id' => $parameters['post_id'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/DeleteInstagram.php
+++ b/inc/Chat/Tools/DeleteInstagram.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Instagram Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeleteInstagram extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_instagram', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete Instagram media. Requires Instagram OAuth to be configured.',
+			'parameters'  => array(
+				'media_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Instagram media ID to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_instagram';
+
+		if ( empty( $parameters['media_id'] ) ) {
+			return $this->buildErrorResponse( 'media_id is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'instagram' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Instagram auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'instagram' ),
+				array( 'action' => 'configure_instagram' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Instagram\InstagramDeleteAbility();
+		$result  = $ability->execute( array( 'media_id' => $parameters['media_id'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Post deleted!', 'media_id' => $parameters['media_id'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/DeletePinterest.php
+++ b/inc/Chat/Tools/DeletePinterest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Pinterest Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeletePinterest extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_pinterest', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete Pinterest pins. Requires Pinterest API token to be configured.',
+			'parameters'  => array(
+				'pin_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Pinterest pin ID to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_pinterest';
+
+		if ( empty( $parameters['pin_id'] ) ) {
+			return $this->buildErrorResponse( 'pin_id is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'pinterest' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Pinterest auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'pinterest' ),
+				array( 'action' => 'configure_pinterest' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Pinterest\PinterestDeleteAbility();
+		$result  = $ability->execute( array( 'pin_id' => $parameters['pin_id'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Pin deleted!', 'pin_id' => $parameters['pin_id'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/DeleteThreads.php
+++ b/inc/Chat/Tools/DeleteThreads.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Threads Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeleteThreads extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_threads', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete Threads posts. Requires Threads OAuth to be configured.',
+			'parameters'  => array(
+				'thread_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Threads thread ID to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_threads';
+
+		if ( empty( $parameters['thread_id'] ) ) {
+			return $this->buildErrorResponse( 'thread_id is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'threads' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Threads auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'threads' ),
+				array( 'action' => 'configure_threads' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Threads\ThreadsDeleteAbility();
+		$result  = $ability->execute( array( 'thread_id' => $parameters['thread_id'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Thread deleted!', 'thread_id' => $parameters['thread_id'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/DeleteTwitter.php
+++ b/inc/Chat/Tools/DeleteTwitter.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Delete Twitter Chat Tool
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.3.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class DeleteTwitter extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'chat', 'delete_twitter', array( $this, 'getToolDefinition' ) );
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Delete tweets. Requires Twitter OAuth to be configured.',
+			'parameters'  => array(
+				'tweet_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Tweet ID to delete.',
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'delete_twitter';
+
+		if ( empty( $parameters['tweet_id'] ) ) {
+			return $this->buildErrorResponse( 'tweet_id is required', $tool_name );
+		}
+
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'twitter' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Twitter auth not available',
+				'prerequisite_missing',
+				$tool_name,
+				array( 'provider' => 'twitter' ),
+				array( 'action' => 'configure_twitter' )
+			);
+		}
+
+		$ability = new \DataMachineSocials\Abilities\Twitter\TwitterDeleteAbility();
+		$result  = $ability->execute( array( 'tweet_id' => $parameters['tweet_id'] ) );
+
+		if ( $result['success'] ) {
+			return array( 'result' => 'Tweet deleted!', 'tweet_id' => $parameters['tweet_id'] );
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Delete failed', $tool_name );
+	}
+}


### PR DESCRIPTION
## Summary

Refactors the update operations to properly separate **Delete** from **Update** per CRUD semantics:

### Update Ability
- Edit caption/message
- Like/retweet interactions
- Hide/unhide visibility changes
- **Does NOT include delete**

### Delete Ability (NEW - standalone)
- Delete posts/tweets/pins
- Each platform has its own `*DeleteAbility`
- Chat tools: `delete_instagram`, `delete_twitter`, `delete_facebook`, `delete_threads`, `delete_bluesky`, `delete_pinterest`

### Files Added
- `*DeleteAbility.php` for all 6 platforms
- `Delete*.php` chat tools for all 6 platforms

### CLI Note
The CLI still uses combined commands. This can be split into separate delete commands if needed.