### PR TITLE
fix: use Facebook Login for Instagram Graph API auth

### DIFF
--- a/inc/Handlers/Instagram/InstagramAuth.php
+++ b/inc/Handlers/Instagram/InstagramAuth.php
@@ -20,10 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
-	const AUTH_URL      = 'https://www.instagram.com/oauth/authorize';
-	const TOKEN_URL     = 'https://api.instagram.com/oauth/access_token';
+	const AUTH_URL      = 'https://www.facebook.com/v18.0/dialog/oauth';
+	const TOKEN_URL     = 'https://graph.instagram.com/oauth/access_token';
 	const GRAPH_API_URL = 'https://graph.instagram.com';
-	const SCOPES        = 'instagram_business_basic,instagram_business_content_publish,instagram_business_manage_messages,instagram_business_manage_comments';
+	const SCOPES        = 'instagram_basic,instagram_content_publish,instagram_manage_messages,instagram_manage_comments,pages_read_engagement';
 
 	public function __construct() {
 		parent::__construct( 'instagram' );
@@ -134,7 +134,6 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			'scope'                => self::SCOPES,
 			'response_type'        => 'code',
 			'state'                => $state,
-			'enable_fb_login'      => '0',
 			'force_authentication' => '1',
 		);
 


### PR DESCRIPTION
Switches Instagram auth from the instagram.com/oauth/authorize endpoint (Basic Display) to facebook.com/v18.0/dialog/oauth (Graph API).

## Changes
- Updates AUTH_URL to Facebook Login dialog
- Updates TOKEN_URL to graph.instagram.com/oauth/access_token
- Updates scopes to Graph API format (instagram_basic, instagram_content_publish, etc.)
- Adds pages_read_engagement scope for Facebook Page verification
- Removes enable_fb_login=0 param (not needed for Facebook Login)

## Why
This fixes the "Invalid platform app" error when authenticating a Business-type Meta app for Instagram content publishing. The old instagram.com/oauth/authorize endpoint is for Basic Display (read-only), while publishing requires Graph API via Facebook Login.