### PR TITLE
fix: update registerTool() calls for Data Machine 0.39.0 compatibility

### DIFF
--- a/inc/Chat/Tools/DeleteBluesky.php
+++ b/inc/Chat/Tools/DeleteBluesky.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeleteBluesky extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_bluesky', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/DeleteFacebook.php
+++ b/inc/Chat/Tools/DeleteFacebook.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeleteFacebook extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_facebook', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/DeleteInstagram.php
+++ b/inc/Chat/Tools/DeleteInstagram.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeleteInstagram extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_instagram', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/DeletePinterest.php
+++ b/inc/Chat/Tools/DeletePinterest.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeletePinterest extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_pinterest', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/DeleteThreads.php
+++ b/inc/Chat/Tools/DeleteThreads.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeleteThreads extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_threads', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/DeleteTwitter.php
+++ b/inc/Chat/Tools/DeleteTwitter.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class DeleteTwitter extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_twitter', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/FetchReddit.php
+++ b/inc/Chat/Tools/FetchReddit.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class FetchReddit extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'fetch_reddit', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'fetch_reddit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Chat/Tools/ReadBluesky.php
+++ b/inc/Chat/Tools/ReadBluesky.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadBluesky extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_bluesky', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/ReadFacebook.php
+++ b/inc/Chat/Tools/ReadFacebook.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadFacebook extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_facebook', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/ReadInstagram.php
+++ b/inc/Chat/Tools/ReadInstagram.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadInstagram extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_instagram', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Chat/Tools/ReadPinterest.php
+++ b/inc/Chat/Tools/ReadPinterest.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadPinterest extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_pinterest', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/ReadThreads.php
+++ b/inc/Chat/Tools/ReadThreads.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadThreads extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_threads', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/ReadTwitter.php
+++ b/inc/Chat/Tools/ReadTwitter.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class ReadTwitter extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_twitter', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/UpdateBluesky.php
+++ b/inc/Chat/Tools/UpdateBluesky.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdateBluesky extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_bluesky', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/UpdateFacebook.php
+++ b/inc/Chat/Tools/UpdateFacebook.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdateFacebook extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_facebook', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/UpdateInstagram.php
+++ b/inc/Chat/Tools/UpdateInstagram.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdateInstagram extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_instagram', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Chat/Tools/UpdatePinterest.php
+++ b/inc/Chat/Tools/UpdatePinterest.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdatePinterest extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_pinterest', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/UpdateThreads.php
+++ b/inc/Chat/Tools/UpdateThreads.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdateThreads extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_threads', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Chat/Tools/UpdateTwitter.php
+++ b/inc/Chat/Tools/UpdateTwitter.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class UpdateTwitter extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_twitter', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {


### PR DESCRIPTION
## Summary

- **Updates all 19 chat tools** in `inc/Chat/Tools/` to use the new `BaseTool::registerTool()` signature from Data Machine 0.39.0
- Old: `registerTool(string $context, string $toolName, callable $toolDefinition)`
- New: `registerTool(string $toolName, callable|array $toolDefinition, array $contexts = [])`

## Files Changed

All 19 tool files — mechanical refactor, one line per file:

| Platform | Read | Update | Delete | Fetch |
|----------|------|--------|--------|-------|
| Bluesky | ✅ | ✅ | ✅ | — |
| Facebook | ✅ | ✅ | ✅ | — |
| Instagram | ✅ | ✅ | ✅ | — |
| Pinterest | ✅ | ✅ | ✅ | — |
| Threads | ✅ | ✅ | ✅ | — |
| Twitter | ✅ | ✅ | ✅ | — |
| Reddit | — | — | — | ✅ |

## Verification

- All 19 files pass `php -l` syntax check
- No other DM API breakages found — `buildErrorResponse`, `buildDiagnosticErrorResponse`, `isAbilitySuccess`, `getAbilityError` are unchanged