### PR TITLE
fix: split CLI delete commands to use separate DeleteAbility

### DIFF
--- a/inc/Cli/Commands/BlueskyCommand.php
+++ b/inc/Cli/Commands/BlueskyCommand.php
@@ -259,6 +259,19 @@ class BlueskyCommand {
 		return new \DataMachineSocials\Abilities\Bluesky\BlueskyUpdateAbility();
 	}
 
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/bluesky-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/bluesky-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Bluesky\BlueskyDeleteAbility();
+	}
+
 	/**
 	 * Delete a Bluesky post.
 	 *
@@ -273,10 +286,9 @@ class BlueskyCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$post_uri = $args[0];
-		$ability  = $this->get_update_ability();
+		$ability  = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action'   => 'delete',
 			'post_uri' => $post_uri,
 		) );
 

--- a/inc/Cli/Commands/FacebookCommand.php
+++ b/inc/Cli/Commands/FacebookCommand.php
@@ -291,6 +291,19 @@ class FacebookCommand {
 		return new \DataMachineSocials\Abilities\Facebook\FacebookUpdateAbility();
 	}
 
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/facebook-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/facebook-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Facebook\FacebookDeleteAbility();
+	}
+
 	/**
 	 * Edit a Facebook post message.
 	 *
@@ -371,10 +384,9 @@ class FacebookCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$post_id = $args[0];
-		$ability = $this->get_update_ability();
+		$ability = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action'  => 'delete',
 			'post_id' => $post_id,
 		) );
 

--- a/inc/Cli/Commands/InstagramCommand.php
+++ b/inc/Cli/Commands/InstagramCommand.php
@@ -363,10 +363,9 @@ class InstagramCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$media_id = $args[0];
-		$ability  = $this->get_update_ability();
+		$ability  = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action'   => 'delete',
 			'media_id' => $media_id,
 		) );
 
@@ -441,5 +440,23 @@ class InstagramCommand {
 		}
 
 		return new \DataMachineSocials\Abilities\Instagram\InstagramUpdateAbility();
+	}
+
+	/**
+	 * Get the Instagram delete ability.
+	 *
+	 * @return \DataMachineSocials\Abilities\Instagram\InstagramDeleteAbility
+	 */
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/instagram-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/instagram-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Instagram\InstagramDeleteAbility();
 	}
 }

--- a/inc/Cli/Commands/PinterestCommand.php
+++ b/inc/Cli/Commands/PinterestCommand.php
@@ -307,6 +307,19 @@ class PinterestCommand {
 		return new \DataMachineSocials\Abilities\Pinterest\PinterestUpdateAbility();
 	}
 
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/pinterest-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/pinterest-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Pinterest\PinterestDeleteAbility();
+	}
+
 	/**
 	 * Delete a Pinterest pin.
 	 *
@@ -321,11 +334,10 @@ class PinterestCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$pin_id = $args[0];
-		$ability = $this->get_update_ability();
+		$ability = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action' => 'delete',
-			'pin_id'  => $pin_id,
+			'pin_id' => $pin_id,
 		) );
 
 		if ( ! $result['success'] ) {

--- a/inc/Cli/Commands/ThreadsCommand.php
+++ b/inc/Cli/Commands/ThreadsCommand.php
@@ -290,6 +290,19 @@ class ThreadsCommand {
 		return new \DataMachineSocials\Abilities\Threads\ThreadsUpdateAbility();
 	}
 
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/threads-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/threads-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Threads\ThreadsDeleteAbility();
+	}
+
 	/**
 	 * Delete a Threads post.
 	 *
@@ -304,10 +317,9 @@ class ThreadsCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$thread_id = $args[0];
-		$ability   = $this->get_update_ability();
+		$ability   = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action'    => 'delete',
 			'thread_id' => $thread_id,
 		) );
 

--- a/inc/Cli/Commands/TwitterCommand.php
+++ b/inc/Cli/Commands/TwitterCommand.php
@@ -260,10 +260,9 @@ class TwitterCommand {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$tweet_id = $args[0];
-		$ability  = $this->get_update_ability();
+		$ability  = $this->get_delete_ability();
 
 		$result = $ability->execute( array(
-			'action'   => 'delete',
 			'tweet_id' => $tweet_id,
 		) );
 
@@ -355,5 +354,18 @@ class TwitterCommand {
 		}
 
 		return new \DataMachineSocials\Abilities\Twitter\TwitterUpdateAbility();
+	}
+
+	private function get_delete_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/twitter-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/twitter-delete ability not registered.' );
+		}
+
+		return new \DataMachineSocials\Abilities\Twitter\TwitterDeleteAbility();
 	}
 }


### PR DESCRIPTION
## Summary

Splits the CLI delete commands from update commands to use separate DeleteAbility classes.

### Changes
- `delete` subcommand now uses `get_delete_ability()` instead of `get_update_ability()`
- Each platform CLI has a dedicated `get_delete_ability()` method

This ensures deletion is isolated from editing operations in CLI as well.