### PR TITLE
feat: SocialShareTracker — cross-platform share history via post meta

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -181,6 +181,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/FacebookCommand.php';
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/TwitterCommand.php';
 	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/BlueskyCommand.php';
+	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/SharesCommand.php';
 	WP_CLI::add_command( 'datamachine-socials pinterest', \DataMachineSocials\Cli\Commands\PinterestCommand::class );
 	WP_CLI::add_command( 'datamachine-socials reddit', \DataMachineSocials\Cli\Commands\RedditCommand::class );
 	WP_CLI::add_command( 'datamachine-socials instagram', \DataMachineSocials\Cli\Commands\InstagramCommand::class );
@@ -188,6 +189,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 'datamachine-socials facebook', \DataMachineSocials\Cli\Commands\FacebookCommand::class );
 	WP_CLI::add_command( 'datamachine-socials twitter', \DataMachineSocials\Cli\Commands\TwitterCommand::class );
 	WP_CLI::add_command( 'datamachine-socials bluesky', \DataMachineSocials\Cli\Commands\BlueskyCommand::class );
+	WP_CLI::add_command( 'datamachine-socials shares', \DataMachineSocials\Cli\Commands\SharesCommand::class );
 }
 
 /**

--- a/inc/Cli/Commands/SharesCommand.php
+++ b/inc/Cli/Commands/SharesCommand.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * WP-CLI Shares Command
+ *
+ * Query and manage social share tracking data.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Cli\Commands
+ * @since      0.4.0
+ */
+
+namespace DataMachineSocials\Cli\Commands;
+
+use WP_CLI;
+use DataMachineSocials\Tracking\SocialShareTracker;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage social share tracking for Data Machine Socials.
+ *
+ * ## EXAMPLES
+ *
+ *     # List shares for a post
+ *     wp datamachine-socials shares list 42
+ *
+ *     # Check if a post was shared to Instagram
+ *     wp datamachine-socials shares check 42 instagram
+ *
+ *     # Clear all tracking data for a post
+ *     wp datamachine-socials shares clear 42
+ */
+class SharesCommand {
+
+	/**
+	 * List share history for a WordPress post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The WordPress post ID.
+	 *
+	 * [--platform=<platform>]
+	 * : Filter by platform slug (instagram, twitter, etc.).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials shares list 42
+	 *     wp datamachine-socials shares list 42 --platform=instagram
+	 *     wp datamachine-socials shares list 42 --format=json
+	 */
+	public function list_( $args, $assoc_args ) {
+		$post_id  = intval( $args[0] );
+		$platform = $assoc_args['platform'] ?? null;
+		$format   = $assoc_args['format'] ?? 'table';
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			WP_CLI::error( "Post {$post_id} not found." );
+		}
+
+		$shares = SocialShareTracker::get_shares( $post_id, $platform );
+
+		if ( empty( $shares ) ) {
+			$msg = $platform
+				? "Post {$post_id} has not been shared to {$platform}."
+				: "Post {$post_id} has no share history.";
+			WP_CLI::warning( $msg );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $shares, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( sprintf(
+			'Found %d share(s) for post %d (%s)',
+			count( $shares ),
+			$post_id,
+			$post->post_title ?: '(no title)'
+		) );
+		WP_CLI::log( '' );
+
+		foreach ( $shares as $share ) {
+			$status    = $share['status'] ?? 'published';
+			$date      = isset( $share['shared_at'] ) ? wp_date( 'Y-m-d H:i', $share['shared_at'] ) : '';
+			$kind      = $share['media_kind'] ?? '';
+			$kind_str  = $kind ? " ({$kind})" : '';
+			$status_str = 'deleted' === $status ? ' [DELETED]' : '';
+
+			WP_CLI::log( sprintf(
+				'  %-12s %s  %s%s%s',
+				$share['platform'] ?? '',
+				$date,
+				$share['platform_url'] ?? $share['platform_post_id'] ?? '',
+				$kind_str,
+				$status_str
+			) );
+		}
+	}
+
+	/**
+	 * Check if a post has been shared to a platform.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The WordPress post ID.
+	 *
+	 * <platform>
+	 * : Platform slug to check (instagram, twitter, etc.).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials shares check 42 instagram
+	 */
+	public function check( $args ) {
+		$post_id  = intval( $args[0] );
+		$platform = $args[1] ?? '';
+
+		if ( empty( $platform ) ) {
+			WP_CLI::error( 'Platform slug is required.' );
+		}
+
+		if ( SocialShareTracker::has_been_shared( $post_id, $platform ) ) {
+			$latest = SocialShareTracker::get_latest_share( $post_id, $platform );
+			$date   = isset( $latest['shared_at'] ) ? wp_date( 'Y-m-d H:i', $latest['shared_at'] ) : 'unknown';
+			$url    = $latest['platform_url'] ?? '';
+
+			WP_CLI::success( "Post {$post_id} was shared to {$platform} (last: {$date})" );
+			if ( $url ) {
+				WP_CLI::log( "  URL: {$url}" );
+			}
+		} else {
+			WP_CLI::warning( "Post {$post_id} has not been shared to {$platform}." );
+		}
+	}
+
+	/**
+	 * Show which platforms a post has been shared to.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The WordPress post ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials shares platforms 42
+	 */
+	public function platforms( $args ) {
+		$post_id   = intval( $args[0] );
+		$platforms = SocialShareTracker::get_shared_platforms( $post_id );
+
+		if ( empty( $platforms ) ) {
+			WP_CLI::warning( "Post {$post_id} has not been shared to any platform." );
+			return;
+		}
+
+		WP_CLI::success( sprintf(
+			'Post %d shared to: %s',
+			$post_id,
+			implode( ', ', $platforms )
+		) );
+	}
+
+	/**
+	 * Clear all share tracking data for a post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The WordPress post ID.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials shares clear 42 --yes
+	 */
+	public function clear( $args, $assoc_args ) {
+		$post_id = intval( $args[0] );
+
+		$count = SocialShareTracker::count_shares( $post_id, null, true );
+
+		if ( 0 === $count ) {
+			WP_CLI::warning( "Post {$post_id} has no share data to clear." );
+			return;
+		}
+
+		WP_CLI::confirm(
+			"Clear {$count} share record(s) for post {$post_id}?",
+			$assoc_args
+		);
+
+		SocialShareTracker::clear( $post_id );
+
+		// Also clean up legacy meta if present.
+		delete_post_meta( $post_id, '_dms_shared_posts' );
+
+		WP_CLI::success( "Share data cleared for post {$post_id}." );
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -867,23 +867,16 @@ class RestApi {
 			if ( ! $result['success'] ) {
 				$errors[] = $platform . ': ' . $result['error'];
 			}
-		}
 
-		// Track the post.
-		if ( $post_id ) {
-			$shared = get_post_meta( $post_id, '_dms_shared_posts', true );
-			if ( ! is_array( $shared ) ) {
-				$shared = array();
+			// Track successful shares via SocialShareTracker.
+			if ( $post_id && ! empty( $result['success'] ) ) {
+				\DataMachineSocials\Tracking\SocialShareTracker::record_from_result(
+					$post_id,
+					$platform,
+					$result,
+					array( 'media_kind' => $media_kind )
+				);
 			}
-
-			$shared[] = array(
-				'timestamp'  => time(),
-				'platforms'  => $platforms,
-				'images'     => count( $images ),
-				'media_kind' => $media_kind,
-			);
-
-			update_post_meta( $post_id, '_dms_shared_posts', $shared );
 		}
 
 		return new \WP_REST_Response(
@@ -967,10 +960,11 @@ class RestApi {
 
 		if ( ! empty( $result['success'] ) ) {
 			return array(
-				'platform'  => $platform,
-				'success'   => true,
-				'media_id'  => $result['media_id'] ?? null,
-				'permalink' => $result['permalink'] ?? null,
+				'platform'         => $platform,
+				'success'          => true,
+				'platform_post_id' => \DataMachineSocials\Tracking\SocialShareTracker::extract_platform_post_id( $platform, $result ),
+				'platform_url'     => \DataMachineSocials\Tracking\SocialShareTracker::extract_platform_url( $platform, $result ),
+				'media_kind'       => $result['media_kind'] ?? null,
 			);
 		}
 
@@ -1031,17 +1025,22 @@ class RestApi {
 	}
 
 	/**
-	 * Get post status
+	 * Get post sharing status and history.
 	 */
 	public static function get_post_status( \WP_REST_Request $request ) {
-		$post_id = $request->get_param( 'post_id' );
+		$post_id  = intval( $request->get_param( 'post_id' ) );
+		$platform = $request->get_param( 'platform' );
 
-		$shared = get_post_meta( $post_id, '_dms_shared_posts', true );
+		$tracker = \DataMachineSocials\Tracking\SocialShareTracker::class;
 
-		if ( ! is_array( $shared ) ) {
-			$shared = array();
-		}
+		$shares    = $tracker::get_shares( $post_id, $platform ?: null );
+		$platforms = $tracker::get_shared_platforms( $post_id );
 
-		return new \WP_REST_Response( $shared );
+		return new \WP_REST_Response( array(
+			'post_id'   => $post_id,
+			'platforms' => $platforms,
+			'shares'    => $shares,
+			'count'     => count( $shares ),
+		) );
 	}
 }

--- a/inc/Tracking/SocialShareTracker.php
+++ b/inc/Tracking/SocialShareTracker.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Social Share Tracker
+ *
+ * Tracks which WordPress posts/attachments have been shared to which
+ * social platforms. Uses WordPress post meta for storage — no custom tables.
+ *
+ * Meta keys:
+ * - _datamachine_social_shares: Full share history (array of share records)
+ * - _datamachine_shared_platforms: Flat array of platform slugs for fast lookups
+ *
+ * @package    DataMachineSocials
+ * @subpackage Tracking
+ * @since      0.4.0
+ */
+
+namespace DataMachineSocials\Tracking;
+
+defined( 'ABSPATH' ) || exit;
+
+class SocialShareTracker {
+
+	/**
+	 * Post meta key for full share history.
+	 */
+	const SHARES_META_KEY = '_datamachine_social_shares';
+
+	/**
+	 * Post meta key for quick platform lookup.
+	 */
+	const PLATFORMS_META_KEY = '_datamachine_shared_platforms';
+
+	/**
+	 * Record a successful share to a social platform.
+	 *
+	 * @param int    $post_id          WordPress post or attachment ID.
+	 * @param string $platform         Platform slug (instagram, twitter, etc.).
+	 * @param string $platform_post_id Platform-specific post ID (media_id, tweet_id, etc.).
+	 * @param string $platform_url     Permalink on the platform.
+	 * @param array  $extra            Optional extra data (media_kind, shared_by, job_id, etc.).
+	 * @return bool True on success.
+	 */
+	public static function record( int $post_id, string $platform, string $platform_post_id = '', string $platform_url = '', array $extra = array() ): bool {
+		if ( ! $post_id || empty( $platform ) ) {
+			return false;
+		}
+
+		$shares = self::get_shares( $post_id );
+
+		$record = array(
+			'platform'         => sanitize_key( $platform ),
+			'platform_post_id' => sanitize_text_field( $platform_post_id ),
+			'platform_url'     => esc_url_raw( $platform_url ),
+			'shared_at'        => time(),
+			'shared_by'        => $extra['shared_by'] ?? get_current_user_id(),
+			'media_kind'       => sanitize_key( $extra['media_kind'] ?? '' ),
+			'job_id'           => intval( $extra['job_id'] ?? 0 ) ?: null,
+		);
+
+		$shares[] = $record;
+
+		update_post_meta( $post_id, self::SHARES_META_KEY, $shares );
+		self::update_platforms_index( $post_id, $shares );
+
+		return true;
+	}
+
+	/**
+	 * Check if a post has been shared to a specific platform.
+	 *
+	 * Uses the flat platforms index for fast lookups.
+	 *
+	 * @param int    $post_id  WordPress post ID.
+	 * @param string $platform Platform slug.
+	 * @return bool
+	 */
+	public static function has_been_shared( int $post_id, string $platform ): bool {
+		$platforms = get_post_meta( $post_id, self::PLATFORMS_META_KEY, true );
+
+		if ( ! is_array( $platforms ) ) {
+			return false;
+		}
+
+		return in_array( $platform, $platforms, true );
+	}
+
+	/**
+	 * Check if a post has been shared to any platform.
+	 *
+	 * @param int $post_id WordPress post ID.
+	 * @return bool
+	 */
+	public static function has_any_shares( int $post_id ): bool {
+		$platforms = get_post_meta( $post_id, self::PLATFORMS_META_KEY, true );
+
+		return is_array( $platforms ) && ! empty( $platforms );
+	}
+
+	/**
+	 * Get all share records for a post, optionally filtered by platform.
+	 *
+	 * @param int         $post_id  WordPress post ID.
+	 * @param string|null $platform Optional platform slug to filter by.
+	 * @return array Array of share records.
+	 */
+	public static function get_shares( int $post_id, ?string $platform = null ): array {
+		$shares = get_post_meta( $post_id, self::SHARES_META_KEY, true );
+
+		if ( ! is_array( $shares ) ) {
+			return array();
+		}
+
+		if ( null === $platform ) {
+			return $shares;
+		}
+
+		return array_values(
+			array_filter(
+				$shares,
+				fn( $share ) => ( $share['platform'] ?? '' ) === $platform
+			)
+		);
+	}
+
+	/**
+	 * Get the list of platforms a post has been shared to.
+	 *
+	 * @param int $post_id WordPress post ID.
+	 * @return string[] Array of platform slugs.
+	 */
+	public static function get_shared_platforms( int $post_id ): array {
+		$platforms = get_post_meta( $post_id, self::PLATFORMS_META_KEY, true );
+
+		if ( ! is_array( $platforms ) ) {
+			return array();
+		}
+
+		return $platforms;
+	}
+
+	/**
+	 * Get the most recent share for a post on a given platform.
+	 *
+	 * @param int    $post_id  WordPress post ID.
+	 * @param string $platform Platform slug.
+	 * @return array|null Share record or null.
+	 */
+	public static function get_latest_share( int $post_id, string $platform ): ?array {
+		$shares = self::get_shares( $post_id, $platform );
+
+		if ( empty( $shares ) ) {
+			return null;
+		}
+
+		// Sort by shared_at descending.
+		usort( $shares, fn( $a, $b ) => ( $b['shared_at'] ?? 0 ) <=> ( $a['shared_at'] ?? 0 ) );
+
+		return $shares[0];
+	}
+
+	/**
+	 * Mark a specific share as deleted on the platform.
+	 *
+	 * Does not remove the record — sets status to 'deleted' for audit trail.
+	 *
+	 * @param int    $post_id          WordPress post ID.
+	 * @param string $platform         Platform slug.
+	 * @param string $platform_post_id Platform-specific post ID.
+	 * @return bool True if found and updated.
+	 */
+	public static function mark_deleted( int $post_id, string $platform, string $platform_post_id ): bool {
+		$shares  = self::get_shares( $post_id );
+		$updated = false;
+
+		foreach ( $shares as &$share ) {
+			if (
+				( $share['platform'] ?? '' ) === $platform &&
+				( $share['platform_post_id'] ?? '' ) === $platform_post_id
+			) {
+				$share['status']     = 'deleted';
+				$share['deleted_at'] = time();
+				$updated             = true;
+				break;
+			}
+		}
+		unset( $share );
+
+		if ( $updated ) {
+			update_post_meta( $post_id, self::SHARES_META_KEY, $shares );
+			self::update_platforms_index( $post_id, $shares );
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Get share count for a post, optionally filtered by platform.
+	 *
+	 * Excludes deleted shares by default.
+	 *
+	 * @param int         $post_id        WordPress post ID.
+	 * @param string|null $platform       Optional platform filter.
+	 * @param bool        $include_deleted Whether to include deleted shares.
+	 * @return int
+	 */
+	public static function count_shares( int $post_id, ?string $platform = null, bool $include_deleted = false ): int {
+		$shares = self::get_shares( $post_id, $platform );
+
+		if ( $include_deleted ) {
+			return count( $shares );
+		}
+
+		return count(
+			array_filter(
+				$shares,
+				fn( $share ) => ( $share['status'] ?? 'published' ) !== 'deleted'
+			)
+		);
+	}
+
+	/**
+	 * Extract the platform post ID from a publish result.
+	 *
+	 * Different platforms use different keys (media_id, tweet_id, post_id, pin_id).
+	 * This normalizes them.
+	 *
+	 * @param string $platform Platform slug.
+	 * @param array  $result   Publish result array.
+	 * @return string Platform post ID or empty string.
+	 */
+	public static function extract_platform_post_id( string $platform, array $result ): string {
+		$id_keys = array(
+			'instagram' => 'media_id',
+			'twitter'   => 'tweet_id',
+			'facebook'  => 'post_id',
+			'bluesky'   => 'post_id',
+			'threads'   => 'post_id',
+			'pinterest' => 'pin_id',
+		);
+
+		$key = $id_keys[ $platform ] ?? 'post_id';
+
+		return (string) ( $result[ $key ] ?? '' );
+	}
+
+	/**
+	 * Extract the platform URL from a publish result.
+	 *
+	 * Different platforms use different keys (permalink, tweet_url, post_url, pin_url).
+	 * This normalizes them.
+	 *
+	 * @param string $platform Platform slug.
+	 * @param array  $result   Publish result array.
+	 * @return string Platform URL or empty string.
+	 */
+	public static function extract_platform_url( string $platform, array $result ): string {
+		$url_keys = array(
+			'instagram' => 'permalink',
+			'twitter'   => 'tweet_url',
+			'facebook'  => 'post_url',
+			'bluesky'   => 'post_url',
+			'threads'   => 'post_url',
+			'pinterest' => 'pin_url',
+		);
+
+		$key = $url_keys[ $platform ] ?? 'permalink';
+
+		return (string) ( $result[ $key ] ?? '' );
+	}
+
+	/**
+	 * Record a share from a publish result using platform-aware key extraction.
+	 *
+	 * Convenience method that combines extract_* and record().
+	 *
+	 * @param int    $post_id  WordPress post ID.
+	 * @param string $platform Platform slug.
+	 * @param array  $result   Publish result from an ability.
+	 * @param array  $extra    Optional extra data.
+	 * @return bool True on success.
+	 */
+	public static function record_from_result( int $post_id, string $platform, array $result, array $extra = array() ): bool {
+		if ( empty( $result['success'] ) ) {
+			return false;
+		}
+
+		$platform_post_id = self::extract_platform_post_id( $platform, $result );
+		$platform_url     = self::extract_platform_url( $platform, $result );
+
+		// Merge media_kind from result if present.
+		if ( ! empty( $result['media_kind'] ) && empty( $extra['media_kind'] ) ) {
+			$extra['media_kind'] = $result['media_kind'];
+		}
+
+		return self::record( $post_id, $platform, $platform_post_id, $platform_url, $extra );
+	}
+
+	/**
+	 * Update the flat platforms index from the full shares array.
+	 *
+	 * Only includes platforms with at least one non-deleted share.
+	 *
+	 * @param int   $post_id WordPress post ID.
+	 * @param array $shares  Full shares array.
+	 */
+	private static function update_platforms_index( int $post_id, array $shares ): void {
+		$active_platforms = array();
+
+		foreach ( $shares as $share ) {
+			$status = $share['status'] ?? 'published';
+			if ( 'deleted' !== $status && ! empty( $share['platform'] ) ) {
+				$active_platforms[] = $share['platform'];
+			}
+		}
+
+		$active_platforms = array_values( array_unique( $active_platforms ) );
+
+		update_post_meta( $post_id, self::PLATFORMS_META_KEY, $active_platforms );
+	}
+
+	/**
+	 * Remove all share tracking data for a post.
+	 *
+	 * @param int $post_id WordPress post ID.
+	 * @return bool
+	 */
+	public static function clear( int $post_id ): bool {
+		delete_post_meta( $post_id, self::SHARES_META_KEY );
+		delete_post_meta( $post_id, self::PLATFORMS_META_KEY );
+		return true;
+	}
+}

--- a/tests/Unit/Tracking/SocialShareTrackerTest.php
+++ b/tests/Unit/Tracking/SocialShareTrackerTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * SocialShareTracker Tests
+ *
+ * Tests for the post-meta-based social share tracking system.
+ *
+ * @package DataMachineSocials\Tests\Unit\Tracking
+ */
+
+namespace DataMachineSocials\Tests\Unit\Tracking;
+
+use DataMachineSocials\Tracking\SocialShareTracker;
+use WP_UnitTestCase;
+
+class SocialShareTrackerTest extends WP_UnitTestCase {
+
+	private int $post_id;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->post_id = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
+	}
+
+	public function tear_down(): void {
+		wp_delete_post( $this->post_id, true );
+		parent::tear_down();
+	}
+
+	public function test_record_stores_share(): void {
+		$result = SocialShareTracker::record(
+			$this->post_id,
+			'instagram',
+			'media_123',
+			'https://instagram.com/p/ABC/',
+			array( 'media_kind' => 'image' )
+		);
+
+		$this->assertTrue( $result );
+
+		$shares = SocialShareTracker::get_shares( $this->post_id );
+		$this->assertCount( 1, $shares );
+		$this->assertSame( 'instagram', $shares[0]['platform'] );
+		$this->assertSame( 'media_123', $shares[0]['platform_post_id'] );
+		$this->assertSame( 'https://instagram.com/p/ABC/', $shares[0]['platform_url'] );
+		$this->assertSame( 'image', $shares[0]['media_kind'] );
+		$this->assertIsInt( $shares[0]['shared_at'] );
+	}
+
+	public function test_record_updates_platforms_index(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'id1' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'id2' );
+
+		$platforms = SocialShareTracker::get_shared_platforms( $this->post_id );
+
+		$this->assertContains( 'instagram', $platforms );
+		$this->assertContains( 'twitter', $platforms );
+		$this->assertCount( 2, $platforms );
+	}
+
+	public function test_has_been_shared(): void {
+		$this->assertFalse( SocialShareTracker::has_been_shared( $this->post_id, 'instagram' ) );
+
+		SocialShareTracker::record( $this->post_id, 'instagram', 'id1' );
+
+		$this->assertTrue( SocialShareTracker::has_been_shared( $this->post_id, 'instagram' ) );
+		$this->assertFalse( SocialShareTracker::has_been_shared( $this->post_id, 'twitter' ) );
+	}
+
+	public function test_has_any_shares(): void {
+		$this->assertFalse( SocialShareTracker::has_any_shares( $this->post_id ) );
+
+		SocialShareTracker::record( $this->post_id, 'bluesky', 'id1' );
+
+		$this->assertTrue( SocialShareTracker::has_any_shares( $this->post_id ) );
+	}
+
+	public function test_get_shares_filtered_by_platform(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1' );
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig2' );
+
+		$ig_shares = SocialShareTracker::get_shares( $this->post_id, 'instagram' );
+		$tw_shares = SocialShareTracker::get_shares( $this->post_id, 'twitter' );
+		$all       = SocialShareTracker::get_shares( $this->post_id );
+
+		$this->assertCount( 2, $ig_shares );
+		$this->assertCount( 1, $tw_shares );
+		$this->assertCount( 3, $all );
+	}
+
+	public function test_get_latest_share(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig_old', 'https://ig.com/old' );
+
+		// Simulate a later share by recording again.
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig_new', 'https://ig.com/new' );
+
+		$latest = SocialShareTracker::get_latest_share( $this->post_id, 'instagram' );
+
+		$this->assertNotNull( $latest );
+		$this->assertSame( 'ig_new', $latest['platform_post_id'] );
+	}
+
+	public function test_get_latest_share_returns_null_for_unshared(): void {
+		$this->assertNull( SocialShareTracker::get_latest_share( $this->post_id, 'instagram' ) );
+	}
+
+	public function test_mark_deleted(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1' );
+
+		$result = SocialShareTracker::mark_deleted( $this->post_id, 'instagram', 'ig1' );
+
+		$this->assertTrue( $result );
+
+		$shares = SocialShareTracker::get_shares( $this->post_id );
+		$ig     = array_values( array_filter( $shares, fn( $s ) => $s['platform'] === 'instagram' ) );
+
+		$this->assertSame( 'deleted', $ig[0]['status'] );
+		$this->assertArrayHasKey( 'deleted_at', $ig[0] );
+
+		// Platforms index should no longer include instagram (no active shares).
+		$platforms = SocialShareTracker::get_shared_platforms( $this->post_id );
+		$this->assertNotContains( 'instagram', $platforms );
+		$this->assertContains( 'twitter', $platforms );
+	}
+
+	public function test_mark_deleted_returns_false_for_unknown(): void {
+		$this->assertFalse( SocialShareTracker::mark_deleted( $this->post_id, 'instagram', 'nonexistent' ) );
+	}
+
+	public function test_count_shares(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1' );
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig2' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1' );
+
+		$this->assertSame( 3, SocialShareTracker::count_shares( $this->post_id ) );
+		$this->assertSame( 2, SocialShareTracker::count_shares( $this->post_id, 'instagram' ) );
+		$this->assertSame( 1, SocialShareTracker::count_shares( $this->post_id, 'twitter' ) );
+	}
+
+	public function test_count_shares_excludes_deleted(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1' );
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig2' );
+		SocialShareTracker::mark_deleted( $this->post_id, 'instagram', 'ig1' );
+
+		$this->assertSame( 1, SocialShareTracker::count_shares( $this->post_id, 'instagram' ) );
+		$this->assertSame( 2, SocialShareTracker::count_shares( $this->post_id, 'instagram', true ) );
+	}
+
+	public function test_clear(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1' );
+
+		SocialShareTracker::clear( $this->post_id );
+
+		$this->assertEmpty( SocialShareTracker::get_shares( $this->post_id ) );
+		$this->assertEmpty( SocialShareTracker::get_shared_platforms( $this->post_id ) );
+		$this->assertFalse( SocialShareTracker::has_any_shares( $this->post_id ) );
+	}
+
+	public function test_extract_platform_post_id(): void {
+		$this->assertSame( 'media_123', SocialShareTracker::extract_platform_post_id( 'instagram', array( 'media_id' => 'media_123' ) ) );
+		$this->assertSame( 'tweet_456', SocialShareTracker::extract_platform_post_id( 'twitter', array( 'tweet_id' => 'tweet_456' ) ) );
+		$this->assertSame( 'fb_789', SocialShareTracker::extract_platform_post_id( 'facebook', array( 'post_id' => 'fb_789' ) ) );
+		$this->assertSame( 'bsky_1', SocialShareTracker::extract_platform_post_id( 'bluesky', array( 'post_id' => 'bsky_1' ) ) );
+		$this->assertSame( 'th_2', SocialShareTracker::extract_platform_post_id( 'threads', array( 'post_id' => 'th_2' ) ) );
+		$this->assertSame( 'pin_3', SocialShareTracker::extract_platform_post_id( 'pinterest', array( 'pin_id' => 'pin_3' ) ) );
+	}
+
+	public function test_extract_platform_url(): void {
+		$this->assertSame( 'https://ig.com/p/1', SocialShareTracker::extract_platform_url( 'instagram', array( 'permalink' => 'https://ig.com/p/1' ) ) );
+		$this->assertSame( 'https://x.com/s/1', SocialShareTracker::extract_platform_url( 'twitter', array( 'tweet_url' => 'https://x.com/s/1' ) ) );
+		$this->assertSame( 'https://fb.com/p/1', SocialShareTracker::extract_platform_url( 'facebook', array( 'post_url' => 'https://fb.com/p/1' ) ) );
+	}
+
+	public function test_record_from_result_success(): void {
+		$result = array(
+			'success'    => true,
+			'media_id'   => 'ig_media_1',
+			'permalink'  => 'https://instagram.com/p/XYZ/',
+			'media_kind' => 'reel',
+		);
+
+		$recorded = SocialShareTracker::record_from_result( $this->post_id, 'instagram', $result );
+
+		$this->assertTrue( $recorded );
+
+		$shares = SocialShareTracker::get_shares( $this->post_id );
+		$this->assertCount( 1, $shares );
+		$this->assertSame( 'ig_media_1', $shares[0]['platform_post_id'] );
+		$this->assertSame( 'https://instagram.com/p/XYZ/', $shares[0]['platform_url'] );
+		$this->assertSame( 'reel', $shares[0]['media_kind'] );
+	}
+
+	public function test_record_from_result_skips_failures(): void {
+		$result = array(
+			'success' => false,
+			'error'   => 'Something went wrong',
+		);
+
+		$recorded = SocialShareTracker::record_from_result( $this->post_id, 'instagram', $result );
+
+		$this->assertFalse( $recorded );
+		$this->assertEmpty( SocialShareTracker::get_shares( $this->post_id ) );
+	}
+
+	public function test_record_rejects_empty_post_id(): void {
+		$this->assertFalse( SocialShareTracker::record( 0, 'instagram', 'id1' ) );
+	}
+
+	public function test_record_rejects_empty_platform(): void {
+		$this->assertFalse( SocialShareTracker::record( $this->post_id, '', 'id1' ) );
+	}
+
+	public function test_multiple_platforms_same_post(): void {
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1', 'https://ig.com/1' );
+		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1', 'https://x.com/1' );
+		SocialShareTracker::record( $this->post_id, 'bluesky', 'bs1', 'https://bsky.app/1' );
+		SocialShareTracker::record( $this->post_id, 'facebook', 'fb1', 'https://fb.com/1' );
+		SocialShareTracker::record( $this->post_id, 'threads', 'th1', 'https://threads.net/1' );
+		SocialShareTracker::record( $this->post_id, 'pinterest', 'pn1', 'https://pinterest.com/1' );
+
+		$all       = SocialShareTracker::get_shares( $this->post_id );
+		$platforms = SocialShareTracker::get_shared_platforms( $this->post_id );
+
+		$this->assertCount( 6, $all );
+		$this->assertCount( 6, $platforms );
+	}
+}


### PR DESCRIPTION
## Summary

Post-meta-based tracking system that records which WordPress posts have been shared to which social platforms, with per-share granularity.

## Architecture

Uses **two WordPress post meta keys** — no custom tables:

- **`_datamachine_social_shares`** — full share history (array of records with platform, platform_post_id, platform_url, media_kind, shared_at, shared_by, job_id, status)
- **`_datamachine_shared_platforms`** — flat array of active platform slugs for fast `meta_query` lookups

### API

```php
SocialShareTracker::record($post_id, 'instagram', $platform_post_id, $url, $extra);
SocialShareTracker::record_from_result($post_id, 'instagram', $ability_result);
SocialShareTracker::has_been_shared($post_id, 'instagram'): bool
SocialShareTracker::get_shares($post_id, 'twitter'): array
SocialShareTracker::get_latest_share($post_id, 'instagram'): ?array
SocialShareTracker::get_shared_platforms($post_id): string[]
SocialShareTracker::mark_deleted($post_id, 'instagram', $platform_post_id);
SocialShareTracker::count_shares($post_id, $platform, $include_deleted);
SocialShareTracker::clear($post_id);
```

Platform-aware key normalization handles the inconsistent ID/URL keys across platforms (media_id vs tweet_id vs post_id vs pin_id).

## Bug Fix

The `cross_post` normalizer was **silently dropping platform IDs and URLs** for every non-Instagram platform. It only mapped `media_id`/`permalink` (Instagram's keys), so Twitter, Facebook, Bluesky, Threads, and Pinterest results came back as `null`. Now uses the tracker's `extract_*` methods for consistent normalization.

## Changes

- **New**: `SocialShareTracker` class (`inc/Tracking/`)
- **New**: `SharesCommand` CLI — `wp datamachine-socials shares {list,check,platforms,clear}`
- **Updated**: `cross_post()` records shares via tracker on success
- **Updated**: `post_to_platform()` returns normalized `platform_post_id` + `platform_url` for all platforms
- **Updated**: `get_post_status` endpoint returns rich share history from tracker
- **Replaces**: legacy `_dms_shared_posts` meta (only stored timestamp + platform list + image count)

## Tests

20 unit tests covering: record, query, filter by platform, latest share, mark deleted, count (with/without deleted), clear, extract normalization, record_from_result, edge cases.

## Closes
- Partial progress on #13 (shared image tracking foundation)