### PR TITLE
refactor: dynamic platform registry via handler $meta

### DIFF
--- a/inc/Handlers/Bluesky/Bluesky.php
+++ b/inc/Handlers/Bluesky/Bluesky.php
@@ -57,7 +57,14 @@ class Bluesky extends PublishHandler {
 				}
 				return $tools;
 			},
-			'bluesky'
+			'bluesky',
+			array(
+				'charLimit'          => 300,
+				'maxImages'          => 4,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'supportsCarousel'   => false,
+			)
 		);
 	}
 

--- a/inc/Handlers/Facebook/Facebook.php
+++ b/inc/Handlers/Facebook/Facebook.php
@@ -66,7 +66,14 @@ class Facebook extends PublishHandler {
 				}
 				return $tools;
 			},
-			'facebook'
+			'facebook',
+			array(
+				'charLimit'          => 63206,
+				'maxImages'          => 10,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'supportsCarousel'   => true,
+			)
 		);
 	}
 

--- a/inc/Handlers/Instagram/Instagram.php
+++ b/inc/Handlers/Instagram/Instagram.php
@@ -82,7 +82,16 @@ class Instagram extends PublishHandler {
 				}
 				return $tools;
 			},
-			'instagram'
+			'instagram',
+			array(
+				'charLimit'          => 2200,
+				'maxImages'          => 10,
+				'aspectRatios'       => array( '1:1', '4:5', '3:4', '1.91:1' ),
+				'defaultAspectRatio' => '4:5',
+				'supportsCarousel'   => true,
+				'supportsVideo'      => true,
+				'supportedMediaKinds' => array( 'image', 'carousel', 'reel', 'story' ),
+			)
 		);
 	}
 

--- a/inc/Handlers/LinkedIn/LinkedIn.php
+++ b/inc/Handlers/LinkedIn/LinkedIn.php
@@ -69,7 +69,14 @@ class LinkedIn extends PublishHandler {
 				}
 				return $tools;
 			},
-			'linkedin'
+			'linkedin',
+			array(
+				'charLimit'          => 3000,
+				'maxImages'          => 9,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'supportsCarousel'   => false,
+			)
 		);
 	}
 

--- a/inc/Handlers/Pinterest/Pinterest.php
+++ b/inc/Handlers/Pinterest/Pinterest.php
@@ -92,7 +92,14 @@ class Pinterest extends PublishHandler {
 				}
 				return $tools;
 			},
-			'pinterest'
+			'pinterest',
+			array(
+				'charLimit'          => 500,
+				'maxImages'          => 1,
+				'aspectRatios'       => array( '2:3' ),
+				'defaultAspectRatio' => '2:3',
+				'supportsCarousel'   => false,
+			)
 		);
 	}
 

--- a/inc/Handlers/Reddit/Reddit.php
+++ b/inc/Handlers/Reddit/Reddit.php
@@ -41,7 +41,12 @@ class Reddit extends FetchHandler {
 			true,
 			RedditAuth::class,
 			RedditSettings::class,
-			null
+			null,
+			null,
+			array(
+				'charLimit' => 40000,
+				'scopes'    => 'identity read',
+			)
 		);
 	}
 

--- a/inc/Handlers/Threads/Threads.php
+++ b/inc/Handlers/Threads/Threads.php
@@ -66,7 +66,14 @@ class Threads extends PublishHandler {
 				}
 				return $tools;
 			},
-			'threads'
+			'threads',
+			array(
+				'charLimit'          => 500,
+				'maxImages'          => 10,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'supportsCarousel'   => true,
+			)
 		);
 	}
 

--- a/inc/Handlers/Twitter/Twitter.php
+++ b/inc/Handlers/Twitter/Twitter.php
@@ -68,7 +68,14 @@ class Twitter extends PublishHandler {
 				}
 				return $tools;
 			},
-			'twitter'
+			'twitter',
+			array(
+				'charLimit'          => 280,
+				'maxImages'          => 4,
+				'aspectRatios'       => array( 'any' ),
+				'defaultAspectRatio' => 'any',
+				'supportsCarousel'   => false,
+			)
 		);
 	}
 

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -699,10 +699,81 @@ class RestApi {
 	}
 
 	/**
-	 * Check if user can edit posts
+	 * Get authentication status for all social platforms.
+	 *
+	 * Kept for backward compatibility. Prefer GET /platforms which
+	 * returns auth status alongside platform config in one response.
 	 */
-	public static function check_edit_permission() {
-		return current_user_can( 'edit_posts' );
+	public static function get_auth_status() {
+		$auth_abilities = new AuthAbilities();
+		$providers      = $auth_abilities->getAllProviders();
+
+		$statuses = array();
+
+		foreach ( $providers as $key => $provider ) {
+			// Only include social auth providers (from this plugin's namespace).
+			if ( strpos( get_class( $provider ), 'DataMachineSocials\\' ) === false ) {
+				continue;
+			}
+
+			$statuses[] = array(
+				'platform'      => $key,
+				'authenticated' => $provider->is_authenticated(),
+				'username'      => $provider->get_username(),
+			);
+		}
+
+		return new \WP_REST_Response( $statuses );
+	}
+
+	/**
+	 * Get platform configurations with auth status.
+	 *
+	 * Assembles from DM core's handler registry — each social handler
+	 * self-declares its constraints via the $meta parameter in registerHandler().
+	 * Auth status is folded in from the auth providers filter.
+	 */
+	public static function get_platforms() {
+		$handler_abilities = new \DataMachine\Abilities\HandlerAbilities();
+		$auth_abilities    = new AuthAbilities();
+		$providers         = $auth_abilities->getAllProviders();
+
+		// Get all handlers that registered via HandlerRegistrationTrait.
+		$all_handlers = $handler_abilities->getAllHandlers();
+
+		$platforms = array();
+
+		foreach ( $all_handlers as $slug => $handler ) {
+			$auth_key = $handler['auth_provider_key'] ?? $slug;
+			$provider = $providers[ $auth_key ] ?? null;
+
+			// Skip handlers without an auth provider.
+			if ( ! $provider ) {
+				continue;
+			}
+
+			// Only include handlers whose auth provider is from this plugin.
+			$provider_class = get_class( $provider );
+			if ( strpos( $provider_class, 'DataMachineSocials\\' ) === false ) {
+				continue;
+			}
+
+			$meta = $handler['meta'] ?? array();
+
+			$platforms[ $auth_key ] = array_merge(
+				array(
+					'label' => $handler['label'] ?? $auth_key,
+					'type'  => $handler['type'] ?? 'publish',
+				),
+				$meta,
+				array(
+					'authenticated' => $provider->is_authenticated(),
+					'username'      => $provider->get_username(),
+				)
+			);
+		}
+
+		return new \WP_REST_Response( $platforms );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up to #89. Replaces the remaining hardcoded platform arrays with dynamic assembly from DM core's handler registry.

- **8 handlers** now pass `$meta` (charLimit, maxImages, aspectRatios, etc.) to `registerHandler()`
- **`/platforms`** assembles from `HandlerAbilities::getAllHandlers()` + auth providers, filtered by `DataMachineSocials\` namespace
- **`/auth/status`** also dynamic — iterates providers, same namespace filter
- Zero hardcoded platform lists remain

## Depends on

- `Extra-Chill/data-machine#915` ✅ (merged — `$meta` param in core)