### PR TITLE
feat!: clean /platforms REST contract — ordered array, slug, filter fetch handlers

### DIFF
--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -947,6 +947,35 @@ class RestApi {
 	 * Assembles from DM core's handler registry — each social handler
 	 * self-declares its constraints via the $meta parameter in registerHandler().
 	 * Auth status is folded in from the auth providers filter.
+	 *
+	 * Response shape (since v0.13.0):
+	 *
+	 *   {
+	 *     "platforms": [
+	 *       {
+	 *         "slug": "instagram",
+	 *         "label": "Instagram",
+	 *         "type": "publish",
+	 *         "authenticated": true,
+	 *         "username": "extrachill",
+	 *         "capabilities": [{ "slug": "publish", "label": "Publish" }, ...],
+	 *         ...meta fields like charLimit, maxImages, supportsCarousel
+	 *       },
+	 *       ...
+	 *     ]
+	 *   }
+	 *
+	 * Server-side rules:
+	 *   - Fetch-only handlers (e.g. Reddit) are filtered out — this endpoint
+	 *     is "where can I publish socially".
+	 *   - `slug` is always included on each entry; clients must not reconstruct
+	 *     it from object keys.
+	 *   - `capabilities` is canonicalised to `[{slug, label}]`. The legacy
+	 *     bare-string form is no longer accepted.
+	 *   - Sort: authenticated first, then alphabetical by label. This is the
+	 *     canonical display order; clients should render in array order.
+	 *   - The `{ platforms: [...] }` envelope leaves room to add metadata
+	 *     (totals, timestamps) without another breaking change.
 	 */
 	public static function get_platforms() {
 		$handler_abilities = new \DataMachine\Abilities\HandlerAbilities();
@@ -973,12 +1002,20 @@ class RestApi {
 				continue;
 			}
 
+			$type = $handler['type'] ?? 'publish';
+
+			// Skip fetch-only handlers (e.g. Reddit). Publish targets only.
+			if ( 'publish' !== $type ) {
+				continue;
+			}
+
 			$meta = $handler['meta'] ?? array();
 
-			$platforms[ $auth_key ] = array_merge(
+			$entry = array_merge(
 				array(
+					'slug'  => $auth_key,
 					'label' => $handler['label'] ?? $auth_key,
-					'type'  => $handler['type'] ?? 'publish',
+					'type'  => $type,
 				),
 				$meta,
 				array(
@@ -986,9 +1023,76 @@ class RestApi {
 					'username'      => $provider->get_username(),
 				)
 			);
+
+			$entry['capabilities'] = self::normalize_capabilities( $entry['capabilities'] ?? null );
+
+			$platforms[] = $entry;
 		}
 
-		return new \WP_REST_Response( $platforms );
+		// Sort: authenticated first, then alphabetical by label.
+		usort(
+			$platforms,
+			static function ( array $a, array $b ): int {
+				if ( $a['authenticated'] !== $b['authenticated'] ) {
+					return $a['authenticated'] ? -1 : 1;
+				}
+				return strcasecmp( $a['label'], $b['label'] );
+			}
+		);
+
+		return new \WP_REST_Response(
+			array(
+				'platforms' => $platforms,
+			)
+		);
+	}
+
+	/**
+	 * Normalise the `capabilities` shape declared by handlers.
+	 *
+	 * Accepts the canonical `[{slug, label}]` form, legacy bare-string lists
+	 * (`['publish', 'comments']`), or `null`/missing. Always returns a list
+	 * with at least one entry — every publish handler implicitly supports
+	 * `{slug:'publish', label:'Publish'}` so client renderers can rely on a
+	 * non-empty array without defaulting.
+	 *
+	 * @param mixed $raw Raw value from the handler's `meta['capabilities']`.
+	 * @return array<int, array{slug: string, label: string}>
+	 */
+	private static function normalize_capabilities( $raw ): array {
+		$default = array(
+			array(
+				'slug'  => 'publish',
+				'label' => 'Publish',
+			),
+		);
+
+		if ( ! is_array( $raw ) || empty( $raw ) ) {
+			return $default;
+		}
+
+		$normalised = array();
+
+		foreach ( $raw as $entry ) {
+			if ( is_string( $entry ) && '' !== $entry ) {
+				$normalised[] = array(
+					'slug'  => $entry,
+					'label' => ucfirst( $entry ),
+				);
+				continue;
+			}
+
+			if ( is_array( $entry ) && ! empty( $entry['slug'] ) ) {
+				$normalised[] = array(
+					'slug'  => (string) $entry['slug'],
+					'label' => isset( $entry['label'] ) && '' !== $entry['label']
+						? (string) $entry['label']
+						: ucfirst( (string) $entry['slug'] ),
+				);
+			}
+		}
+
+		return $normalised ?: $default;
 	}
 
 	/**

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -11,7 +11,26 @@ export async function getAuthStatus(): Promise<PlatformAuthStatus[]> {
 	return apiFetch({ path: `${REST_BASE}/auth/status` });
 }
 
-export async function getPlatforms(): Promise<Record<string, unknown>> {
+export interface PlatformCapability {
+	slug: string;
+	label: string;
+}
+
+export interface PlatformConfig {
+	slug: string;
+	label: string;
+	type: string;
+	authenticated: boolean;
+	username: string | null;
+	capabilities: PlatformCapability[];
+	[key: string]: unknown;
+}
+
+export interface PlatformsResponse {
+	platforms: PlatformConfig[];
+}
+
+export async function getPlatforms(): Promise<PlatformsResponse> {
 	return apiFetch({ path: `${REST_BASE}/platforms` });
 }
 


### PR DESCRIPTION
## Summary

`GET /datamachine/v1/socials/platforms` returned a slug-keyed object with implicit ordering (a side effect of which `new ()` calls fired first in `data-machine-socials.php`), included Reddit (a fetch handler) in a "where can I publish socially" list, and required every client to normalize capability shape and synthesize a `slug` field from object keys.

This is the upstream cause of the studio sidebar ordering question and a chunk of mirrored client logic across consumers.

## Breaking changes

### Old shape

```json
{
  "twitter":   { "label": "Twitter", "authenticated": true, ... },
  "facebook":  { "label": "Facebook", "authenticated": false, ... },
  "instagram": { "label": "Instagram", "authenticated": true, ... },
  "reddit":    { "label": "Reddit", "type": "fetch", ... },
  ...
}
```

### New shape

```json
{
  "platforms": [
    { "slug": "bluesky",   "label": "Bluesky",   "authenticated": true,  ... },
    { "slug": "instagram", "label": "Instagram", "authenticated": true,  ... },
    { "slug": "twitter",   "label": "Twitter",   "authenticated": true,  ... },
    { "slug": "facebook",  "label": "Facebook",  "authenticated": false, ... },
    { "slug": "linkedin",  "label": "LinkedIn",  "authenticated": false, ... },
    { "slug": "pinterest", "label": "Pinterest", "authenticated": false, ... },
    { "slug": "threads",   "label": "Threads",   "authenticated": false, ... }
  ]
}
```

## Server-side rules

- **Filter fetch-only handlers.** Reddit no longer appears. Endpoint name reflects intent (publish targets only).
- **Inject `slug` on every entry.** Clients no longer reconstruct it from object keys.
- **Normalize `capabilities` to canonical `[{slug, label}]`.** Legacy bare-string lists from older handlers are still accepted by the normaliser but converted; clients can rely on the canonical shape.
- **Sort: authenticated first, then alphabetical by label.** Stable, predictable, utility-first display order. Clients should render in array order — no client-side sort needed.
- **`{ platforms: [...] }` envelope.** Leaves room to add metadata (`total`, `last_updated`, `version`) without another breaking change.

## Verified locally

```
Authenticated (3): bluesky, instagram, twitter
Unauthenticated (4): facebook, linkedin, pinterest, threads
Reddit: filtered out (fetch handler)
```

## Coordinated rollout

This is **PR A** of a 3-PR cluster. Merge order matters:

1. **A** (this PR) — REST contract change in `data-machine-socials`
2. **B** — `extrachill-api-client` types + `getPlatforms()` signature update
3. **C** — `extrachill-studio` consumes the new shape

Studio + api-client will break against this PR until B + C land. Internal `getPlatforms()` export in DM Socials' own `src/utils/api.ts` updated in this PR for consistency (the export is unused by DM Socials' Gutenberg sidebar, which uses `getAuthStatus` instead, so no internal regression risk).

## Test plan

- ✅ `php -l` clean
- ✅ Live preview against production handlers confirms ordering + Reddit exclusion
- ⏳ Studio sidebar regression check after PRs B + C deploy