### PR TITLE
feat: broaden social ability permissions from can_manage to use_tools

### DIFF
--- a/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
@@ -74,7 +74,7 @@ class BlueskyDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Bluesky/BlueskyPublishAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyPublishAbility.php
@@ -89,7 +89,7 @@ class BlueskyPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -115,7 +115,7 @@ class BlueskyPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_account' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Bluesky/BlueskyReadAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyReadAbility.php
@@ -90,7 +90,7 @@ class BlueskyReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
@@ -80,7 +80,7 @@ class BlueskyUpdateAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -76,7 +76,7 @@ class FacebookDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Facebook/FacebookPublishAbility.php
+++ b/inc/Abilities/Facebook/FacebookPublishAbility.php
@@ -100,7 +100,7 @@ class FacebookPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -125,7 +125,7 @@ class FacebookPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_pages' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Facebook/FacebookReadAbility.php
+++ b/inc/Abilities/Facebook/FacebookReadAbility.php
@@ -94,7 +94,7 @@ class FacebookReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Facebook/FacebookUpdateAbility.php
+++ b/inc/Abilities/Facebook/FacebookUpdateAbility.php
@@ -91,7 +91,7 @@ class FacebookUpdateAbility {
 	 * @return bool
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
+++ b/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
@@ -83,7 +83,7 @@ class InstagramCommentReplyAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -76,7 +76,7 @@ class InstagramDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -155,7 +155,7 @@ class InstagramPublishAbility {
 					),
 				),
 				'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -182,7 +182,7 @@ class InstagramPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_account' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -113,7 +113,7 @@ class InstagramReadAbility {
 	 * @return bool
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -97,7 +97,7 @@ class InstagramUpdateAbility {
 	 * @return bool
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
@@ -76,7 +76,7 @@ class LinkedInDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
@@ -99,7 +99,7 @@ class LinkedInPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -126,7 +126,7 @@ class LinkedInPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_account' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/LinkedIn/LinkedInReadAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInReadAbility.php
@@ -91,7 +91,7 @@ class LinkedInReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
@@ -80,7 +80,7 @@ class LinkedInUpdateAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
@@ -122,7 +122,7 @@ class PinterestAnalyticsAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Pinterest/PinterestBoardsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestBoardsAbility.php
@@ -85,7 +85,7 @@ class PinterestBoardsAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'sync_boards' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -109,7 +109,7 @@ class PinterestBoardsAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_list_boards' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -135,7 +135,7 @@ class PinterestBoardsAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_status' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Pinterest/PinterestDeleteAbility.php
+++ b/inc/Abilities/Pinterest/PinterestDeleteAbility.php
@@ -76,7 +76,7 @@ class PinterestDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Pinterest/PinterestPublishAbility.php
+++ b/inc/Abilities/Pinterest/PinterestPublishAbility.php
@@ -96,7 +96,7 @@ class PinterestPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Pinterest/PinterestReadAbility.php
+++ b/inc/Abilities/Pinterest/PinterestReadAbility.php
@@ -96,7 +96,7 @@ class PinterestReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Pinterest/PinterestUpdateAbility.php
+++ b/inc/Abilities/Pinterest/PinterestUpdateAbility.php
@@ -82,7 +82,7 @@ class PinterestUpdateAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -143,7 +143,7 @@ class FetchRedditAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Reddit/ReplyRedditAbility.php
+++ b/inc/Abilities/Reddit/ReplyRedditAbility.php
@@ -93,7 +93,7 @@ class ReplyRedditAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Reddit/SubmitRedditAbility.php
+++ b/inc/Abilities/Reddit/SubmitRedditAbility.php
@@ -129,7 +129,7 @@ class SubmitRedditAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Reddit/VoteRedditAbility.php
+++ b/inc/Abilities/Reddit/VoteRedditAbility.php
@@ -87,7 +87,7 @@ class VoteRedditAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**

--- a/inc/Abilities/Threads/ThreadsDeleteAbility.php
+++ b/inc/Abilities/Threads/ThreadsDeleteAbility.php
@@ -76,7 +76,7 @@ class ThreadsDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Threads/ThreadsPublishAbility.php
+++ b/inc/Abilities/Threads/ThreadsPublishAbility.php
@@ -86,7 +86,7 @@ class ThreadsPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -112,7 +112,7 @@ class ThreadsPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_account' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Threads/ThreadsReadAbility.php
+++ b/inc/Abilities/Threads/ThreadsReadAbility.php
@@ -96,7 +96,7 @@ class ThreadsReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Threads/ThreadsUpdateAbility.php
+++ b/inc/Abilities/Threads/ThreadsUpdateAbility.php
@@ -82,7 +82,7 @@ class ThreadsUpdateAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Twitter/TwitterDeleteAbility.php
+++ b/inc/Abilities/Twitter/TwitterDeleteAbility.php
@@ -74,7 +74,7 @@ class TwitterDeleteAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Twitter/TwitterPublishAbility.php
+++ b/inc/Abilities/Twitter/TwitterPublishAbility.php
@@ -99,7 +99,7 @@ class TwitterPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'execute_publish' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -125,7 +125,7 @@ class TwitterPublishAbility {
 						),
 					),
 					'execute_callback'    => array( self::class, 'get_account' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'use_tools' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Twitter/TwitterReadAbility.php
+++ b/inc/Abilities/Twitter/TwitterReadAbility.php
@@ -93,7 +93,7 @@ class TwitterReadAbility {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	public function execute( array $input ): array|\WP_Error {

--- a/inc/Abilities/Twitter/TwitterUpdateAbility.php
+++ b/inc/Abilities/Twitter/TwitterUpdateAbility.php
@@ -85,7 +85,7 @@ class TwitterUpdateAbility {
 	 * @return bool
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #110

Swaps all social platform ability permission callbacks from `PermissionHelper::can_manage()` to `PermissionHelper::can('use_tools')` so editors can use social abilities via chat tools.

## Changes

- **35 files** across all 8 platform directories (Instagram, Twitter, Facebook, Bluesky, Threads, Pinterest, LinkedIn, Reddit)
- **43 instances** of `can_manage()` → `can('use_tools')` in both `permission_callback` closures and `checkPermission()` methods
- No changes to `RestApi.php` permission checks (those correctly use `publish_posts`/`edit_posts`)
- No changes to auth/account management permissions (those correctly stay admin-only)

## Platforms affected

- Instagram (Publish, Read, Update, Delete, CommentReply)
- Twitter (Publish, Read, Update, Delete)
- Facebook (Publish, Read, Update, Delete)
- Bluesky (Publish, Read, Update, Delete)
- Threads (Publish, Read, Update, Delete)
- Pinterest (Publish, Read, Update, Delete, Boards, Analytics)
- LinkedIn (Publish, Read, Update, Delete)
- Reddit (Fetch, Reply, Submit, Vote)