### PR TITLE
feat: expand Reddit CLI with discovery and intelligence subcommands

### DIFF
--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -2,8 +2,9 @@
 /**
  * WP-CLI Reddit Command
  *
- * Provides CLI access to Reddit fetch operations and account management.
- * Wraps the FetchRedditAbility and RedditAuth providers.
+ * Provides CLI access to Reddit fetch operations, subreddit discovery,
+ * and account management. Wraps the FetchRedditAbility and RedditAuth
+ * providers, plus direct Reddit API calls for discovery commands.
  *
  * @package    DataMachineSocials
  * @subpackage Cli\Commands
@@ -14,6 +15,7 @@ namespace DataMachineSocials\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Core\HttpClient;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -25,13 +27,414 @@ defined( 'ABSPATH' ) || exit;
  *     # Fetch a post from a subreddit
  *     wp datamachine-socials reddit fetch jambands
  *
- *     # Fetch with filters
- *     wp datamachine-socials reddit fetch jambands --sort=top --min-upvotes=100
+ *     # Get subreddit info
+ *     wp datamachine-socials reddit info bonnaroo
+ *
+ *     # Search for subreddits
+ *     wp datamachine-socials reddit search "music festivals"
+ *
+ *     # List posts with scores
+ *     wp datamachine-socials reddit posts sxsw --sort=top --limit=20
+ *
+ *     # Browse trending subreddits
+ *     wp datamachine-socials reddit trending --limit=10
  *
  *     # Check Reddit auth status
  *     wp datamachine-socials reddit status
  */
 class RedditCommand {
+
+	/**
+	 * Reddit OAuth API base URL.
+	 */
+	private const API_BASE = 'https://oauth.reddit.com';
+
+	/**
+	 * Get subreddit information and statistics.
+	 *
+	 * Returns subscriber count, description, creation date, and activity
+	 * metrics for a subreddit. Use this to understand a subreddit's size
+	 * and set appropriate thresholds for flow configuration.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <subreddit>
+	 * : The subreddit name (without "r/").
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit info bonnaroo
+	 *     wp datamachine-socials reddit info festivals --format=json
+	 *     wp datamachine-socials reddit info jambands --format=yaml
+	 *
+	 * @subcommand info
+	 */
+	public function info( $args, $assoc_args ) {
+		$subreddit = $args[0];
+		$format    = $assoc_args['format'] ?? 'table';
+
+		WP_CLI::log( "Fetching info for r/{$subreddit}..." );
+
+		$result = $this->reddit_api_get( "/r/{$subreddit}/about" );
+		$data   = $result['data'] ?? array();
+
+		$info = array(
+			'name'               => $data['display_name'] ?? $subreddit,
+			'title'              => $data['title'] ?? '',
+			'description'        => $data['public_description'] ?? '',
+			'subscribers'        => $data['subscribers'] ?? 0,
+			'active_users'       => $data['accounts_active'] ?? 0,
+			'created'            => ! empty( $data['created_utc'] ) ? wp_date( 'Y-m-d', intval( $data['created_utc'] ) ) : 'unknown',
+			'over_18'            => ! empty( $data['over18'] ) ? 'yes' : 'no',
+			'subreddit_type'     => $data['subreddit_type'] ?? 'unknown',
+			'url'                => 'https://www.reddit.com/r/' . ( $data['display_name'] ?? $subreddit ),
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $info, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$this->output_yaml( $info );
+			return;
+		}
+
+		// Table format.
+		WP_CLI::success( "r/{$subreddit}" );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Name:         ' . $info['name'] );
+		WP_CLI::log( 'Title:        ' . $info['title'] );
+		WP_CLI::log( 'Subscribers:  ' . number_format( $info['subscribers'] ) );
+		WP_CLI::log( 'Active now:   ' . number_format( $info['active_users'] ) );
+		WP_CLI::log( 'Created:      ' . $info['created'] );
+		WP_CLI::log( 'Type:         ' . $info['subreddit_type'] );
+		WP_CLI::log( 'NSFW:         ' . $info['over_18'] );
+		WP_CLI::log( 'URL:          ' . $info['url'] );
+
+		if ( ! empty( $info['description'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Description:' );
+			WP_CLI::log( $info['description'] );
+		}
+	}
+
+	/**
+	 * Search for subreddits by keyword.
+	 *
+	 * Find subreddits matching a search query. Returns name, subscriber
+	 * count, and description for each match. Useful for discovering new
+	 * data sources for flows.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <query>
+	 * : Search query to find subreddits.
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum number of results.
+	 * ---
+	 * default: 10
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit search "music festivals"
+	 *     wp datamachine-socials reddit search "jam bands" --limit=20
+	 *     wp datamachine-socials reddit search "electronic music" --format=json
+	 */
+	public function search( $args, $assoc_args ) {
+		$query  = $args[0];
+		$limit  = absint( $assoc_args['limit'] ?? 10 );
+		$format = $assoc_args['format'] ?? 'table';
+
+		WP_CLI::log( "Searching subreddits for \"{$query}\"..." );
+
+		$result   = $this->reddit_api_get( '/subreddits/search', array(
+			'q'     => $query,
+			'limit' => min( $limit, 100 ),
+			'sort'  => 'relevance',
+			'type'  => 'sr',
+		) );
+		$children = $result['data']['children'] ?? array();
+
+		if ( empty( $children ) ) {
+			WP_CLI::warning( 'No subreddits found for "' . $query . '".' );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $children as $child ) {
+			$sub    = $child['data'] ?? array();
+			$rows[] = array(
+				'subreddit'   => 'r/' . ( $sub['display_name'] ?? '' ),
+				'subscribers' => $sub['subscribers'] ?? 0,
+				'active'      => $sub['accounts_active'] ?? 0,
+				'nsfw'        => ! empty( $sub['over18'] ) ? 'yes' : 'no',
+				'description' => mb_substr( $sub['public_description'] ?? '', 0, 80 ),
+			);
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$this->output_yaml( $rows );
+			return;
+		}
+
+		WP_CLI::success( count( $rows ) . ' subreddits found for "' . $query . '"' );
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'subreddit', 'subscribers', 'active', 'nsfw', 'description' ) );
+	}
+
+	/**
+	 * List posts from a subreddit with scores.
+	 *
+	 * Unlike `fetch` which returns a single processed post, `posts` returns
+	 * a table of multiple posts with their scores, comment counts, and ages.
+	 * Use this to understand a subreddit's score distribution and set
+	 * appropriate min_upvotes thresholds.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <subreddit>
+	 * : The subreddit name (without "r/").
+	 *
+	 * [--sort=<sort>]
+	 * : Sort order for posts.
+	 * ---
+	 * default: top
+	 * options:
+	 *   - hot
+	 *   - new
+	 *   - top
+	 *   - rising
+	 *   - controversial
+	 * ---
+	 *
+	 * [--timeframe=<timeframe>]
+	 * : Time period for top/controversial sort.
+	 * ---
+	 * default: week
+	 * options:
+	 *   - hour
+	 *   - day
+	 *   - week
+	 *   - month
+	 *   - year
+	 *   - all
+	 * ---
+	 *
+	 * [--limit=<limit>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit posts bonnaroo
+	 *     wp datamachine-socials reddit posts sxsw --sort=top --timeframe=month
+	 *     wp datamachine-socials reddit posts festivals --limit=50 --format=json
+	 *     wp datamachine-socials reddit posts jambands --sort=hot
+	 */
+	public function posts( $args, $assoc_args ) {
+		$subreddit = $args[0];
+		$sort      = $assoc_args['sort'] ?? 'top';
+		$timeframe = $assoc_args['timeframe'] ?? 'week';
+		$limit     = absint( $assoc_args['limit'] ?? 25 );
+		$format    = $assoc_args['format'] ?? 'table';
+
+		WP_CLI::log( "Listing posts from r/{$subreddit} (sort: {$sort}, timeframe: {$timeframe})..." );
+
+		$params = array(
+			'limit' => min( $limit, 100 ),
+		);
+
+		// Reddit only uses the 't' parameter for top and controversial sorts.
+		if ( in_array( $sort, array( 'top', 'controversial' ), true ) ) {
+			$params['t'] = $timeframe;
+		}
+
+		$result   = $this->reddit_api_get( "/r/{$subreddit}/{$sort}", $params );
+		$children = $result['data']['children'] ?? array();
+
+		if ( empty( $children ) ) {
+			WP_CLI::warning( "No posts found in r/{$subreddit}." );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $children as $child ) {
+			$post = $child['data'] ?? array();
+
+			// Skip stickied/pinned mod posts.
+			if ( ! empty( $post['stickied'] ) || ! empty( $post['pinned'] ) ) {
+				continue;
+			}
+
+			$age_hours = ! empty( $post['created_utc'] ) ? round( ( time() - $post['created_utc'] ) / 3600 ) : 0;
+			if ( $age_hours >= 24 ) {
+				$age = round( $age_hours / 24 ) . 'd';
+			} else {
+				$age = $age_hours . 'h';
+			}
+
+			$rows[] = array(
+				'score'    => $post['score'] ?? 0,
+				'comments' => $post['num_comments'] ?? 0,
+				'age'      => $age,
+				'author'   => $post['author'] ?? '[deleted]',
+				'title'    => mb_substr( $post['title'] ?? '', 0, 70 ),
+			);
+		}
+
+		if ( empty( $rows ) ) {
+			WP_CLI::warning( "No non-stickied posts found in r/{$subreddit}." );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$this->output_yaml( $rows );
+			return;
+		}
+
+		// Show score distribution summary before table.
+		$scores = array_column( $rows, 'score' );
+		sort( $scores );
+		$count  = count( $scores );
+		$median = $count % 2 === 0
+			? ( $scores[ $count / 2 - 1 ] + $scores[ $count / 2 ] ) / 2
+			: $scores[ intval( $count / 2 ) ];
+
+		WP_CLI::success( count( $rows ) . " posts from r/{$subreddit}" );
+		WP_CLI::log( sprintf(
+			'Score distribution: min=%d, median=%s, max=%d, avg=%d',
+			min( $scores ),
+			$median,
+			max( $scores ),
+			round( array_sum( $scores ) / $count )
+		) );
+		WP_CLI::log( '' );
+		WP_CLI\Utils\format_items( $format, $rows, array( 'score', 'comments', 'age', 'author', 'title' ) );
+	}
+
+	/**
+	 * Browse trending and popular subreddits.
+	 *
+	 * Lists popular subreddits sorted by subscriber count. Use --search
+	 * to filter by category or topic. Useful for discovering new sources.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<limit>]
+	 * : Number of subreddits to show.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--new]
+	 * : Show new subreddits instead of popular ones.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit trending
+	 *     wp datamachine-socials reddit trending --limit=50
+	 *     wp datamachine-socials reddit trending --new
+	 *     wp datamachine-socials reddit trending --format=json
+	 */
+	public function trending( $args, $assoc_args ) {
+		$limit    = absint( $assoc_args['limit'] ?? 25 );
+		$format   = $assoc_args['format'] ?? 'table';
+		$endpoint = isset( $assoc_args['new'] ) ? '/subreddits/new' : '/subreddits/popular';
+		$label    = isset( $assoc_args['new'] ) ? 'new' : 'popular';
+
+		WP_CLI::log( "Fetching {$label} subreddits..." );
+
+		$result   = $this->reddit_api_get( $endpoint, array(
+			'limit' => min( $limit, 100 ),
+		) );
+		$children = $result['data']['children'] ?? array();
+
+		if ( empty( $children ) ) {
+			WP_CLI::warning( "No {$label} subreddits returned." );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $children as $child ) {
+			$sub    = $child['data'] ?? array();
+			$rows[] = array(
+				'subreddit'   => 'r/' . ( $sub['display_name'] ?? '' ),
+				'subscribers' => $sub['subscribers'] ?? 0,
+				'active'      => $sub['accounts_active'] ?? 0,
+				'nsfw'        => ! empty( $sub['over18'] ) ? 'yes' : 'no',
+				'description' => mb_substr( $sub['public_description'] ?? '', 0, 60 ),
+			);
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$this->output_yaml( $rows );
+			return;
+		}
+
+		WP_CLI::success( count( $rows ) . " {$label} subreddits" );
+		WP_CLI\Utils\format_items( $format, $rows, array( 'subreddit', 'subscribers', 'active', 'nsfw', 'description' ) );
+	}
 
 	/**
 	 * Fetch a post from a Reddit subreddit.
@@ -110,24 +513,8 @@ class RedditCommand {
 	 *     wp datamachine-socials reddit fetch sxsw --format=json
 	 */
 	public function fetch( $args, $assoc_args ) {
-		$subreddit = $args[0];
-
-		// Get auth provider.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'reddit' );
-
-		if ( ! $provider ) {
-			WP_CLI::error( 'Reddit auth provider not found. Is data-machine-socials active?' );
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			WP_CLI::error( 'Reddit is not authenticated. Connect via Settings > Data Machine > Auth.' );
-		}
-
-		$access_token = $provider->get_valid_access_token();
-		if ( empty( $access_token ) ) {
-			WP_CLI::error( 'Failed to obtain a valid Reddit access token (expired and refresh failed).' );
-		}
+		$subreddit    = $args[0];
+		$access_token = $this->get_access_token();
 
 		// Build ability input.
 		$input = array(
@@ -253,6 +640,67 @@ class RedditCommand {
 				WP_CLI::log( 'Next cron:     ' . wp_date( 'Y-m-d H:i:s', $next_cron ) );
 			}
 		}
+	}
+
+	/**
+	 * Get a valid Reddit access token or exit with error.
+	 *
+	 * @return string Access token.
+	 */
+	private function get_access_token(): string {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'reddit' );
+
+		if ( ! $provider ) {
+			WP_CLI::error( 'Reddit auth provider not found. Is data-machine-socials active?' );
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			WP_CLI::error( 'Reddit is not authenticated. Connect via Settings > Data Machine > Auth.' );
+		}
+
+		$access_token = $provider->get_valid_access_token();
+		if ( empty( $access_token ) ) {
+			WP_CLI::error( 'Failed to obtain a valid Reddit access token (expired and refresh failed).' );
+		}
+
+		return $access_token;
+	}
+
+	/**
+	 * Make an authenticated GET request to the Reddit OAuth API.
+	 *
+	 * @param string $endpoint API endpoint path (e.g. "/r/bonnaroo/about").
+	 * @param array  $params   Optional query parameters.
+	 * @return array Decoded JSON response data.
+	 */
+	private function reddit_api_get( string $endpoint, array $params = array() ): array {
+		$access_token = $this->get_access_token();
+
+		$url = self::API_BASE . $endpoint . '.json';
+		if ( ! empty( $params ) ) {
+			$url .= '?' . http_build_query( $params );
+		}
+
+		$result = HttpClient::get( $url, array(
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $access_token,
+				'User-Agent'    => 'php:DataMachineWPPlugin:v' . DATAMACHINE_VERSION . ' (by Data Machine)',
+			),
+			'context' => 'Reddit CLI',
+		) );
+
+		if ( ! $result['success'] || 200 !== ( $result['status_code'] ?? 0 ) ) {
+			$status = $result['status_code'] ?? 'unknown';
+			WP_CLI::error( "Reddit API request failed (HTTP {$status}): {$endpoint}" );
+		}
+
+		$decoded = json_decode( $result['data'] ?? '', true );
+		if ( ! is_array( $decoded ) ) {
+			WP_CLI::error( "Reddit API returned invalid JSON for {$endpoint}" );
+		}
+
+		return $decoded;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Expands `wp datamachine-socials reddit` from 2 subcommands to 6, adding subreddit discovery and intelligence gathering capabilities.

## New subcommands

| Command | Purpose |
|---|---|
| `reddit info <subreddit>` | Subscriber count, description, active users, creation date |
| `reddit search <query>` | Find subreddits by keyword with subscriber counts |
| `reddit posts <subreddit>` | List posts with score distribution stats (min/median/max/avg) |
| `reddit trending` | Browse popular or new subreddits |

## Why

**Tooling first.** The wire has 13 Reddit flows all returning `completed_no_items` because `min_upvotes=30` is too high for niche subs. Before we can tune thresholds intelligently, we need CLI tools to check what a subreddit's score distribution actually looks like.

Example — before this PR, no way to know this from the CLI:
```
r/sxsw: 15,472 subscribers, top-of-week median score = 8, max = 21
r/bonnaroo: 123,097 subscribers (8x larger)
```

Setting `min_upvotes=30` for both is obviously wrong, but we had no tooling to surface this.

## Also includes

- `get_access_token()` — DRY helper for auth boilerplate
- `reddit_api_get()` — reusable authenticated GET to `oauth.reddit.com`
- All commands support `--format=table|json|yaml|csv`
- All use existing read-only OAuth scopes (`identity read`)

## Tested

All 4 new subcommands tested live against Reddit API:
- `info bonnaroo` ✅ — returns 123,097 subscribers
- `info sxsw` ✅ — returns 15,472 subscribers  
- `search "music festivals"` ✅ — returns 10 matching subs
- `posts sxsw --sort=top --timeframe=week` ✅ — shows score distribution
- `trending --limit=10` ✅ — returns popular subs

Closes #39 (partially — Reddit portion)