### PR TITLE
fix: register datamachine-socials ability category

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -26,6 +26,23 @@ define( 'DATAMACHINE_SOCIALS_URL', plugin_dir_url( __FILE__ ) );
 require_once __DIR__ . '/vendor/autoload.php';
 
 /**
+ * Register the Data Machine Socials ability category.
+ *
+ * Hooked on wp_abilities_api_categories_init so the category is
+ * available before any social abilities are registered.
+ */
+function datamachine_socials_register_ability_category() {
+	wp_register_ability_category(
+		'datamachine-socials',
+		array(
+			'label'       => __( 'Socials', 'data-machine-socials' ),
+			'description' => __( 'Social media publishing, reading, and engagement across all supported platforms.', 'data-machine-socials' ),
+		)
+	);
+}
+add_action( 'wp_abilities_api_categories_init', 'datamachine_socials_register_ability_category' );
+
+/**
  * Bootstrap the plugin after all plugins are loaded.
  *
  * Data Machine core must be active — check at plugins_loaded time

--- a/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
@@ -40,7 +40,7 @@ class BlueskyDeleteAbility {
 				array(
 					'label'               => __( 'Delete Bluesky Posts', 'data-machine-socials' ),
 					'description'         => __( 'Delete your Bluesky posts', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Bluesky/BlueskyPublishAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyPublishAbility.php
@@ -51,7 +51,7 @@ class BlueskyPublishAbility {
 				array(
 					'label'               => __( 'Publish to Bluesky', 'data-machine-socials' ),
 					'description'         => __( 'Post content to Bluesky with optional media', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'content' ),
@@ -100,7 +100,7 @@ class BlueskyPublishAbility {
 				array(
 					'label'               => __( 'Bluesky Account Info', 'data-machine-socials' ),
 					'description'         => __( 'Get authenticated Bluesky account details', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Bluesky/BlueskyReadAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyReadAbility.php
@@ -42,7 +42,7 @@ class BlueskyReadAbility {
 				array(
 					'label'               => __( 'Read Bluesky Posts', 'data-machine-socials' ),
 					'description'         => __( 'List recent Bluesky posts, get a post thread, or view profile', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
@@ -41,7 +41,7 @@ class BlueskyUpdateAbility {
 				array(
 					'label'               => __( 'Update Bluesky Posts', 'data-machine-socials' ),
 					'description'         => __( 'Delete posts or like/unlike posts on Bluesky', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -42,7 +42,7 @@ class FacebookDeleteAbility {
 				array(
 					'label'               => __( 'Delete Facebook Posts', 'data-machine-socials' ),
 					'description'         => __( 'Delete posts from your Facebook Page', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Facebook/FacebookPublishAbility.php
+++ b/inc/Abilities/Facebook/FacebookPublishAbility.php
@@ -51,7 +51,7 @@ class FacebookPublishAbility {
 				array(
 					'label'               => __( 'Publish to Facebook', 'data-machine-socials' ),
 					'description'         => __( 'Post content to Facebook Pages with optional media', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'content' ),
@@ -111,7 +111,7 @@ class FacebookPublishAbility {
 				array(
 					'label'               => __( 'Facebook Pages', 'data-machine-socials' ),
 					'description'         => __( 'Get connected Facebook pages', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Facebook/FacebookReadAbility.php
+++ b/inc/Abilities/Facebook/FacebookReadAbility.php
@@ -46,7 +46,7 @@ class FacebookReadAbility {
 				array(
 					'label'               => __( 'Read Facebook Page Posts', 'data-machine-socials' ),
 					'description'         => __( 'List recent Facebook Page posts or get details for a specific post', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Facebook/FacebookUpdateAbility.php
+++ b/inc/Abilities/Facebook/FacebookUpdateAbility.php
@@ -43,7 +43,7 @@ class FacebookUpdateAbility {
 				array(
 					'label'               => __( 'Update Facebook Page Posts', 'data-machine-socials' ),
 					'description'         => __( 'Edit post message, hide/unhide posts, or delete posts from a Facebook Page', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
+++ b/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
@@ -44,7 +44,7 @@ class InstagramCommentReplyAbility {
 				array(
 					'label'               => __( 'Reply to Instagram Comment', 'data-machine-socials' ),
 					'description'         => __( 'Reply to a specific Instagram comment', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -42,7 +42,7 @@ class InstagramDeleteAbility {
 				array(
 					'label'               => __( 'Delete Instagram Media', 'data-machine-socials' ),
 					'description'         => __( 'Delete Instagram posts', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -83,7 +83,7 @@ class InstagramPublishAbility {
 				array(
 					'label'               => __( 'Publish to Instagram', 'data-machine-socials' ),
 				'description'         => __( 'Post content to Instagram — supports single image, carousel (up to 10 images), Reel (video), and Story (image or video)', 'data-machine-socials' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-socials',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'content' ),
@@ -166,7 +166,7 @@ class InstagramPublishAbility {
 				array(
 					'label'               => __( 'Instagram Account Info', 'data-machine-socials' ),
 					'description'         => __( 'Get authenticated Instagram account details', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -60,7 +60,7 @@ class InstagramReadAbility {
 				array(
 					'label'               => __( 'Read Instagram Media', 'data-machine-socials' ),
 					'description'         => __( 'List recent Instagram posts or get details for a specific post', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -48,7 +48,7 @@ class InstagramUpdateAbility {
 				array(
 					'label'               => __( 'Update Instagram Media', 'data-machine-socials' ),
 					'description'         => __( 'Edit caption, delete, or archive Instagram posts', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
@@ -42,7 +42,7 @@ class LinkedInDeleteAbility {
 				array(
 					'label'               => __( 'Delete LinkedIn Post', 'data-machine-socials' ),
 					'description'         => __( 'Delete a post from LinkedIn', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'post_id' ),

--- a/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
@@ -55,7 +55,7 @@ class LinkedInPublishAbility {
 				array(
 					'label'               => __( 'Publish to LinkedIn', 'data-machine-socials' ),
 					'description'         => __( 'Post content to LinkedIn with optional media and article sharing', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'content' ),
@@ -110,7 +110,7 @@ class LinkedInPublishAbility {
 				array(
 					'label'               => __( 'LinkedIn Account Info', 'data-machine-socials' ),
 					'description'         => __( 'Get authenticated LinkedIn account details', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/LinkedIn/LinkedInReadAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInReadAbility.php
@@ -42,7 +42,7 @@ class LinkedInReadAbility {
 				array(
 					'label'               => __( 'Read LinkedIn Posts', 'data-machine-socials' ),
 					'description'         => __( 'List recent posts or get a specific post from LinkedIn', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
@@ -42,7 +42,7 @@ class LinkedInUpdateAbility {
 				array(
 					'label'               => __( 'Update LinkedIn Post', 'data-machine-socials' ),
 					'description'         => __( 'Update the commentary of an existing LinkedIn post', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'post_id', 'commentary' ),

--- a/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
@@ -65,7 +65,7 @@ class PinterestAnalyticsAbility {
 				array(
 					'label'               => __( 'Pinterest Analytics', 'data-machine-socials' ),
 					'description'         => __( 'Get analytics metrics for user account, pins, or boards. Includes impressions, saves, clicks, and engagement data.', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Pinterest/PinterestBoardsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestBoardsAbility.php
@@ -70,7 +70,7 @@ class PinterestBoardsAbility {
 				array(
 					'label'               => __( 'Sync Pinterest Boards', 'data-machine-socials' ),
 					'description'         => __( 'Sync Pinterest boards from API and cache locally', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),
@@ -96,7 +96,7 @@ class PinterestBoardsAbility {
 				array(
 					'label'               => __( 'List Pinterest Boards', 'data-machine-socials' ),
 					'description'         => __( 'Get cached Pinterest boards', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),
@@ -120,7 +120,7 @@ class PinterestBoardsAbility {
 				array(
 					'label'               => __( 'Pinterest Status', 'data-machine-socials' ),
 					'description'         => __( 'Get Pinterest integration status', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Pinterest/PinterestDeleteAbility.php
+++ b/inc/Abilities/Pinterest/PinterestDeleteAbility.php
@@ -42,7 +42,7 @@ class PinterestDeleteAbility {
 				array(
 					'label'               => __( 'Delete Pinterest Pins', 'data-machine-socials' ),
 					'description'         => __( 'Delete pins from your Pinterest boards', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Pinterest/PinterestPublishAbility.php
+++ b/inc/Abilities/Pinterest/PinterestPublishAbility.php
@@ -52,7 +52,7 @@ class PinterestPublishAbility {
 				array(
 					'label'               => __( 'Publish to Pinterest', 'data-machine-socials' ),
 					'description'         => __( 'Create a pin on Pinterest with image, title, description, and link', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'title', 'description', 'image_url' ),

--- a/inc/Abilities/Pinterest/PinterestReadAbility.php
+++ b/inc/Abilities/Pinterest/PinterestReadAbility.php
@@ -44,7 +44,7 @@ class PinterestReadAbility {
 				array(
 					'label'               => __( 'Read Pinterest Pins', 'data-machine-socials' ),
 					'description'         => __( 'List pins, get pin details, list boards, or list board pins', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Pinterest/PinterestUpdateAbility.php
+++ b/inc/Abilities/Pinterest/PinterestUpdateAbility.php
@@ -43,7 +43,7 @@ class PinterestUpdateAbility {
 				array(
 					'label'               => __( 'Update Pinterest Pins', 'data-machine-socials' ),
 					'description'         => __( 'Delete pins from Pinterest boards', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -42,7 +42,7 @@ class FetchRedditAbility {
 				array(
 					'label'               => __( 'Fetch Reddit Posts', 'data-machine-socials' ),
 					'description'         => __( 'Fetch posts from Reddit subreddits with filtering and pagination', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'access_token' ),

--- a/inc/Abilities/Reddit/ReplyRedditAbility.php
+++ b/inc/Abilities/Reddit/ReplyRedditAbility.php
@@ -50,7 +50,7 @@ class ReplyRedditAbility {
 				array(
 					'label'               => __( 'Reply to Reddit Post or Comment', 'data-machine-socials' ),
 					'description'         => __( 'Post a reply to a Reddit post or comment', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'thing_id', 'text', 'access_token' ),

--- a/inc/Abilities/Reddit/SubmitRedditAbility.php
+++ b/inc/Abilities/Reddit/SubmitRedditAbility.php
@@ -55,7 +55,7 @@ class SubmitRedditAbility {
 				array(
 					'label'               => __( 'Submit Reddit Post', 'data-machine-socials' ),
 					'description'         => __( 'Submit a new text or link post to a Reddit subreddit', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'subreddit', 'title', 'access_token' ),

--- a/inc/Abilities/Reddit/VoteRedditAbility.php
+++ b/inc/Abilities/Reddit/VoteRedditAbility.php
@@ -44,7 +44,7 @@ class VoteRedditAbility {
 				array(
 					'label'               => __( 'Vote on Reddit Post or Comment', 'data-machine-socials' ),
 					'description'         => __( 'Upvote, downvote, or unvote a Reddit post or comment', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'thing_id', 'direction', 'access_token' ),

--- a/inc/Abilities/Threads/ThreadsDeleteAbility.php
+++ b/inc/Abilities/Threads/ThreadsDeleteAbility.php
@@ -42,7 +42,7 @@ class ThreadsDeleteAbility {
 				array(
 					'label'               => __( 'Delete Threads Posts', 'data-machine-socials' ),
 					'description'         => __( 'Delete your Threads posts', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Threads/ThreadsPublishAbility.php
+++ b/inc/Abilities/Threads/ThreadsPublishAbility.php
@@ -51,7 +51,7 @@ class ThreadsPublishAbility {
 				array(
 					'label'               => __( 'Publish to Threads', 'data-machine-socials' ),
 					'description'         => __( 'Post content to Meta Threads with optional media', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'content' ),
@@ -97,7 +97,7 @@ class ThreadsPublishAbility {
 				array(
 					'label'               => __( 'Threads Account Info', 'data-machine-socials' ),
 					'description'         => __( 'Get authenticated Threads account details', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Threads/ThreadsReadAbility.php
+++ b/inc/Abilities/Threads/ThreadsReadAbility.php
@@ -48,7 +48,7 @@ class ThreadsReadAbility {
 				array(
 					'label'               => __( 'Read Threads Posts', 'data-machine-socials' ),
 					'description'         => __( 'List recent Threads posts or get details for a specific thread', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Threads/ThreadsUpdateAbility.php
+++ b/inc/Abilities/Threads/ThreadsUpdateAbility.php
@@ -43,7 +43,7 @@ class ThreadsUpdateAbility {
 				array(
 					'label'               => __( 'Update Threads Posts', 'data-machine-socials' ),
 					'description'         => __( 'Delete Threads posts', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Twitter/TwitterDeleteAbility.php
+++ b/inc/Abilities/Twitter/TwitterDeleteAbility.php
@@ -40,7 +40,7 @@ class TwitterDeleteAbility {
 				array(
 					'label'               => __( 'Delete Tweets', 'data-machine-socials' ),
 					'description'         => __( 'Delete tweets from your account', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Twitter/TwitterPublishAbility.php
+++ b/inc/Abilities/Twitter/TwitterPublishAbility.php
@@ -54,7 +54,7 @@ class TwitterPublishAbility {
 				array(
 					'label'               => __( 'Publish to Twitter', 'data-machine-socials' ),
 					'description'         => __( 'Post content to Twitter/X with optional media', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'content' ),
@@ -110,7 +110,7 @@ class TwitterPublishAbility {
 				array(
 					'label'               => __( 'Twitter Account Info', 'data-machine-socials' ),
 					'description'         => __( 'Get authenticated Twitter account details', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),

--- a/inc/Abilities/Twitter/TwitterReadAbility.php
+++ b/inc/Abilities/Twitter/TwitterReadAbility.php
@@ -45,7 +45,7 @@ class TwitterReadAbility {
 				array(
 					'label'               => __( 'Read Tweets', 'data-machine-socials' ),
 					'description'         => __( 'List recent tweets, get a specific tweet, or get mentions', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/Twitter/TwitterUpdateAbility.php
+++ b/inc/Abilities/Twitter/TwitterUpdateAbility.php
@@ -41,7 +41,7 @@ class TwitterUpdateAbility {
 				array(
 					'label'               => __( 'Update Twitter', 'data-machine-socials' ),
 					'description'         => __( 'Delete tweets, retweet, unretweet, like, or unlike tweets', 'data-machine-socials' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(


### PR DESCRIPTION
Fixes unreported WP 6.9 Abilities API category registration warnings.

## Problem
Every social ability referenced category `datamachine`, which was never registered via `wp_register_ability_category()`. This caused `_doing_it_wrong()` notices on every bootstrap:

> Ability category 'datamachine' is not registered. Please register the ability category before assigning it to ability 'datamachine/...'

## Changes
- Registers a new `datamachine-socials` category on `wp_abilities_api_categories_init`
- Updates all 43 ability category references from `datamachine` to `datamachine-socials` across 35 ability files

## Verification
- [ ] Bootstraps without `_doing_it_wrong()` notices
- [ ] All abilities remain discoverable via `wp_get_ability()`
- [ ] Category appears in abilities registry listing