### PR TITLE
feat: fold auth status into /platforms, add LinkedIn

### DIFF
--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -728,7 +728,7 @@ class RestApi {
 
 		$statuses = array();
 
-		$platforms = array( 'instagram', 'twitter', 'facebook', 'bluesky', 'threads', 'pinterest', 'reddit' );
+		$platforms = array( 'instagram', 'twitter', 'facebook', 'bluesky', 'threads', 'pinterest', 'linkedin', 'reddit' );
 
 		foreach ( $platforms as $platform ) {
 			$provider = $providers[ $platform ] ?? null;
@@ -744,10 +744,12 @@ class RestApi {
 	}
 
 	/**
-	 * Get platform configurations
+	 * Get platform configurations with auth status.
+	 *
+	 * Returns every registered platform's config plus its current
+	 * `authenticated` and `username` fields so callers need only one request.
 	 */
 	public static function get_platforms() {
-		// Return platform configurations from registry
 		$platforms = array(
 			'instagram' => array(
 				'label'              => 'Instagram',
@@ -799,6 +801,14 @@ class RestApi {
 				'charLimit'          => 500,
 				'supportsCarousel'   => false,
 			),
+			'linkedin'  => array(
+				'label'              => 'LinkedIn',
+				'maxImages'          => 9,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'charLimit'          => 3000,
+				'supportsCarousel'   => false,
+			),
 			'reddit'    => array(
 				'label'     => 'Reddit',
 				'type'      => 'fetch',
@@ -806,6 +816,17 @@ class RestApi {
 				'scopes'    => 'identity read',
 			),
 		);
+
+		// Fold auth status into each platform entry.
+		$auth_abilities = new AuthAbilities();
+		$providers      = $auth_abilities->getAllProviders();
+
+		foreach ( $platforms as $slug => &$config ) {
+			$provider              = $providers[ $slug ] ?? null;
+			$config['authenticated'] = $provider ? $provider->is_authenticated() : false;
+			$config['username']      = $provider ? $provider->get_username() : null;
+		}
+		unset( $config );
 
 		return new \WP_REST_Response( $platforms );
 	}


### PR DESCRIPTION
## Summary

- **`/platforms` endpoint now includes `authenticated` and `username`** per platform, so callers get config + auth in one request
- **Adds LinkedIn** to the platforms config (was missing despite handler being added in v0.5.0)
- **Adds LinkedIn to `/auth/status`** list for backward compat
- `/auth/status` endpoint is unchanged and still works for existing consumers (DM Socials sidebar)

## Why

Studio was making two round trips (`/platforms` + `/auth/status`) to render the socials overview. These are the same permission level, same data source — no reason they should be separate requests.

## Merge order

1. **This PR first** (backend)
2. `extrachill-api-client` — type update
3. `extrachill-studio` — frontend update