### PR TITLE
fix: return save_account result from OAuth storage callback

### DIFF
--- a/inc/Handlers/Instagram/InstagramAuth.php
+++ b/inc/Handlers/Instagram/InstagramAuth.php
@@ -200,8 +200,9 @@ class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			},
 			null, // No token transform needed after exchange
 			function ( $account_data ) {
-				$this->save_account( $account_data );
+				$saved = $this->save_account( $account_data );
 				$this->schedule_proactive_refresh();
+				return $saved;
 			}
 		);
 	}


### PR DESCRIPTION
The storage_fn callback must return a boolean for OAuth2Handler to recognize the account data was saved successfully. Without a return value, $stored evaluates to null (falsy), triggering 'Failed to save authentication data.'