### PR TITLE
feat: add homeboy-action v2 CI pipeline

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -1,0 +1,34 @@
+name: Homeboy
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  homeboy:
+    name: Homeboy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: Extra-Chill/homeboy-action@v2
+        with:
+          app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/homeboy.json
+++ b/homeboy.json
@@ -2,7 +2,10 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "php": "8.2",
+      "node": "20"
+    }
   },
   "id": "data-machine-socials",
   "remote_path": "wp-content/plugins/data-machine-socials",


### PR DESCRIPTION
## Summary

First CI pipeline for this repo. Uses homeboy-action v2 — the action infers everything from `homeboy.json`.

## Changes
- **Added** `.github/workflows/homeboy.yml` (35 lines)
- **Updated** `homeboy.json` with `php: "8.2"` and `node: "20"` in extensions config
- No MySQL service needed — `database_type` defaults to `auto` (SQLite fallback)

## What you get
- PR checks: scoped `audit`, `lint`, `test`
- Push-to-main: full `audit`, `lint`, `test` with auto-issue filing
- Tag push: full quality gate
- Autofix: auto-enabled when homeboy-ci app token is available

## Depends on
- Extra-Chill/homeboy-action `feat/v2-convention-driven` (must be merged and tagged as v2 first)