### PR TITLE
refactor(handlers): migrate aiToolCallback to new datamachine_tools signature

### DIFF
--- a/inc/Handlers/Bluesky/Bluesky.php
+++ b/inc/Handlers/Bluesky/Bluesky.php
@@ -35,13 +35,12 @@ class Bluesky extends PublishHandler {
 			true,
 			BlueskyAuth::class,
 			BlueskySettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'bluesky_publish' === $handler_slug ) {
-					$tools['bluesky_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'bluesky_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'bluesky_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to Bluesky. Supports text and images.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -53,9 +52,8 @@ class Bluesky extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'bluesky',
 			array(

--- a/inc/Handlers/Facebook/Facebook.php
+++ b/inc/Handlers/Facebook/Facebook.php
@@ -44,13 +44,12 @@ class Facebook extends PublishHandler {
 			true,
 			FacebookAuth::class,
 			FacebookSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'facebook_publish' === $handler_slug ) {
-					$tools['facebook_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'facebook_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'facebook_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to a Facebook Page. Supports text and images.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -62,9 +61,8 @@ class Facebook extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'facebook',
 			array(

--- a/inc/Handlers/Instagram/Instagram.php
+++ b/inc/Handlers/Instagram/Instagram.php
@@ -46,13 +46,12 @@ class Instagram extends PublishHandler {
 			true,
 			InstagramAuth::class,
 			InstagramSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'instagram_publish' === $handler_slug ) {
-					$tools['instagram_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'instagram_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'instagram_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to Instagram. Supports single images and carousels (up to 10 images). Images are processed async.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -78,9 +77,8 @@ class Instagram extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'instagram',
 			array(

--- a/inc/Handlers/LinkedIn/LinkedIn.php
+++ b/inc/Handlers/LinkedIn/LinkedIn.php
@@ -47,13 +47,12 @@ class LinkedIn extends PublishHandler {
 			true,
 			LinkedInAuth::class,
 			LinkedInSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'linkedin_publish' === $handler_slug ) {
-					$tools['linkedin_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'linkedin_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'linkedin_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to LinkedIn. Supports text (up to 3000 chars), images, and article sharing.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -65,9 +64,8 @@ class LinkedIn extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'linkedin',
 			array(

--- a/inc/Handlers/Pinterest/Pinterest.php
+++ b/inc/Handlers/Pinterest/Pinterest.php
@@ -49,26 +49,26 @@ class Pinterest extends PublishHandler {
 			true,
 			PinterestAuth::class,
 			PinterestSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				if ( 'pinterest_publish' === $handler_slug ) {
-					$board_id_description = 'Pinterest board ID override (uses default if omitted)';
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				$board_id_description = 'Pinterest board ID override (uses default if omitted)';
 
-					// Inject cached board names when AI decides mode is active.
-					$mode = $handler_config['board_selection_mode'] ?? 'pre_selected';
-					if ( 'ai_decides' === $mode ) {
-						$cached_boards = PinterestBoardsAbility::get_cached_boards();
-						if ( ! empty( $cached_boards ) ) {
-							$board_list           = implode( ', ', array_map( function ( $b ) {
-								return $b['name'] . ' (' . $b['id'] . ')';
-							}, $cached_boards ) );
-							$board_id_description = "Pinterest board ID. Available boards: {$board_list}";
-						}
+				// Inject cached board names when AI decides mode is active.
+				$mode = $handler_config['board_selection_mode'] ?? 'pre_selected';
+				if ( 'ai_decides' === $mode ) {
+					$cached_boards = PinterestBoardsAbility::get_cached_boards();
+					if ( ! empty( $cached_boards ) ) {
+						$board_list           = implode( ', ', array_map( function ( $b ) {
+							return $b['name'] . ' (' . $b['id'] . ')';
+						}, $cached_boards ) );
+						$board_id_description = "Pinterest board ID. Available boards: {$board_list}";
 					}
+				}
 
-					$tools['pinterest_publish'] = array(
+				return array(
+					'pinterest_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'pinterest_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Pin content to Pinterest with image, title, description, and link.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -88,9 +88,8 @@ class Pinterest extends PublishHandler {
 							),
 							'required'   => array( 'title', 'description' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'pinterest',
 			array(

--- a/inc/Handlers/Threads/Threads.php
+++ b/inc/Handlers/Threads/Threads.php
@@ -44,13 +44,12 @@ class Threads extends PublishHandler {
 			true,
 			ThreadsAuth::class,
 			ThreadsSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'threads_publish' === $handler_slug ) {
-					$tools['threads_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'threads_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'threads_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to Meta Threads. Supports text and images.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -62,9 +61,8 @@ class Threads extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'threads',
 			array(

--- a/inc/Handlers/Twitter/Twitter.php
+++ b/inc/Handlers/Twitter/Twitter.php
@@ -46,13 +46,12 @@ class Twitter extends PublishHandler {
 			true,
 			TwitterAuth::class,
 			TwitterSettings::class,
-			function ( $tools, $handler_slug, $handler_config ) {
-				$handler_config;
-				if ( 'twitter_publish' === $handler_slug ) {
-					$tools['twitter_publish'] = array(
+			function ( $handler_slug, $handler_config, $engine_data ) {
+				return array(
+					'twitter_publish' => array(
 						'class'       => self::class,
 						'method'      => 'handle_tool_call',
-						'handler'     => 'twitter_publish',
+						'handler'     => $handler_slug,
 						'description' => 'Post content to Twitter. Supports text (280 chars), images, and URL handling.',
 						'parameters'  => array(
 							'type'       => 'object',
@@ -64,9 +63,8 @@ class Twitter extends PublishHandler {
 							),
 							'required'   => array( 'content' ),
 						),
-					);
-				}
-				return $tools;
+					),
+				);
 			},
 			'twitter',
 			array(


### PR DESCRIPTION
## Summary

Coordinated change required by Data Machine core PR [Extra-Chill/data-machine#1130](https://github.com/Extra-Chill/data-machine/pull/1130), which eliminated the legacy `chubes_ai_tools` filter and consolidated handler tool registration into the unified `datamachine_tools` registry.

The `aiToolCallback` parameter on `HandlerRegistrationTrait::registerHandler()` now uses a new signature. This PR migrates all 7 publish handlers in data-machine-socials.

## The signature change

### Before
```php
function ($tools, $handler_slug, $handler_config) {
    if ($handler_slug === 'twitter_publish') {
        $tools['twitter_publish'] = [/* def */];
    }
    return $tools;
}
```

### After
```php
function ($handler_slug, $handler_config, $engine_data) {
    return ['twitter_publish' => [/* def */]];
}
```

The trait handles slug routing (entries are keyed by handler slug in the
registry); callbacks no longer need manual guards or array merge gymnastics.
Net LOC shrinks by ~2 per handler.

## Migrated handlers

- `Twitter/Twitter.php`
- `Bluesky/Bluesky.php`
- `Facebook/Facebook.php`
- `Instagram/Instagram.php`
- `LinkedIn/LinkedIn.php`
- `Pinterest/Pinterest.php` — keeps its dynamic `board_id` description generation from `handler_config`
- `Threads/Threads.php`

## Not migrated

- `Reddit/Reddit.php` — fetch-only handler, no AI tool callback registered. No change needed.

## Stats

**7 files changed, 54 insertions(+), 67 deletions(-)** — net -13 LOC.

## Coordination

Merge this alongside data-machine#1130 — extension handler tools will silently fail to register if data-machine main is deployed while this PR is unmerged.

`data-machine-events` and `data-machine-business` don't register any handler AI tool callbacks today, so they need no matching PR.