### PR TITLE
feat: migrate SocialCrossPostTask to executeTask() contract

### DIFF
--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -24,7 +24,7 @@ class SocialCrossPostTask extends SystemTask {
 	 * @param int   $jobId  Job ID from DM Jobs table.
 	 * @param array $params Task parameters from engine_data.
 	 */
-	public function execute( int $jobId, array $params ): void {
+	public function executeTask( int $jobId, array $params ): void {
 		$post_id   = absint( $params['post_id'] ?? 0 );
 		$platforms = $params['platforms'] ?? array();
 		$caption   = $params['caption'] ?? '';


### PR DESCRIPTION
## Summary

Part of the coordinated **workflow-json-migration** across the Extra Chill platform.

- Renames `SocialCrossPostTask::execute()` → `executeTask()` to match the updated `SystemTask` abstract contract introduced in data-machine 0.72.0+.
- No logic changes — method body is identical, only the signature is updated.

## Breaking Change

Requires the new `SystemTask.executeTask()` abstract method from the core data-machine plugin. This PR **must be merged and deployed together** with the core migration via a coordinated homeboy release.

## Dependencies

Depends on Extra-Chill/data-machine#1153

## Deployment

Merge together with all workflow-json-migration PRs across repos in a single coordinated homeboy release. Do not merge independently.