### PR TITLE
docs: add LinkedIn, Pinterest, and Reddit handler docs

### DIFF
--- a/docs/handlers/linkedin.md
+++ b/docs/handlers/linkedin.md
@@ -1,0 +1,114 @@
+# LinkedIn Publish Handler
+
+Posts content to LinkedIn using OAuth 2.0 authentication with media upload support and configurable post visibility.
+
+## Architecture
+
+**Base Class**: Extends PublishHandler (@since v0.5.0)
+
+**Handler Registration**: `linkedin_publish` via `HandlerRegistrationTrait`
+
+**Implementation**: Tool-first architecture via `handle_tool_call()` method for AI agents
+
+**Capabilities**: publish (text up to 3000 chars, images, article sharing)
+
+## Authentication
+
+**OAuth 2.0 Required**: Uses LinkedIn authorization code flow with `client_id`/`client_secret` from [LinkedIn Developers](https://linkedin.com/developers).
+
+**Provider**: `LinkedInAuth` extends `BaseOAuth2Provider` with:
+- Authorization URL: `https://www.linkedin.com/oauth/v2/authorization`
+- Token URL: `https://www.linkedin.com/oauth/v2/accessToken`
+- Userinfo URL: `https://api.linkedin.com/v2/userinfo` (OpenID Connect)
+- Scopes: `openid profile email w_member_social`
+- API version header: `202603`
+
+**Token Refresh**: Supports `refresh_token` grant for programmatic token renewal. Access tokens last 60 days.
+
+**Configuration Fields** (`LinkedInAuth::get_config_fields()`):
+- `client_id` (required): LinkedIn application Client ID
+- `client_secret` (required): LinkedIn application Client Secret
+
+## Configuration Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `visibility` | string | No | Post visibility: `PUBLIC` or `CONNECTIONS` (default: `PUBLIC`) |
+
+## Source URL Attribution
+
+**Engine Data Source**: `source_url` retrieved from fetch handlers via `datamachine_engine_data` filter
+
+Content and source URL are assembled by `LinkedInPublishAbility::execute_publish()` which handles the actual API call.
+
+## Usage Examples
+
+**Basic Tool Call**:
+```php
+$parameters = [
+    'content' => 'This is my LinkedIn post content'
+];
+
+$tool_def = [
+    'handler_config' => [
+        'visibility' => 'PUBLIC'
+    ]
+];
+
+$result = $handler->handle_tool_call($parameters, $tool_def);
+```
+
+**With Media**:
+```php
+$parameters = [
+    'content' => 'Important announcement about new features.',
+    'source_url' => 'https://example.com/article',
+    'image_url' => 'https://example.com/image.jpg'
+];
+```
+
+## Media Support
+
+- Image uploads via engine data (`getImagePath()`)
+- Up to 9 images per post
+- Any aspect ratio supported
+
+## Tool Call Response
+
+**Success Response**:
+```php
+[
+    'success' => true,
+    'data' => [
+        'post_id' => 'linkedin_post_urn',
+        'post_url' => 'https://www.linkedin.com/feed/update/{post_id}',
+        'content' => 'Posted content'
+    ],
+    'tool_name' => 'linkedin_publish'
+]
+```
+
+**Error Response**:
+```php
+[
+    'success' => false,
+    'error' => 'Error description',
+    'tool_name' => 'linkedin_publish'
+]
+```
+
+## Settings
+
+`LinkedInSettings` extends `PublishHandlerSettings` with:
+- `visibility`: Select (`PUBLIC` or `CONNECTIONS`) — controls who can see published posts
+
+## Error Handling
+
+- **Authentication Errors**: Missing OAuth credentials, expired tokens, profile fetch failures
+- **Content Errors**: Empty content parameter, API post creation failures
+- **Media Errors**: Invalid image paths, upload failures
+
+## API Integration
+
+- Uses `LinkedInAuth::api_request()` for authenticated API calls with required headers (`Authorization`, `Linkedin-Version`, `X-Restli-Protocol-Version`)
+- Person URN resolved from stored `person_id` via `LinkedInAuth::get_person_urn()`

--- a/docs/handlers/pinterest.md
+++ b/docs/handlers/pinterest.md
@@ -1,0 +1,137 @@
+# Pinterest Publish Handler
+
+Creates pins on Pinterest via API v5 with OAuth 2.0 authentication, board selection (pre-selected, AI-decides, or category-mapped), and media upload support.
+
+## Architecture
+
+**Base Class**: Extends PublishHandler (@since v0.3.0)
+
+**Handler Registration**: `pinterest_publish` via `HandlerRegistrationTrait`
+
+**Implementation**: Tool-first architecture via `handle_tool_call()` method for AI agents
+
+**Capabilities**: publish (1 image per pin, 2:3 aspect ratio, up to 500 char description)
+
+## Authentication
+
+**OAuth 2.0 Required**: Uses Pinterest authorization code flow with `App ID`/`App Secret` from [developers.pinterest.com](https://developers.pinterest.com).
+
+**Provider**: `PinterestAuth` extends `BaseOAuth2Provider` with:
+- Authorization URL: `https://www.pinterest.com/oauth/`
+- Token URL: `https://api.pinterest.com/v5/oauth/token`
+- Scopes: `boards:read,pins:read,pins:write,user_accounts:read`
+- Basic Auth required for token exchange and refresh
+
+**Token Lifecycle**:
+- Access tokens expire in 30 days (production)
+- Refresh tokens valid for 1 year and rotated on use — new refresh token must be stored after each refresh
+- Proactive refresh via WP-Cron at `(expires_at - 7 day buffer)`
+
+**Configuration Fields** (`PinterestAuth::get_config_fields()`):
+- `client_id` / `App ID` (required)
+- `client_secret` / `App Secret` (required)
+
+## Configuration Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `board_id` | string | Conditional | Pinterest board ID (required if no default set) |
+| `title` | string | Yes | Pin title (max 100 characters) |
+| `description` | string | Yes | Pin description (max 500 characters) |
+
+## Board Selection
+
+Three modes configured via `PinterestSettings`:
+
+1. **Pre-selected** (`board_selection_mode: 'pre_selected'`): Uses the default `board_id` from handler settings. No AI choice.
+
+2. **AI Decides** (`board_selection_mode: 'ai_decides'`): AI agent picks a board from cached board list. The handler injects available board names + IDs into the tool parameter description at runtime so the AI can select. Boards cached via `PinterestBoardsAbility::get_cached_boards()`.
+
+3. **Category Mapping** (`board_selection_mode: 'category_mapping'`): Maps WordPress post categories to Pinterest boards via `board_mapping` config (format: `category_slug=board_id`, one per line). Resolved by `PinterestBoardsAbility::resolve_board_id()`.
+
+**Resolution order**: AI parameter `board_id` → category mapping → default `board_id` from settings.
+
+## Source URL Attribution
+
+**Engine Data Source**: `source_url` retrieved from fetch handlers. Used as the pin's `link` field to drive traffic back to the source.
+
+## Media Support
+
+- **Images**: Uploaded via `source_type: 'image_url'` with the publicly accessible image URL from engine data
+- **Video**: Supported via `source_type: 'video_id'` with a cover image URL
+- **Resolution**: Images resolved via `resolveMediaUrls()` which checks engine data for both image and video URLs
+- **Requirement**: At least one media URL (image or video) is required — pins cannot be text-only
+
+## Usage Examples
+
+**Basic Pin**:
+```php
+$parameters = [
+    'title' => 'Blog Post Title',
+    'description' => 'A brief description of the content',
+    'board_id' => '1234567890123456789'
+];
+
+$tool_def = [
+    'handler_config' => [
+        'board_id' => '1234567890123456789',
+        'board_selection_mode' => 'pre_selected'
+    ]
+];
+
+$result = $handler->handle_tool_call($parameters, $tool_def);
+```
+
+**AI Board Selection**:
+```php
+$tool_def = [
+    'handler_config' => [
+        'board_selection_mode' => 'ai_decides'
+    ]
+];
+// Tool parameter description will include: "Available boards: Board A (123), Board B (456)"
+```
+
+## Tool Call Response
+
+**Success Response**:
+```php
+[
+    'success' => true,
+    'data' => [
+        'pin_id' => 'pinterest_pin_id',
+        'pin_url' => 'https://www.pinterest.com/pin/{pin_id}/'
+    ],
+    'tool_name' => 'pinterest_publish'
+]
+```
+
+**Error Response**:
+```php
+[
+    'success' => false,
+    'error' => 'No publicly accessible media URL found for pin',
+    'tool_name' => 'pinterest_publish'
+]
+```
+
+## Settings
+
+`PinterestSettings` extends `PublishHandlerSettings` with:
+- `board_id`: Default Pinterest board ID
+- `board_selection_mode`: `pre_selected` | `ai_decides` | `category_mapping`
+- `board_mapping`: Category-to-board mapping (one per line: `category_slug=board_id`)
+
+## API Integration
+
+- Creates pins via `POST https://api.pinterest.com/v5/pins`
+- Expects 201 status on success with `id` in response
+- Bearer token from `PinterestAuth::get_valid_access_token()`
+- Image and video pins use different `media_source` structures
+
+## Error Handling
+
+- **Authentication Errors**: Missing or expired token, incomplete OAuth config
+- **Board Errors**: No board_id resolved, invalid board ID
+- **Media Errors**: No image/video URL in engine data, download failures
+- **API Errors**: Non-201 status codes, Pinterest API error messages

--- a/docs/handlers/reddit.md
+++ b/docs/handlers/reddit.md
@@ -1,0 +1,95 @@
+# Reddit Fetch Handler
+
+Fetches posts from Reddit subreddits via OAuth 2.0 with timeframe filtering, keyword matching, and batch fan-out support.
+
+## Architecture
+
+**Base Class**: Extends FetchHandler (@since v0.3.0)
+
+**Handler Registration**: `reddit` (fetch step) via `HandlerRegistrationTrait`
+
+**Implementation**: Delegates to `FetchRedditAbility` for core logic, returns eligible items as batch for fan-out
+
+**Note**: Reddit is a **fetch** handler (reads posts from subreddits), not a publish handler. Use `SubmitRedditAbility` and `ReplyRedditAbility` for writing.
+
+## Authentication
+
+**OAuth 2.0 Required**: Uses Reddit authorization code flow with `client_id`/`client_secret` from [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps).
+
+**Provider**: `RedditAuth` extends `BaseOAuth2Provider` with:
+- Authorization URL: `https://www.reddit.com/api/v1/authorize`
+- Token URL: `https://www.reddit.com/api/v1/access_token`
+- Scopes: `identity read submit vote`
+- Basic Auth required for token exchange (`client_id:client_secret`)
+- Tokens expire in 1 hour; refresh uses stored refresh_token
+
+**Configuration Fields** (`RedditAuth::get_config_fields()`):
+- `client_id` (required): Reddit application Client ID
+- `client_secret` (required): Reddit application Client Secret
+- `developer_username` (required): Reddit username registered in the app (used for User-Agent header)
+
+## Configuration Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subreddit` | string | Yes | Subreddit name (without r/ prefix) |
+| `sort_by` | string | No | Sort method: `hot`, `new`, `top`, `rising` (default: `hot`) |
+| `timeframe_limit` | string | No | Time filter for `top` sort: `hour`, `day`, `week`, `month`, `year`, `all_time` (default: `all_time`) |
+| `min_upvotes` | int | No | Minimum upvote threshold (default: 0) |
+| `min_comment_count` | int | No | Minimum comment count threshold (default: 0) |
+| `search` | string | No | Keyword filter for post titles and content |
+
+## Fetch Behavior
+
+1. Authenticates via `RedditAuth::get_valid_access_token()` (auto-refreshes expired tokens)
+2. Delegates to `FetchRedditAbility::execute()` with config parameters
+3. Fetches up to `fetch_batch_size` (100) posts across `max_pages` (5) pages
+4. Filters by upvotes, comment count, and keywords
+5. Checks processed items for dedup
+6. Downloads images for eligible posts via `ExecutionContext::downloadFile()`
+7. Returns all eligible items as batch array for fan-out via `PipelineBatchScheduler`
+
+## Data Output
+
+Each eligible item contains:
+```php
+[
+    'metadata' => [
+        'original_id' => 't3_abc123',
+        'dedup_key'   => 't3_abc123',
+        'source_url'  => 'https://reddit.com/r/subreddit/comments/abc123/...',
+        '_engine_data' => [
+            'source_url'      => 'https://reddit.com/...',
+            'image_file_path' => '/path/to/downloaded/image.jpg'
+        ]
+    ],
+    // ... post content fields
+]
+```
+
+## Image Handling
+
+- Reddit post images are downloaded to the file repository during fetch via `store_reddit_image()`
+- File naming: `reddit_image_{item_id}.{extension}`
+- Downloaded images are stored as `file_info` metadata for downstream pipeline steps
+
+## Settings
+
+`RedditSettings` provides subreddit and filter configuration for the handler.
+
+## CLI Commands
+
+`RedditCommand` provides WP-CLI access:
+- `wp datamachine reddit fetch` — fetch posts from a subreddit
+
+## Chat Tools
+
+- `VoteReddit` — upvote/downvote Reddit posts
+- `ReplyReddit` — reply to Reddit posts or comments
+- `SubmitReddit` — submit new posts to subreddits
+
+## Error Handling
+
+- **Authentication Errors**: Missing OAuth config, expired/revoked tokens, refresh failures
+- **API Errors**: Rate limiting (Reddit enforces per-app limits), subreddit not found, network timeouts
+- **Image Errors**: Download failures, invalid URLs — non-fatal (post still eligible without image)


### PR DESCRIPTION
## Summary

Adds documentation for the three handlers that lacked it:

- **LinkedIn** (`docs/handlers/linkedin.md`): OAuth 2.0 publish handler with media upload, visibility control (PUBLIC/CONNECTIONS), and API version header management.
- **Pinterest** (`docs/handlers/pinterest.md`): Pin creation via API v5 with three board selection modes (pre-selected, AI-decides, category mapping), video pin support, and token rotation handling.
- **Reddit** (`docs/handlers/reddit.md`): Fetch handler for subreddit posts with upvote/comment filtering, keyword search, image download, and batch fan-out architecture. Also documents the associated chat tools (VoteReddit, ReplyReddit, SubmitReddit).

Existing handler docs (Bluesky, Facebook, Instagram, Threads, Twitter) were audited and have no broken references.

## Test plan
- [ ] Verify handler docs match the actual implementation in `inc/Handlers/`
- [ ] Verify configuration parameters match `*Settings.php` field definitions
- [ ] Verify auth flows match `*Auth.php` implementations