### PR TITLE
feat: async social publishing via DM Jobs + Publisher utility

### DIFF
--- a/inc/Publisher.php
+++ b/inc/Publisher.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Social Publisher
+ *
+ * Core publishing logic extracted from RestApi for reuse by both
+ * the REST endpoint and the DM Task System.
+ *
+ * @package DataMachineSocials
+ * @since   0.12.0
+ */
+
+namespace DataMachineSocials;
+
+use DataMachineSocials\Tracking\SocialShareTracker;
+
+defined( 'ABSPATH' ) || exit;
+
+class Publisher {
+
+	/**
+	 * Cross-post content to multiple social platforms.
+	 *
+	 * Takes the same params shape as the REST request and returns
+	 * per-platform results. Does NOT schedule jobs — that is the
+	 * caller's responsibility (RestApi or SocialCrossPostTask).
+	 *
+	 * @param array $params {
+	 *     @type array  $platforms    Target platforms.
+	 *     @type string $caption      Post caption.
+	 *     @type array  $images       Image objects with 'url' key.
+	 *     @type int    $post_id      Optional WP post ID.
+	 *     @type string $aspect_ratio Image aspect ratio.
+	 *     @type string $media_kind   image | carousel | reel | story.
+	 *     @type string $video_url    Video URL for reels/stories.
+	 *     @type string $cover_url    Cover image URL.
+	 *     @type bool   $share_to_feed Share reel to feed.
+	 * }
+	 * @return array{
+	 *     success: bool,
+	 *     results: array,
+	 *     errors?: array,
+	 * }
+	 */
+	public static function cross_post( array $params ): array {
+		$platforms     = $params['platforms'] ?? array();
+		$images        = $params['images'] ?? array();
+		$caption       = sanitize_textarea_field( $params['caption'] ?? '' );
+		$post_id       = intval( $params['post_id'] ?? 0 );
+		$aspect_ratio  = sanitize_text_field( $params['aspect_ratio'] ?? '4:5' );
+		$media_kind    = sanitize_text_field( $params['media_kind'] ?? 'image' );
+		$video_url     = sanitize_url( $params['video_url'] ?? '' );
+		$cover_url     = sanitize_url( $params['cover_url'] ?? '' );
+		$share_to_feed = $params['share_to_feed'] ?? true;
+
+		if ( empty( $platforms ) || ! is_array( $platforms ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No platforms selected',
+				'results' => array(),
+			);
+		}
+
+		if ( 'reel' === $media_kind ) {
+			if ( empty( $video_url ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'video_url is required for Reel publishing',
+					'results' => array(),
+				);
+			}
+		} elseif ( 'story' === $media_kind ) {
+			if ( empty( $video_url ) && empty( $images ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'image or video_url is required for Story publishing',
+					'results' => array(),
+				);
+			}
+		} elseif ( empty( $images ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No images provided',
+				'results' => array(),
+			);
+		}
+
+		$source_url = $post_id ? get_permalink( $post_id ) : '';
+
+		$extra = array(
+			'media_kind'    => $media_kind,
+			'video_url'     => $video_url,
+			'cover_url'     => $cover_url,
+			'share_to_feed' => $share_to_feed,
+		);
+
+		$results = array();
+		$errors  = array();
+
+		foreach ( $platforms as $platform ) {
+			$result    = self::post_to_platform( $platform, $images, $caption, $source_url, $extra );
+			$results[] = $result;
+
+			if ( ! $result['success'] ) {
+				$errors[] = $platform . ': ' . $result['error'];
+			}
+
+			// Track successful shares via SocialShareTracker when post_id is available.
+			if ( $post_id && ! empty( $result['success'] ) ) {
+				SocialShareTracker::record_from_result(
+					$post_id,
+					$platform,
+					$result,
+					array( 'media_kind' => $media_kind )
+				);
+			}
+		}
+
+		return array(
+			'success' => empty( $errors ),
+			'results' => $results,
+			'errors'  => $errors ?: null,
+		);
+	}
+
+	/**
+	 * Post to an individual platform via its publish ability.
+	 *
+	 * @param string $platform   Platform slug.
+	 * @param array  $images     Array of image objects with 'url' key.
+	 * @param string $caption    Post caption.
+	 * @param string $source_url Source URL to attribute.
+	 * @param array  $extra      Extra params (media_kind, video_url, cover_url, share_to_feed).
+	 * @return array Result.
+	 */
+	public static function post_to_platform( string $platform, array $images, string $caption, string $source_url, array $extra = array() ): array {
+		$ability_slug = "datamachine/{$platform}-publish";
+
+		$ability = wp_get_ability( $ability_slug );
+
+		if ( ! $ability ) {
+			return array(
+				'platform' => $platform,
+				'success'  => false,
+				'error'    => "Ability {$ability_slug} not registered",
+			);
+		}
+
+		$image_urls = array_map(
+			function ( $img ) {
+				return $img['url'] ?? '';
+			},
+			$images
+		);
+
+		$input = array(
+			'content'    => $caption,
+			'image_urls' => $image_urls,
+			'source_url' => $source_url,
+		);
+
+		$media_kind = $extra['media_kind'] ?? 'image';
+		if ( 'reel' === $media_kind ) {
+			$input['media_kind']    = 'reel';
+			$input['video_url']     = $extra['video_url'] ?? '';
+			$input['cover_url']     = $extra['cover_url'] ?? '';
+			$input['share_to_feed'] = $extra['share_to_feed'] ?? true;
+		} elseif ( 'story' === $media_kind ) {
+			$input['media_kind'] = 'story';
+			$input['video_url']  = $extra['video_url'] ?? '';
+			if ( ! empty( $image_urls[0] ) && empty( $extra['video_url'] ) ) {
+				$input['story_image_url'] = $image_urls[0];
+			}
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'platform' => $platform,
+				'success'  => false,
+				'error'    => $result->get_error_message(),
+			);
+		}
+
+		if ( ! empty( $result['success'] ) ) {
+			return array(
+				'platform'         => $platform,
+				'success'          => true,
+				'platform_post_id' => SocialShareTracker::extract_platform_post_id( $platform, $result ),
+				'platform_url'     => SocialShareTracker::extract_platform_url( $platform, $result ),
+				'media_kind'       => $result['media_kind'] ?? null,
+			);
+		}
+
+		return array(
+			'platform' => $platform,
+			'success'  => false,
+			'error'    => $result['error'] ?? 'Unknown error',
+		);
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -9,6 +9,7 @@
 namespace DataMachineSocials;
 
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Engine\Tasks\TaskScheduler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -114,6 +115,17 @@ class RestApi {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( __CLASS__, 'get_post_status' ),
+				'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
+			)
+		);
+
+		// Get job status by job ID
+		register_rest_route(
+			self::NAMESPACE,
+			'/socials/jobs/(?P<job_id>\d+)',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'get_job_status' ),
 				'permission_callback' => array( __CLASS__, 'check_edit_permission' ),
 			)
 		);
@@ -1001,10 +1013,18 @@ class RestApi {
 	}
 
 	/**
-	 * Cross-platform post
+	 * Cross-platform post (always async)
+	 *
+	 * Validates input and schedules a DM job via TaskScheduler.
+	 * The job executes via the workflow engine (datamachine/execute-workflow)
+	 * which routes to SocialCrossPostTask::executeTask().
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
 	 */
 	public static function cross_post( \WP_REST_Request $request ) {
-		$params        = $request->get_json_params();
+		$params = $request->get_json_params();
+
 		$platforms     = $params['platforms'] ?? array();
 		$images        = $params['images'] ?? array();
 		$caption       = sanitize_textarea_field( $params['caption'] ?? '' );
@@ -1056,126 +1076,86 @@ class RestApi {
 			);
 		}
 
-		$results = array();
-		$errors  = array();
-
-		// Get source URL.
-		$source_url = $post_id ? get_permalink( $post_id ) : '';
-
-		// Build extra params for reel publishing.
-		$extra = array(
+		$task_params = array(
+			'post_id'       => $post_id,
+			'platforms'     => $platforms,
+			'caption'       => $caption,
+			'images'        => $images,
+			'aspect_ratio'  => $aspect_ratio,
 			'media_kind'    => $media_kind,
 			'video_url'     => $video_url,
 			'cover_url'     => $cover_url,
 			'share_to_feed' => $share_to_feed,
 		);
 
-		// Post to each platform.
-		foreach ( $platforms as $platform ) {
-			$result    = self::post_to_platform( $platform, $images, $caption, $source_url, $extra );
-			$results[] = $result;
+		$context = array(
+			'user_id' => get_current_user_id(),
+			'origin'  => 'rest_api',
+		);
 
-			if ( ! $result['success'] ) {
-				$errors[] = $platform . ': ' . $result['error'];
-			}
+		$job_id = TaskScheduler::schedule( 'social_cross_post', $task_params, $context );
 
-			// Track successful shares via SocialShareTracker.
-			if ( $post_id && ! empty( $result['success'] ) ) {
-				\DataMachineSocials\Tracking\SocialShareTracker::record_from_result(
-					$post_id,
-					$platform,
-					$result,
-					array( 'media_kind' => $media_kind )
-				);
-			}
+		if ( ! $job_id ) {
+			return new \WP_REST_Response(
+				array(
+					'success' => false,
+					'error'   => 'Failed to schedule cross-post job',
+				),
+				500
+			);
+		}
+
+		// Store job reference on post when available.
+		if ( $post_id ) {
+			update_post_meta( $post_id, '_studio_social_job_id', $job_id );
 		}
 
 		return new \WP_REST_Response(
 			array(
-				'success' => empty( $errors ),
-				'results' => $results,
-				'errors'  => $errors ? $errors : null,
+				'success' => true,
+				'job_id'  => $job_id,
+				'status'  => 'pending',
 			)
 		);
 	}
 
 	/**
-	 * Post to individual platform.
+	 * Get job status by job ID.
 	 *
-	 * @param string $platform   Platform slug.
-	 * @param array  $images     Array of image objects with 'url' key.
-	 * @param string $caption    Post caption.
-	 * @param string $source_url Source URL to attribute.
-	 * @param array  $extra      Extra params (media_kind, video_url, cover_url, share_to_feed).
-	 * @return array Result.
+	 * Returns the DM job record including engine_data (per-platform results).
+	 * Thin wrapper around datamachine/jobs-get ability.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
 	 */
-	private static function post_to_platform( string $platform, array $images, string $caption, string $source_url, array $extra = array() ): array {
-		$ability_slug = "datamachine/{$platform}-publish";
+	public static function get_job_status( \WP_REST_Request $request ) {
+		$job_id = intval( $request->get_param( 'job_id' ) );
 
-		$ability = wp_get_ability( $ability_slug );
+		$ability = wp_get_ability( 'datamachine/jobs-get' );
 
 		if ( ! $ability ) {
-			return array(
-				'platform' => $platform,
-				'success'  => false,
-				'error'    => "Ability {$ability_slug} not registered",
+			return new \WP_REST_Response(
+				array(
+					'success' => false,
+					'error'   => 'Job lookup ability not available',
+				),
+				500
 			);
 		}
 
-		$image_urls = array_map(
-			function ( $img ) {
-				return $img['url'] ?? '';
-			},
-			$images
-		);
+		$result = $ability->execute( array( 'job_id' => $job_id ) );
 
-		$input = array(
-			'content'    => $caption,
-			'image_urls' => $image_urls,
-			'source_url' => $source_url,
-		);
-
-		// Pass through media-kind-specific params when applicable.
-		$media_kind = $extra['media_kind'] ?? 'image';
-		if ( 'reel' === $media_kind ) {
-			$input['media_kind']    = 'reel';
-			$input['video_url']     = $extra['video_url'] ?? '';
-			$input['cover_url']     = $extra['cover_url'] ?? '';
-			$input['share_to_feed'] = $extra['share_to_feed'] ?? true;
-		} elseif ( 'story' === $media_kind ) {
-			$input['media_kind'] = 'story';
-			$input['video_url']  = $extra['video_url'] ?? '';
-			// For stories, image comes from story_image_url or first image_url.
-			if ( ! empty( $image_urls[0] ) && empty( $extra['video_url'] ) ) {
-				$input['story_image_url'] = $image_urls[0];
-			}
-		}
-
-		$result = $ability->execute( $input );
-
-		if ( is_wp_error( $result ) ) {
-			return array(
-				'platform' => $platform,
-				'success'  => false,
-				'error'    => $result->get_error_message(),
+		if ( is_wp_error( $result ) || empty( $result['success'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'success' => false,
+					'error'   => $result['error'] ?? 'Job not found',
+				),
+				404
 			);
 		}
 
-		if ( ! empty( $result['success'] ) ) {
-			return array(
-				'platform'         => $platform,
-				'success'          => true,
-				'platform_post_id' => \DataMachineSocials\Tracking\SocialShareTracker::extract_platform_post_id( $platform, $result ),
-				'platform_url'     => \DataMachineSocials\Tracking\SocialShareTracker::extract_platform_url( $platform, $result ),
-				'media_kind'       => $result['media_kind'] ?? null,
-			);
-		}
-
-		return array(
-			'platform' => $platform,
-			'success'  => false,
-			'error'    => $result['error'] ?? 'Unknown error',
-		);
+		return new \WP_REST_Response( $result );
 	}
 
 	/**

--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -3,18 +3,20 @@
  * Social Cross-Post Task for Data Machine Task System.
  *
  * Async cross-posting of published content to social platforms.
- * Fires via Action Scheduler after a post transitions to 'publish'.
+ * Fires via the workflow engine (datamachine/execute-workflow).
  * Each platform is posted sequentially within a single job.
  *
  * @package DataMachineSocials\Tasks
- * @since 0.9.0
+ * @since   0.9.0
+ * @since   0.12.0 Removed rest_do_request(); calls Publisher directly.
  */
 
 namespace DataMachineSocials\Tasks;
 
-defined( 'ABSPATH' ) || exit;
-
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachineSocials\Publisher;
+
+defined( 'ABSPATH' ) || exit;
 
 class SocialCrossPostTask extends SystemTask {
 
@@ -25,19 +27,14 @@ class SocialCrossPostTask extends SystemTask {
 	 * @param array $params Task parameters from engine_data.
 	 */
 	public function executeTask( int $jobId, array $params ): void {
-		$post_id   = absint( $params['post_id'] ?? 0 );
-		$platforms = $params['platforms'] ?? array();
-		$caption   = $params['caption'] ?? '';
-		$images    = $params['images'] ?? array();
+		$post_id      = absint( $params['post_id'] ?? 0 );
+		$platforms    = $params['platforms'] ?? array();
+		$caption      = $params['caption'] ?? '';
+		$images       = $params['images'] ?? array();
 		$media_kind   = $params['media_kind'] ?? 'image';
 		$aspect_ratio = $params['aspect_ratio'] ?? '4:5';
 		$video_url    = $params['video_url'] ?? '';
 		$cover_url    = $params['cover_url'] ?? '';
-
-		if ( $post_id <= 0 ) {
-			$this->failJob( $jobId, 'Missing or invalid post_id' );
-			return;
-		}
 
 		if ( empty( $platforms ) || ! is_array( $platforms ) ) {
 			$this->failJob( $jobId, 'No platforms specified' );
@@ -49,76 +46,55 @@ class SocialCrossPostTask extends SystemTask {
 			return;
 		}
 
-		// Call the cross-post REST endpoint internally.
-		$request = new \WP_REST_Request( 'POST', '/datamachine/v1/socials/post' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( array(
-			'platforms'     => $platforms,
-			'caption'       => $caption,
-			'images'        => $images,
-			'aspect_ratio'  => $aspect_ratio,
-			'media_kind'    => $media_kind,
-			'video_url'     => $video_url,
-			'cover_url'     => $cover_url,
-			'post_id'       => $post_id,
-			'share_to_feed' => true,
-		) ) );
+		// Publish directly via Publisher utility (no REST round-trip).
+		$publish_result = Publisher::cross_post( $params );
 
-		$response = rest_do_request( $request );
-		$data     = $response->get_data();
-
-		// Build per-platform result log.
-		$log      = array();
-		$failures = array();
-
-		if ( isset( $data['results'] ) && is_array( $data['results'] ) ) {
-			foreach ( $data['results'] as $result ) {
-				$entry = array(
-					'platform'  => $result['platform'] ?? 'unknown',
-					'success'   => $result['success'] ?? false,
-					'post_id'   => $result['platform_post_id'] ?? '',
-					'url'       => $result['platform_url'] ?? '',
-					'error'     => $result['error'] ?? '',
-					'timestamp' => gmdate( 'c' ),
-				);
-				$log[] = $entry;
-
-				if ( empty( $result['success'] ) ) {
-					$failures[] = ( $result['platform'] ?? 'unknown' ) . ': ' . ( $result['error'] ?? 'Unknown error' );
-				}
-			}
-		} else {
-			$log[] = array(
-				'platform'  => 'system',
-				'success'   => false,
-				'error'     => $data['error'] ?? 'Cross-post API returned unexpected response.',
-				'timestamp' => gmdate( 'c' ),
-			);
-			$failures[] = $data['error'] ?? 'Unexpected response';
-		}
-
-		// Store results in post meta.
-		$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true ) ?: array();
-		$merged_log   = array_merge( $existing_log, $log );
-		update_post_meta( $post_id, '_studio_social_publish_log', $merged_log );
-
-		// Complete or fail the job.
-		$successes = array_filter( $log, function ( $entry ) {
-			return ! empty( $entry['success'] );
-		} );
-
-		if ( empty( $successes ) ) {
-			$this->failJob( $jobId, 'All platforms failed: ' . implode( '; ', $failures ) );
+		if ( ! empty( $publish_result['error'] ) && empty( $publish_result['results'] ) ) {
+			// Validation-level failure (e.g. missing video_url for reel).
+			$this->failJob( $jobId, $publish_result['error'] );
 			return;
 		}
 
-		$this->completeJob( $jobId, array(
-			'post_id'       => $post_id,
+		$results  = $publish_result['results'] ?? array();
+		$errors   = $publish_result['errors'] ?? array();
+		$successes = array_filter( $results, fn( $r ) => ! empty( $r['success'] ) );
+
+		// Build normalized log entries.
+		$log = array();
+		foreach ( $results as $result ) {
+			$log[] = array(
+				'platform'  => $result['platform'] ?? 'unknown',
+				'success'   => $result['success'] ?? false,
+				'post_id'   => $result['platform_post_id'] ?? '',
+				'url'       => $result['platform_url'] ?? '',
+				'error'     => $result['error'] ?? '',
+				'timestamp' => gmdate( 'c' ),
+			);
+		}
+
+		// Store results in post meta when post_id is available.
+		if ( $post_id ) {
+			$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true ) ?: array();
+			$merged_log   = array_merge( $existing_log, $log );
+			update_post_meta( $post_id, '_studio_social_publish_log', $merged_log );
+		}
+
+		// Write full results to job engine_data.
+		$completion_data = array(
+			'post_id'       => $post_id ?: null,
 			'platforms'     => $platforms,
-			'results'       => $log,
+			'results'       => $results,
+			'log'           => $log,
 			'success_count' => count( $successes ),
-			'failure_count' => count( $failures ),
-		) );
+			'failure_count' => count( $errors ),
+		);
+
+		if ( empty( $successes ) ) {
+			$this->failJob( $jobId, 'All platforms failed: ' . implode( '; ', $errors ) );
+			return;
+		}
+
+		$this->completeJob( $jobId, $completion_data );
 	}
 
 	/**


### PR DESCRIPTION
Closes #51

Makes all social publishing async through the DM Task System.

## Changes

- Add Publisher utility class that extracts publishing logic from RestApi
- Refactor RestApi::cross_post() to always schedule a DM job
- Add GET /datamachine/v1/socials/jobs/{job_id} endpoint
- Rewrite SocialCrossPostTask::executeTask() to call abilities directly

## Architecture

Studio/REST/Chat -> TaskScheduler::schedule() -> execute-workflow -> Action Scheduler -> SystemTaskStep -> Publisher::cross_post() -> platforms

## Verification

- [ ] POST /socials/post returns { job_id, status: pending }
- [ ] GET /socials/jobs/{job_id} returns job with engine_data results
- [ ] SocialCrossPostTask executes without rest_do_request()
- [ ] Post publish hook still schedules and stores job_id
- [ ] Results stored in engine_data for job-level tracking
- [ ] Results stored in _studio_social_publish_log when post_id available