### PR TITLE
feat: add publish chat tools + CLI commands for all platforms

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -207,8 +207,14 @@ function datamachine_socials_load_chat_tools() {
 	new \DataMachineSocials\Chat\Tools\ReadInstagram();
 	new \DataMachineSocials\Chat\Tools\UpdateInstagram();
 	new \DataMachineSocials\Chat\Tools\ReplyInstagramComment();
+	new \DataMachineSocials\Chat\Tools\PublishInstagram();
 	new \DataMachineSocials\Chat\Tools\PublishReelInstagram();
 	new \DataMachineSocials\Chat\Tools\PublishStoryInstagram();
+	new \DataMachineSocials\Chat\Tools\PublishTwitter();
+	new \DataMachineSocials\Chat\Tools\PublishFacebook();
+	new \DataMachineSocials\Chat\Tools\PublishBluesky();
+	new \DataMachineSocials\Chat\Tools\PublishThreads();
+	new \DataMachineSocials\Chat\Tools\PublishPinterest();
 	new \DataMachineSocials\Chat\Tools\ReadThreads();
 	new \DataMachineSocials\Chat\Tools\ReadFacebook();
 	new \DataMachineSocials\Chat\Tools\UpdateFacebook();

--- a/inc/Chat/Tools/PublishBluesky.php
+++ b/inc/Chat/Tools/PublishBluesky.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Publish Bluesky Chat Tool
+ *
+ * Chat tool for publishing posts to Bluesky.
+ * Wraps the datamachine/bluesky-publish ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishBluesky extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a post to Bluesky. Supports text with optional image and source URL. Requires Bluesky authentication to be configured.',
+			'parameters'  => array(
+				'content'    => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Post content text. Max 300 characters.',
+				),
+				'title'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional title for the post.',
+				),
+				'image_url'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional public URL of an image to attach.',
+				),
+				'source_url' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional source URL to embed as a link card.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_bluesky';
+
+		if ( empty( $parameters['content'] ) ) {
+			return $this->buildErrorResponse( 'content is required', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'bluesky' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Bluesky auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'bluesky',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_bluesky_auth',
+					'message'   => 'Bluesky authentication needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Bluesky is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'bluesky',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_bluesky',
+					'message'   => 'Bluesky needs to be connected. Go to Data Machine Settings > Auth > Bluesky.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'content' => sanitize_textarea_field( $parameters['content'] ),
+		);
+
+		if ( ! empty( $parameters['title'] ) ) {
+			$input['title'] = sanitize_text_field( $parameters['title'] );
+		}
+
+		if ( ! empty( $parameters['image_url'] ) ) {
+			$input['image_url'] = sanitize_url( $parameters['image_url'] );
+		}
+
+		if ( ! empty( $parameters['source_url'] ) ) {
+			$input['source_url'] = sanitize_url( $parameters['source_url'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Bluesky\BlueskyPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			return array(
+				'result'   => 'Post published to Bluesky!',
+				'post_id'  => $result['post_id'] ?? '',
+				'post_url' => $result['post_url'] ?? '',
+			);
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Bluesky publish failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/PublishFacebook.php
+++ b/inc/Chat/Tools/PublishFacebook.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Publish Facebook Chat Tool
+ *
+ * Chat tool for publishing posts to a Facebook Page.
+ * Wraps the datamachine/facebook-publish ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishFacebook extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a post to a Facebook Page. Supports text with optional image and source URL. Requires Facebook OAuth to be configured.',
+			'parameters'  => array(
+				'content'       => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Post content text.',
+				),
+				'title'         => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional title to prepend to the post content.',
+				),
+				'image_url'     => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional public URL of an image to attach to the post.',
+				),
+				'source_url'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional source URL to include in the post.',
+				),
+				'link_handling' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'How to handle the source URL: none, append (default), or comment (post as a follow-up comment).',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_facebook';
+
+		if ( empty( $parameters['content'] ) ) {
+			return $this->buildErrorResponse( 'content is required', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'facebook' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Facebook auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'facebook',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_facebook_auth',
+					'message'   => 'Facebook OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Facebook is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'facebook',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_facebook',
+					'message'   => 'Facebook OAuth needs to be connected. Go to Data Machine Settings > Auth > Facebook.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'content' => sanitize_textarea_field( $parameters['content'] ),
+		);
+
+		if ( ! empty( $parameters['title'] ) ) {
+			$input['title'] = sanitize_text_field( $parameters['title'] );
+		}
+
+		if ( ! empty( $parameters['image_url'] ) ) {
+			$input['image_url'] = sanitize_url( $parameters['image_url'] );
+		}
+
+		if ( ! empty( $parameters['source_url'] ) ) {
+			$input['source_url'] = sanitize_url( $parameters['source_url'] );
+		}
+
+		if ( ! empty( $parameters['link_handling'] ) ) {
+			$input['link_handling'] = sanitize_text_field( $parameters['link_handling'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Facebook\FacebookPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			$response = array(
+				'result'   => 'Post published to Facebook!',
+				'post_id'  => $result['post_id'] ?? '',
+				'post_url' => $result['post_url'] ?? '',
+			);
+
+			if ( ! empty( $result['comment_id'] ) ) {
+				$response['comment_id']  = $result['comment_id'];
+				$response['comment_url'] = $result['comment_url'] ?? '';
+			}
+
+			return $response;
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Facebook publish failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/PublishInstagram.php
+++ b/inc/Chat/Tools/PublishInstagram.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Publish Instagram Post Chat Tool
+ *
+ * Chat tool for publishing standard image/carousel posts to Instagram.
+ * Wraps the datamachine/instagram-publish ability with media_kind=image
+ * for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishInstagram extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a standard image or carousel post to Instagram. Requires at least one image URL and a caption. Supports up to 10 images for carousel. Requires Instagram OAuth to be configured.',
+			'parameters'  => array(
+				'caption'      => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Caption text for the post. Max 2200 characters.',
+				),
+				'image_urls'   => array(
+					'type'        => 'array',
+					'required'    => true,
+					'description' => 'Array of public image URLs to post. 1 image for single post, 2-10 for carousel.',
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
+				'aspect_ratio' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Aspect ratio for images: 1:1, 4:5, 3:4, or 1.91:1. Defaults to 4:5.',
+				),
+				'source_url'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional source URL to include at the end of the caption.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_instagram';
+
+		if ( empty( $parameters['caption'] ) ) {
+			return $this->buildErrorResponse( 'caption is required', $tool_name );
+		}
+
+		if ( empty( $parameters['image_urls'] ) || ! is_array( $parameters['image_urls'] ) ) {
+			return $this->buildErrorResponse( 'image_urls is required (array of image URLs)', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'instagram' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Instagram auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'instagram',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_instagram_auth',
+					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Instagram is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'instagram',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_instagram',
+					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'content'    => sanitize_textarea_field( $parameters['caption'] ),
+			'media_kind' => 'image',
+			'image_urls' => array_map( 'sanitize_url', $parameters['image_urls'] ),
+		);
+
+		if ( ! empty( $parameters['aspect_ratio'] ) ) {
+			$input['aspect_ratio'] = sanitize_text_field( $parameters['aspect_ratio'] );
+		}
+
+		if ( ! empty( $parameters['source_url'] ) ) {
+			$input['source_url'] = sanitize_url( $parameters['source_url'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Instagram\InstagramPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			return array(
+				'result'     => 'Post published to Instagram!',
+				'media_id'   => $result['media_id'] ?? '',
+				'media_kind' => $result['media_kind'] ?? 'image',
+				'permalink'  => $result['permalink'] ?? '',
+			);
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Instagram publish failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/PublishPinterest.php
+++ b/inc/Chat/Tools/PublishPinterest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Publish Pinterest Chat Tool
+ *
+ * Chat tool for publishing pins to Pinterest.
+ * Wraps the datamachine/pinterest-publish ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishPinterest extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a pin to Pinterest. Requires a title, description, and image URL. Optionally specify a board and destination link. Requires Pinterest OAuth to be configured.',
+			'parameters'  => array(
+				'title'       => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Pin title. Max 100 characters.',
+				),
+				'description' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Pin description. Max 500 characters.',
+				),
+				'image_url'   => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Public URL of the image for the pin.',
+				),
+				'link'        => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional destination URL the pin will link to.',
+				),
+				'board_id'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional Pinterest board ID. Uses default board if not specified.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_pinterest';
+
+		if ( empty( $parameters['title'] ) ) {
+			return $this->buildErrorResponse( 'title is required', $tool_name );
+		}
+
+		if ( empty( $parameters['description'] ) ) {
+			return $this->buildErrorResponse( 'description is required', $tool_name );
+		}
+
+		if ( empty( $parameters['image_url'] ) ) {
+			return $this->buildErrorResponse( 'image_url is required', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'pinterest' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Pinterest auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'pinterest',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_pinterest_auth',
+					'message'   => 'Pinterest OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Pinterest is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'pinterest',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_pinterest',
+					'message'   => 'Pinterest OAuth needs to be connected. Go to Data Machine Settings > Auth > Pinterest.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'title'       => sanitize_text_field( $parameters['title'] ),
+			'description' => sanitize_textarea_field( $parameters['description'] ),
+			'image_url'   => sanitize_url( $parameters['image_url'] ),
+		);
+
+		if ( ! empty( $parameters['link'] ) ) {
+			$input['link'] = sanitize_url( $parameters['link'] );
+		}
+
+		if ( ! empty( $parameters['board_id'] ) ) {
+			$input['board_id'] = sanitize_text_field( $parameters['board_id'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Pinterest\PinterestPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			return array(
+				'result'  => 'Pin published to Pinterest!',
+				'pin_id'  => $result['pin_id'] ?? '',
+				'pin_url' => $result['pin_url'] ?? '',
+			);
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Pinterest publish failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/PublishThreads.php
+++ b/inc/Chat/Tools/PublishThreads.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Publish Threads Chat Tool
+ *
+ * Chat tool for publishing posts to Threads.
+ * Wraps the datamachine/threads-publish ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishThreads extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a post to Threads. Supports text (max 500 characters) with optional image and source URL. Requires Threads OAuth to be configured.',
+			'parameters'  => array(
+				'content'    => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Post content text. Max 500 characters.',
+				),
+				'image_url'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional public URL of an image to attach to the post.',
+				),
+				'source_url' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional source URL to append to the post text.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_threads';
+
+		if ( empty( $parameters['content'] ) ) {
+			return $this->buildErrorResponse( 'content is required', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'threads' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Threads auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'threads',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_threads_auth',
+					'message'   => 'Threads OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Threads is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'threads',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_threads',
+					'message'   => 'Threads OAuth needs to be connected. Go to Data Machine Settings > Auth > Threads.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'content' => sanitize_textarea_field( $parameters['content'] ),
+		);
+
+		if ( ! empty( $parameters['image_url'] ) ) {
+			$input['image_url'] = sanitize_url( $parameters['image_url'] );
+		}
+
+		if ( ! empty( $parameters['source_url'] ) ) {
+			$input['source_url'] = sanitize_url( $parameters['source_url'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Threads\ThreadsPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			return array(
+				'result'   => 'Post published to Threads!',
+				'post_id'  => $result['post_id'] ?? '',
+				'post_url' => $result['post_url'] ?? '',
+			);
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Threads publish failed', $tool_name );
+	}
+}

--- a/inc/Chat/Tools/PublishTwitter.php
+++ b/inc/Chat/Tools/PublishTwitter.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Publish Twitter Chat Tool
+ *
+ * Chat tool for publishing tweets to Twitter/X.
+ * Wraps the datamachine/twitter-publish ability for use by the Data Machine chat agent.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.5.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class PublishTwitter extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool( 'publish_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Get tool definition for AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Publish a tweet to Twitter/X. Supports text (max 280 characters) with optional image and source URL. Requires Twitter OAuth to be configured.',
+			'parameters'  => array(
+				'content'    => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Tweet text. Max 280 characters.',
+				),
+				'source_url' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional source URL to include in or after the tweet.',
+				),
+				'link_handling' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'How to handle the source URL: append (add to tweet text) or reply (post as a reply). Defaults to append.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_name = 'publish_twitter';
+
+		if ( empty( $parameters['content'] ) ) {
+			return $this->buildErrorResponse( 'content is required', $tool_name );
+		}
+
+		// Get auth provider and check authentication.
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProvider( 'twitter' );
+
+		if ( ! $provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Twitter auth provider not available',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'twitter',
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_twitter_auth',
+					'message'   => 'Twitter OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( ! $provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				'Twitter is not authenticated',
+				'prerequisite_missing',
+				$tool_name,
+				array(
+					'provider' => 'twitter',
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_twitter',
+					'message'   => 'Twitter OAuth needs to be connected. Go to Data Machine Settings > Auth > Twitter.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		// Build ability input.
+		$input = array(
+			'content' => sanitize_textarea_field( $parameters['content'] ),
+		);
+
+		if ( ! empty( $parameters['source_url'] ) ) {
+			$input['source_url'] = sanitize_url( $parameters['source_url'] );
+		}
+
+		if ( ! empty( $parameters['link_handling'] ) ) {
+			$input['link_handling'] = sanitize_text_field( $parameters['link_handling'] );
+		}
+
+		// Execute via the publish ability.
+		$result = \DataMachineSocials\Abilities\Twitter\TwitterPublishAbility::execute_publish( $input );
+
+		if ( $result['success'] ) {
+			$response = array(
+				'result'    => 'Tweet published to Twitter!',
+				'tweet_id'  => $result['tweet_id'] ?? '',
+				'tweet_url' => $result['tweet_url'] ?? '',
+			);
+
+			if ( ! empty( $result['reply_tweet_id'] ) ) {
+				$response['reply_tweet_id']  = $result['reply_tweet_id'];
+				$response['reply_tweet_url'] = $result['reply_tweet_url'] ?? '';
+			}
+
+			return $response;
+		}
+
+		return $this->buildErrorResponse( $result['error'] ?? 'Twitter publish failed', $tool_name );
+	}
+}

--- a/inc/Cli/Commands/FacebookCommand.php
+++ b/inc/Cli/Commands/FacebookCommand.php
@@ -267,6 +267,92 @@ class FacebookCommand {
 		}
 	}
 
+	/**
+	 * Publish a post to Facebook.
+	 *
+	 * Posts content to a Facebook Page with optional image and source URL.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <content>
+	 * : The post content text.
+	 *
+	 * [--title=<title>]
+	 * : Optional title to prepend to the post.
+	 *
+	 * [--image=<url>]
+	 * : Image URL to attach to the post.
+	 *
+	 * [--source-url=<url>]
+	 * : Source URL to include in the post.
+	 *
+	 * [--link-handling=<handling>]
+	 * : How to handle the source URL: none, append (default), or comment.
+	 * ---
+	 * default: append
+	 * options:
+	 *   - none
+	 *   - append
+	 *   - comment
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Simple text post
+	 *     wp datamachine-socials facebook publish "Check out our latest article!"
+	 *
+	 *     # Post with image
+	 *     wp datamachine-socials facebook publish "New photo from the show" --image=https://example.com/photo.jpg
+	 *
+	 *     # Post with source URL as comment
+	 *     wp datamachine-socials facebook publish "Great read" --source-url=https://extrachill.com/article --link-handling=comment
+	 */
+	public function publish( $args, $assoc_args ) {
+		$content = $args[0] ?? '';
+
+		if ( empty( $content ) ) {
+			WP_CLI::error( 'Post content is required.' );
+		}
+
+		$this->get_publish_ability();
+
+		$input = array( 'content' => $content );
+
+		if ( ! empty( $assoc_args['title'] ) ) {
+			$input['title'] = $assoc_args['title'];
+		}
+
+		if ( ! empty( $assoc_args['image'] ) ) {
+			$input['image_url'] = $assoc_args['image'];
+			WP_CLI::log( 'Publishing to Facebook with image...' );
+		} else {
+			WP_CLI::log( 'Publishing to Facebook...' );
+		}
+
+		if ( ! empty( $assoc_args['source-url'] ) ) {
+			$input['source_url'] = $assoc_args['source-url'];
+		}
+
+		if ( ! empty( $assoc_args['link-handling'] ) ) {
+			$input['link_handling'] = $assoc_args['link-handling'];
+		}
+
+		$result = \DataMachineSocials\Abilities\Facebook\FacebookPublishAbility::execute_publish( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		WP_CLI::success( 'Published to Facebook!' );
+		WP_CLI::log( 'Post ID:  ' . ( $result['post_id'] ?? '' ) );
+		WP_CLI::log( 'Post URL: ' . ( $result['post_url'] ?? '' ) );
+
+		if ( ! empty( $result['comment_id'] ) ) {
+			WP_CLI::log( 'Comment ID:  ' . $result['comment_id'] );
+			WP_CLI::log( 'Comment URL: ' . ( $result['comment_url'] ?? '' ) );
+		}
+	}
+
 	private function get_ability() {
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
@@ -301,6 +387,19 @@ class FacebookCommand {
 		$ability = wp_get_ability( 'datamachine/facebook-delete' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'datamachine/facebook-delete ability not registered.' );
+		}
+
+		return $ability;
+	}
+
+	private function get_publish_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/facebook-publish' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/facebook-publish ability not registered.' );
 		}
 
 		return $ability;

--- a/inc/Cli/Commands/PinterestCommand.php
+++ b/inc/Cli/Commands/PinterestCommand.php
@@ -280,6 +280,81 @@ class PinterestCommand {
 	}
 
 	/**
+	 * Publish a pin to Pinterest.
+	 *
+	 * Creates a new pin with a title, description, and image.
+	 * Requires Pinterest OAuth to be configured.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <title>
+	 * : Pin title (max 100 characters).
+	 *
+	 * --description=<text>
+	 * : Pin description (max 500 characters, required).
+	 *
+	 * --image=<url>
+	 * : Public URL of the image for the pin (required).
+	 *
+	 * [--link=<url>]
+	 * : Destination URL the pin will link to.
+	 *
+	 * [--board=<board_id>]
+	 * : Pinterest board ID. Uses default board if not specified.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Publish a pin
+	 *     wp datamachine-socials pinterest publish "Beautiful sunset" --description="Sunset at Lady Bird Lake" --image=https://example.com/sunset.jpg
+	 *
+	 *     # Pin with link and specific board
+	 *     wp datamachine-socials pinterest publish "New Recipe" --description="Easy pasta recipe" --image=https://example.com/pasta.jpg --link=https://example.com/recipes/pasta --board=123456789
+	 */
+	public function publish( $args, $assoc_args ) {
+		$title = $args[0] ?? '';
+
+		if ( empty( $title ) ) {
+			WP_CLI::error( 'Pin title is required.' );
+		}
+
+		if ( empty( $assoc_args['description'] ) ) {
+			WP_CLI::error( 'Pin description is required. Use --description=<text>.' );
+		}
+
+		if ( empty( $assoc_args['image'] ) ) {
+			WP_CLI::error( 'Image URL is required. Use --image=<url>.' );
+		}
+
+		$this->get_publish_ability();
+
+		$input = array(
+			'title'       => $title,
+			'description' => $assoc_args['description'],
+			'image_url'   => $assoc_args['image'],
+		);
+
+		if ( ! empty( $assoc_args['link'] ) ) {
+			$input['link'] = $assoc_args['link'];
+		}
+
+		if ( ! empty( $assoc_args['board'] ) ) {
+			$input['board_id'] = $assoc_args['board'];
+		}
+
+		WP_CLI::log( 'Publishing pin to Pinterest...' );
+
+		$result = \DataMachineSocials\Abilities\Pinterest\PinterestPublishAbility::execute_publish( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		WP_CLI::success( 'Pin published to Pinterest!' );
+		WP_CLI::log( 'Pin ID:  ' . ( $result['pin_id'] ?? '' ) );
+		WP_CLI::log( 'Pin URL: ' . ( $result['pin_url'] ?? '' ) );
+	}
+
+	/**
 	 * Get the Pinterest read ability.
 	 *
 	 * @return \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility
@@ -318,6 +393,19 @@ class PinterestCommand {
 		$ability = wp_get_ability( 'datamachine/pinterest-delete' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'datamachine/pinterest-delete ability not registered.' );
+		}
+
+		return $ability;
+	}
+
+	private function get_publish_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/pinterest-publish' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/pinterest-publish ability not registered.' );
 		}
 
 		return $ability;

--- a/inc/Cli/Commands/ThreadsCommand.php
+++ b/inc/Cli/Commands/ThreadsCommand.php
@@ -266,6 +266,67 @@ class ThreadsCommand {
 		}
 	}
 
+	/**
+	 * Publish a post to Threads.
+	 *
+	 * Posts content to Threads with optional image and source URL.
+	 * Max 500 characters.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <content>
+	 * : The post content text (max 500 characters).
+	 *
+	 * [--image=<url>]
+	 * : Public URL of an image to attach.
+	 *
+	 * [--source-url=<url>]
+	 * : Source URL to append to the post text.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Simple text post
+	 *     wp datamachine-socials threads publish "New article just dropped!"
+	 *
+	 *     # Post with image
+	 *     wp datamachine-socials threads publish "Check this out" --image=https://example.com/photo.jpg
+	 *
+	 *     # Post with source URL
+	 *     wp datamachine-socials threads publish "Read the full review" --source-url=https://extrachill.com/review
+	 */
+	public function publish( $args, $assoc_args ) {
+		$content = $args[0] ?? '';
+
+		if ( empty( $content ) ) {
+			WP_CLI::error( 'Post content is required.' );
+		}
+
+		$this->get_publish_ability();
+
+		$input = array( 'content' => $content );
+
+		if ( ! empty( $assoc_args['image'] ) ) {
+			$input['image_url'] = $assoc_args['image'];
+			WP_CLI::log( 'Publishing to Threads with image...' );
+		} else {
+			WP_CLI::log( 'Publishing to Threads...' );
+		}
+
+		if ( ! empty( $assoc_args['source-url'] ) ) {
+			$input['source_url'] = $assoc_args['source-url'];
+		}
+
+		$result = \DataMachineSocials\Abilities\Threads\ThreadsPublishAbility::execute_publish( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] );
+		}
+
+		WP_CLI::success( 'Published to Threads!' );
+		WP_CLI::log( 'Post ID:  ' . ( $result['post_id'] ?? '' ) );
+		WP_CLI::log( 'Post URL: ' . ( $result['post_url'] ?? '' ) );
+	}
+
 	private function get_ability() {
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
@@ -300,6 +361,19 @@ class ThreadsCommand {
 		$ability = wp_get_ability( 'datamachine/threads-delete' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'datamachine/threads-delete ability not registered.' );
+		}
+
+		return $ability;
+	}
+
+	private function get_publish_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
+		}
+
+		$ability = wp_get_ability( 'datamachine/threads-publish' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/threads-publish ability not registered.' );
 		}
 
 		return $ability;


### PR DESCRIPTION
## Summary

- Add **6 new publish chat tools** so AI agents can publish to every platform directly from chat
- Add **3 CLI publish commands** for the platforms that were missing them (Facebook, Threads, Pinterest)

## Chat Tools Added

| Tool | Platform | What it does |
|---|---|---|
| `publish_instagram` | Instagram | Standard image/carousel posts (1-10 images) |
| `publish_twitter` | Twitter/X | Tweets with optional source URL and link handling |
| `publish_facebook` | Facebook | Page posts with optional image, title, and link handling |
| `publish_bluesky` | Bluesky | Posts with optional image and link card |
| `publish_threads` | Threads | Posts with optional image (max 500 chars) |
| `publish_pinterest` | Pinterest | Pins with title, description, image, optional board and link |

## CLI Commands Added

- `wp datamachine-socials facebook publish`
- `wp datamachine-socials threads publish`
- `wp datamachine-socials pinterest publish`

## Before/After

**Before:** Chat could only read/update/delete. Publishing limited to Instagram Reel + Story chat tools. CLI had publish for Instagram, Twitter, Bluesky only.

**After:** Full publish parity across all 6 publishing platforms for both chat tools and CLI.

Relates to #37