### PR TITLE
feat: add global search to Reddit fetch

### DIFF
--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -45,11 +45,17 @@ class FetchRedditAbility {
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'subreddit', 'access_token' ),
+						'required'   => array( 'access_token' ),
 						'properties' => array(
 							'subreddit'         => array(
 								'type'        => 'string',
-								'description' => __( 'Subreddit name to fetch from', 'data-machine-socials' ),
+								'default'     => '',
+								'description' => __( 'Subreddit name to fetch from. Optional when query is provided for global search.', 'data-machine-socials' ),
+							),
+							'query'             => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Search query for Reddit global search. When provided without subreddit, searches across all of Reddit. Can also be combined with subreddit to search within it.', 'data-machine-socials' ),
 							),
 							'access_token'      => array(
 								'type'        => 'string',
@@ -57,9 +63,9 @@ class FetchRedditAbility {
 							),
 							'sort_by'           => array(
 								'type'        => 'string',
-								'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial' ),
+								'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' ),
 								'default'     => 'hot',
-								'description' => __( 'Sort order for posts', 'data-machine-socials' ),
+								'description' => __( 'Sort order for posts. Use "relevance" for global search.', 'data-machine-socials' ),
 							),
 							'timeframe_limit'   => array(
 								'type'        => 'string',
@@ -154,6 +160,7 @@ class FetchRedditAbility {
 		$config = $this->normalizeConfig( $input );
 
 		$subreddit             = $config['subreddit'];
+		$query                 = $config['query'];
 		$access_token          = $config['access_token'];
 		$sort                  = $config['sort_by'];
 		$timeframe_limit       = $config['timeframe_limit'];
@@ -166,7 +173,24 @@ class FetchRedditAbility {
 		$max_pages             = $config['max_pages'];
 		$download_images       = $config['download_images'];
 
-		if ( ! preg_match( '/^[a-zA-Z0-9_]+$/', $subreddit ) ) {
+		// Determine mode: global search vs subreddit fetch.
+		$is_global_search = ! empty( $query ) && empty( $subreddit );
+		$is_subreddit_search = ! empty( $query ) && ! empty( $subreddit );
+
+		// Validate: must have either subreddit or query.
+		if ( empty( $subreddit ) && empty( $query ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'Reddit: Either subreddit or query must be provided.',
+			);
+			return array(
+				'success' => false,
+				'error'   => 'Either subreddit or query must be provided',
+				'logs'    => $logs,
+			);
+		}
+
+		if ( ! empty( $subreddit ) && ! preg_match( '/^[a-zA-Z0-9_]+$/', $subreddit ) ) {
 			$logs[] = array(
 				'level'   => 'error',
 				'message' => 'Reddit: Invalid subreddit name format.',
@@ -179,7 +203,7 @@ class FetchRedditAbility {
 			);
 		}
 
-		$valid_sorts = array( 'hot', 'new', 'top', 'rising', 'controversial' );
+		$valid_sorts = array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' );
 		if ( ! in_array( $sort, $valid_sorts, true ) ) {
 			$logs[] = array(
 				'level'   => 'error',
@@ -196,6 +220,17 @@ class FetchRedditAbility {
 			);
 		}
 
+		$mode_label = $is_global_search ? 'global search' : ( $is_subreddit_search ? "r/{$subreddit} search" : "r/{$subreddit}" );
+		$logs[]     = array(
+			'level'   => 'info',
+			'message' => sprintf( 'Reddit: Starting fetch (%s, sort: %s).', $mode_label, $sort ),
+			'data'    => array(
+				'subreddit'       => $subreddit,
+				'query'           => $query,
+				'is_global_search' => $is_global_search,
+			),
+		);
+
 		$after_param    = null;
 		$total_checked  = 0;
 		$pages_fetched  = 0;
@@ -204,35 +239,16 @@ class FetchRedditAbility {
 		while ( $pages_fetched < $max_pages ) {
 			++$pages_fetched;
 
-			$time_param = '';
-			if ( in_array( $sort, array( 'top', 'controversial' ), true ) && 'all_time' !== $timeframe_limit ) {
-				$reddit_time_map = array(
-					'24_hours' => 'day',
-					'72_hours' => 'week',
-					'7_days'   => 'week',
-					'30_days'  => 'month',
-				);
-				if ( isset( $reddit_time_map[ $timeframe_limit ] ) ) {
-					$time_param = '&t=' . $reddit_time_map[ $timeframe_limit ];
-					$logs[]     = array(
-						'level'   => 'debug',
-						'message' => 'Reddit: Using native API time filtering.',
-						'data'    => array(
-							'sort'              => $sort,
-							'timeframe_limit'   => $timeframe_limit,
-							'reddit_time_param' => $reddit_time_map[ $timeframe_limit ],
-						),
-					);
-				}
-			}
-
-			$reddit_url = sprintf(
-				'https://oauth.reddit.com/r/%s/%s.json?limit=%d%s%s',
-				esc_attr( $subreddit ),
-				esc_attr( $sort ),
+			$reddit_url = $this->buildApiUrl(
+				$subreddit,
+				$query,
+				$sort,
+				$timeframe_limit,
 				$fetch_batch_size,
-				$after_param ? '&after=' . urlencode( $after_param ) : '',
-				$time_param
+				$after_param,
+				$is_global_search,
+				$is_subreddit_search,
+				$logs
 			);
 
 			$headers = array(
@@ -324,7 +340,7 @@ class FetchRedditAbility {
 					$logs[] = array(
 						'level'   => 'warning',
 						'message' => 'Reddit: Skipping post with missing data.',
-						'data'    => array( 'subreddit' => $subreddit ),
+						'data'    => array( 'context' => $mode_label ),
 					);
 					continue;
 				}
@@ -415,13 +431,16 @@ class FetchRedditAbility {
 					$image_info = $this->extractImageInfo( $item_data );
 				}
 
+				// Use the post's own subreddit (important for global search results).
+				$post_subreddit = $item_data['subreddit'] ?? $subreddit;
+
 				$metadata = array(
 					'source_type'            => 'reddit',
 					'item_identifier_to_log' => (string) $current_item_id,
 					'original_id'            => $current_item_id,
 					'original_title'         => $title,
 					'original_date_gmt'      => gmdate( 'Y-m-d\TH:i:s\Z', (int) ( $item_data['created_utc'] ?? time() ) ),
-					'subreddit'              => $subreddit,
+					'subreddit'              => $post_subreddit,
 					'upvotes'                => $item_data['score'] ?? 0,
 					'comment_count'          => $item_data['num_comments'] ?? 0,
 					'author'                 => $item_data['author'] ?? '[deleted]',
@@ -524,6 +543,7 @@ class FetchRedditAbility {
 	private function normalizeConfig( array $input ): array {
 		$defaults = array(
 			'subreddit'         => '',
+			'query'             => '',
 			'access_token'      => '',
 			'sort_by'           => 'hot',
 			'timeframe_limit'   => 'all_time',
@@ -538,6 +558,108 @@ class FetchRedditAbility {
 		);
 
 		return array_merge( $defaults, $input );
+	}
+
+	/**
+	 * Build the Reddit API URL based on mode (subreddit browse, subreddit search, or global search).
+	 *
+	 * @param string      $subreddit           Subreddit name (empty for global search).
+	 * @param string      $query               Search query (empty for subreddit browse).
+	 * @param string      $sort                Sort order.
+	 * @param string      $timeframe_limit     Timeframe filter.
+	 * @param int         $fetch_batch_size    Number of posts per page.
+	 * @param string|null $after_param         Pagination cursor.
+	 * @param bool        $is_global_search    Whether this is a global search.
+	 * @param bool        $is_subreddit_search Whether this is a search within a subreddit.
+	 * @param array       &$logs               Log entries array (passed by reference).
+	 * @return string The full Reddit API URL.
+	 */
+	private function buildApiUrl(
+		string $subreddit,
+		string $query,
+		string $sort,
+		string $timeframe_limit,
+		int $fetch_batch_size,
+		?string $after_param,
+		bool $is_global_search,
+		bool $is_subreddit_search,
+		array &$logs
+	): string {
+		$base = 'https://oauth.reddit.com';
+
+		// Map our timeframe values to Reddit's native 't' parameter.
+		$reddit_time_map = array(
+			'24_hours' => 'day',
+			'72_hours' => 'week',
+			'7_days'   => 'week',
+			'30_days'  => 'month',
+			'90_days'  => 'year',
+			'6_months' => 'year',
+			'1_year'   => 'year',
+		);
+
+		if ( $is_global_search || $is_subreddit_search ) {
+			// Search endpoint: /search.json or /r/{subreddit}/search.json
+			$params = array(
+				'q'     => $query,
+				'type'  => 'link',
+				'sort'  => $sort,
+				'limit' => $fetch_batch_size,
+			);
+
+			// Reddit search uses 't' for time filtering on all sort types.
+			if ( 'all_time' !== $timeframe_limit && isset( $reddit_time_map[ $timeframe_limit ] ) ) {
+				$params['t'] = $reddit_time_map[ $timeframe_limit ];
+				$logs[]      = array(
+					'level'   => 'debug',
+					'message' => 'Reddit: Using native search time filtering.',
+					'data'    => array(
+						'timeframe_limit'   => $timeframe_limit,
+						'reddit_time_param' => $reddit_time_map[ $timeframe_limit ],
+					),
+				);
+			}
+
+			if ( $is_subreddit_search ) {
+				$params['restrict_sr'] = 'on';
+				$endpoint              = "/r/{$subreddit}/search.json";
+			} else {
+				$endpoint = '/search.json';
+			}
+
+			if ( $after_param ) {
+				$params['after'] = $after_param;
+			}
+
+			return $base . $endpoint . '?' . http_build_query( $params );
+		}
+
+		// Subreddit browse: /r/{subreddit}/{sort}.json
+		$time_param = '';
+		if ( in_array( $sort, array( 'top', 'controversial' ), true ) && 'all_time' !== $timeframe_limit ) {
+			if ( isset( $reddit_time_map[ $timeframe_limit ] ) ) {
+				$time_param = '&t=' . $reddit_time_map[ $timeframe_limit ];
+				$logs[]     = array(
+					'level'   => 'debug',
+					'message' => 'Reddit: Using native API time filtering.',
+					'data'    => array(
+						'sort'              => $sort,
+						'timeframe_limit'   => $timeframe_limit,
+						'reddit_time_param' => $reddit_time_map[ $timeframe_limit ],
+					),
+				);
+			}
+		}
+
+		return sprintf(
+			'%s/r/%s/%s.json?limit=%d%s%s',
+			$base,
+			esc_attr( $subreddit ),
+			esc_attr( $sort ),
+			$fetch_batch_size,
+			$after_param ? '&after=' . urlencode( $after_param ) : '',
+			$time_param
+		);
 	}
 
 	/**

--- a/inc/Chat/Tools/FetchReddit.php
+++ b/inc/Chat/Tools/FetchReddit.php
@@ -32,18 +32,23 @@ class FetchReddit extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Fetch a post from a Reddit subreddit. Returns the first eligible post matching filters (upvotes, comments, timeframe, keywords). Requires Reddit OAuth to be configured.',
+			'description' => 'Fetch posts from Reddit. Provide a subreddit to browse it, or a query to search across all of Reddit. Both can be combined to search within a subreddit. Returns eligible posts matching filters (upvotes, comments, timeframe, keywords). Requires Reddit OAuth to be configured.',
 			'parameters'  => array(
 				'subreddit'         => array(
 					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Subreddit name to fetch from (without "r/", e.g. "jambands", "festivals")',
+					'required'    => false,
+					'description' => 'Subreddit name to fetch from (without "r/", e.g. "jambands", "festivals"). Optional when query is provided.',
+				),
+				'query'             => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Search query. Without subreddit, searches all of Reddit. With subreddit, searches within it.',
 				),
 				'sort_by'           => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Sort order: hot, new, top, rising, controversial',
-					'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial' ),
+					'description' => 'Sort order: hot, new, top, rising, controversial, relevance. Use "relevance" for search queries.',
+					'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' ),
 				),
 				'timeframe_limit'   => array(
 					'type'        => 'string',
@@ -84,9 +89,9 @@ class FetchReddit extends BaseTool {
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
 		$tool_name = 'fetch_reddit';
 
-		// Validate subreddit.
-		if ( empty( $parameters['subreddit'] ) ) {
-			return $this->buildErrorResponse( 'subreddit parameter is required', $tool_name );
+		// Validate: must have subreddit or query.
+		if ( empty( $parameters['subreddit'] ) && empty( $parameters['query'] ) ) {
+			return $this->buildErrorResponse( 'Either subreddit or query parameter is required', $tool_name );
 		}
 
 		// Get auth provider and valid token.
@@ -154,11 +159,16 @@ class FetchReddit extends BaseTool {
 			return $this->buildErrorResponse( 'datamachine/fetch-reddit ability not registered', $tool_name );
 		}
 
+		// Default sort to 'relevance' for search queries.
+		$has_query    = ! empty( $parameters['query'] );
+		$default_sort = $has_query ? 'relevance' : 'hot';
+
 		// Build ability input.
 		$input = array(
-			'subreddit'         => sanitize_text_field( $parameters['subreddit'] ),
+			'subreddit'         => sanitize_text_field( $parameters['subreddit'] ?? '' ),
+			'query'             => sanitize_text_field( $parameters['query'] ?? '' ),
 			'access_token'      => $access_token,
-			'sort_by'           => $parameters['sort_by'] ?? 'hot',
+			'sort_by'           => $parameters['sort_by'] ?? $default_sort,
 			'timeframe_limit'   => $parameters['timeframe_limit'] ?? 'all_time',
 			'min_upvotes'       => absint( $parameters['min_upvotes'] ?? 0 ),
 			'min_comment_count' => absint( $parameters['min_comment_count'] ?? 0 ),
@@ -177,25 +187,31 @@ class FetchReddit extends BaseTool {
 			return $this->buildErrorResponse( $error, $tool_name );
 		}
 
-		if ( empty( $result['data'] ) ) {
+		// The ability returns 'items' for multiple results, 'data' for single.
+		$items = $result['items'] ?? array();
+		if ( empty( $items ) && ! empty( $result['data'] ) ) {
+			$items = array( array( 'data' => $result['data'], 'source_url' => $result['source_url'] ?? '', 'item_id' => $result['item_id'] ?? '' ) );
+		}
+
+		if ( empty( $items ) ) {
+			$context_label = ! empty( $input['subreddit'] ) ? 'r/' . $input['subreddit'] : 'Reddit';
 			return array(
 				'success'   => true,
 				'data'      => null,
-				'message'   => 'No eligible posts found in r/' . $input['subreddit'] . ' with the given filters.',
+				'message'   => 'No eligible posts found on ' . $context_label . ' with the given filters.',
 				'tool_name' => $tool_name,
 				'guidance'  => array(
 					'status'    => 'empty_result',
-					'next_step' => 'Try broadening filters (lower min_upvotes, expand timeframe, remove search terms).',
+					'next_step' => 'Try broadening filters (lower min_upvotes, expand timeframe, remove search terms, or adjust query).',
 				),
 			);
 		}
 
 		return array(
-			'success'    => true,
-			'data'       => $result['data'],
-			'source_url' => $result['source_url'] ?? '',
-			'item_id'    => $result['item_id'] ?? '',
-			'tool_name'  => $tool_name,
+			'success'   => true,
+			'items'     => $items,
+			'count'     => count( $items ),
+			'tool_name' => $tool_name,
 		);
 	}
 }

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -437,15 +437,20 @@ class RedditCommand {
 	}
 
 	/**
-	 * Fetch a post from a Reddit subreddit.
+	 * Fetch posts from Reddit.
 	 *
-	 * Uses the datamachine/fetch-reddit ability to fetch the first eligible
-	 * post from the given subreddit, applying all configured filters.
+	 * Fetches from a specific subreddit, or searches across all of Reddit
+	 * when --query is provided without a subreddit. Uses the
+	 * datamachine/fetch-reddit ability with all configured filters.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <subreddit>
-	 * : The subreddit name (without "r/").
+	 * [<subreddit>]
+	 * : The subreddit name (without "r/"). Optional when --query is used.
+	 *
+	 * [--query=<query>]
+	 * : Search query. Without a subreddit, searches all of Reddit.
+	 *   With a subreddit, searches within that subreddit.
 	 *
 	 * [--sort=<sort>]
 	 * : Sort order for posts.
@@ -457,6 +462,7 @@ class RedditCommand {
 	 *   - top
 	 *   - rising
 	 *   - controversial
+	 *   - relevance
 	 * ---
 	 *
 	 * [--timeframe=<timeframe>]
@@ -493,7 +499,7 @@ class RedditCommand {
 	 * ---
 	 *
 	 * [--search=<search>]
-	 * : Comma-separated search terms to filter posts.
+	 * : Comma-separated search terms to filter posts locally (client-side).
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -507,20 +513,37 @@ class RedditCommand {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Fetch from a subreddit
 	 *     wp datamachine-socials reddit fetch jambands
 	 *     wp datamachine-socials reddit fetch festivals --sort=top --min-upvotes=50
 	 *     wp datamachine-socials reddit fetch bonnaroo --timeframe=7_days --comments=5
-	 *     wp datamachine-socials reddit fetch sxsw --format=json
+	 *
+	 *     # Global search across all of Reddit
+	 *     wp datamachine-socials reddit fetch --query="best live music calendar" --sort=relevance --timeframe=30_days
+	 *     wp datamachine-socials reddit fetch --query="concert events near me" --min-upvotes=5 --comments=3
+	 *
+	 *     # Search within a specific subreddit
+	 *     wp datamachine-socials reddit fetch Austin --query="live music tonight"
 	 */
 	public function fetch( $args, $assoc_args ) {
-		$subreddit    = $args[0];
+		$subreddit    = $args[0] ?? '';
+		$query        = $assoc_args['query'] ?? '';
 		$access_token = $this->get_access_token();
+
+		// Validate: must have at least one of subreddit or query.
+		if ( empty( $subreddit ) && empty( $query ) ) {
+			WP_CLI::error( 'Provide a subreddit name or --query (or both).' );
+		}
+
+		// Default sort to 'relevance' for search queries.
+		$default_sort = ! empty( $query ) ? 'relevance' : 'hot';
 
 		// Build ability input.
 		$input = array(
 			'subreddit'         => $subreddit,
+			'query'             => $query,
 			'access_token'      => $access_token,
-			'sort_by'           => $assoc_args['sort'] ?? 'hot',
+			'sort_by'           => $assoc_args['sort'] ?? $default_sort,
 			'timeframe_limit'   => $assoc_args['timeframe'] ?? 'all_time',
 			'min_upvotes'       => absint( $assoc_args['min-upvotes'] ?? 0 ),
 			'min_comment_count' => absint( $assoc_args['min-comments'] ?? 0 ),
@@ -532,7 +555,13 @@ class RedditCommand {
 			'download_images'   => false, // CLI doesn't download images by default.
 		);
 
-		WP_CLI::log( "Fetching from r/{$subreddit} (sort: {$input['sort_by']})..." );
+		if ( ! empty( $subreddit ) && ! empty( $query ) ) {
+			WP_CLI::log( "Searching r/{$subreddit} for \"{$query}\" (sort: {$input['sort_by']})..." );
+		} elseif ( ! empty( $query ) ) {
+			WP_CLI::log( "Searching all of Reddit for \"{$query}\" (sort: {$input['sort_by']})..." );
+		} else {
+			WP_CLI::log( "Fetching from r/{$subreddit} (sort: {$input['sort_by']})..." );
+		}
 
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			WP_CLI::error( 'WordPress Abilities API not available (requires WP 6.9+).' );
@@ -549,45 +578,48 @@ class RedditCommand {
 			WP_CLI::error( $result['error'] ?? 'Reddit fetch failed.' );
 		}
 
-		if ( empty( $result['data'] ) ) {
+		// The ability returns 'items' array for multiple results.
+		$items = $result['items'] ?? array();
+
+		// Backward compat: single-result 'data' key.
+		if ( empty( $items ) && ! empty( $result['data'] ) ) {
+			$items = is_array( $result['data'] ) ? array( array( 'data' => $result['data'], 'source_url' => $result['source_url'] ?? '', 'item_id' => $result['item_id'] ?? '' ) ) : array();
+		}
+
+		if ( empty( $items ) ) {
 			WP_CLI::warning( 'No eligible posts found with the given filters.' );
 			return;
 		}
 
-		$data   = $result['data'];
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::log( wp_json_encode( $items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
 		if ( 'yaml' === $format ) {
-			$this->output_yaml( $data );
+			$this->output_yaml( $items );
 			return;
 		}
 
-		// Table format: show key fields.
-		$metadata = $data['metadata'] ?? array();
-		WP_CLI::success( 'Fetched post from r/' . $subreddit );
-		WP_CLI::log( '' );
-		WP_CLI::log( 'Title:    ' . ( $data['title'] ?? '(none)' ) );
-		WP_CLI::log( 'Author:   ' . ( $metadata['author'] ?? 'unknown' ) );
-		WP_CLI::log( 'Upvotes:  ' . ( $metadata['upvotes'] ?? 0 ) );
-		WP_CLI::log( 'Comments: ' . ( $metadata['comment_count'] ?? 0 ) );
-		WP_CLI::log( 'Date:     ' . ( $metadata['original_date_gmt'] ?? 'unknown' ) );
-		WP_CLI::log( 'URL:      ' . ( $result['source_url'] ?? '' ) );
-
-		$content = $data['content'] ?? '';
-		if ( ! empty( $content ) ) {
-			WP_CLI::log( '' );
-			$preview = mb_substr( $content, 0, 500 );
-			if ( mb_strlen( $content ) > 500 ) {
-				$preview .= '...';
-			}
-			WP_CLI::log( 'Content:' );
-			WP_CLI::log( $preview );
+		// Table format: show all results.
+		$rows = array();
+		foreach ( $items as $item ) {
+			$data     = $item['data'] ?? array();
+			$metadata = $data['metadata'] ?? array();
+			$rows[]   = array(
+				'score'     => $metadata['upvotes'] ?? 0,
+				'comments'  => $metadata['comment_count'] ?? 0,
+				'subreddit' => 'r/' . ( $metadata['subreddit'] ?? '' ),
+				'author'    => $metadata['author'] ?? '[deleted]',
+				'title'     => mb_substr( $data['title'] ?? '', 0, 60 ),
+				'url'       => $item['source_url'] ?? '',
+			);
 		}
+
+		WP_CLI::success( count( $rows ) . ' posts found' );
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'score', 'comments', 'subreddit', 'author', 'title' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extends `reddit fetch` to support **cross-Reddit global search** via Reddit's `/search.json` endpoint
- The `subreddit` parameter is now **optional** — provide `--query` without a subreddit to search all of Reddit
- Both can be combined (`reddit fetch Austin --query="live music"`) to search within a specific subreddit
- Ability, CLI, and chat tool all updated — one primitive, three interfaces

## Usage

```bash
# Existing (unchanged)
wp datamachine-socials reddit fetch jambands --sort=top

# Global search across all of Reddit
wp datamachine-socials reddit fetch --query="best live music calendar" --sort=relevance --timeframe=30_days

# Search within a subreddit
wp datamachine-socials reddit fetch Austin --query="live music tonight"
```

## Changes

| File | What changed |
|------|-------------|
| `FetchRedditAbility.php` | `subreddit` no longer required, new `query` param, `buildApiUrl()` helper for 3 modes, `relevance` sort, post subreddit from item data |
| `RedditCommand.php` | `<subreddit>` optional, `--query` flag, smart sort default, multi-result table output |
| `FetchReddit.php` | `subreddit` optional, `query` param, returns `items` array |

## Testing

Tested live against Reddit OAuth API:
- ✅ Existing subreddit browse still works (`reddit fetch jambands`)
- ✅ Global search returns results (`--query="best live music calendar"` → 221 posts)
- ✅ Subreddit search works (`reddit fetch Concerts --query="how do I find concerts"`)
- ✅ All filters work with global search (min-upvotes, min-comments, timeframe, comments)