### PR TITLE
feat: datamachine_socials_platform_priority filter for ordering /platforms response

### DIFF
--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -1029,13 +1029,57 @@ class RestApi {
 			$platforms[] = $entry;
 		}
 
-		// Sort: authenticated first, then alphabetical by label.
+		/**
+		 * Filter the platform display priority list.
+		 *
+		 * Returns an ordered list of platform slugs that should be pinned to
+		 * the top of the response, in declared order. Slugs not in the list
+		 * fall through to the default sort (authenticated first, then
+		 * alphabetical by label).
+		 *
+		 * Pinned slugs bypass the authenticated-first rule. If a caller pins
+		 * an unauthenticated platform it will still appear at the top — the
+		 * filter respects caller intent. Clients that only want to render
+		 * authenticated platforms should filter on `authenticated` themselves.
+		 *
+		 * Example: pin Instagram to the top regardless of auth state.
+		 *
+		 *   add_filter( 'datamachine_socials_platform_priority', function ( $list ) {
+		 *       return array_merge( array( 'instagram' ), $list );
+		 *   } );
+		 *
+		 * @since 0.13.1
+		 * @param array $priority Ordered list of slugs to pin to the top. Default empty.
+		 */
+		$priority = apply_filters( 'datamachine_socials_platform_priority', array() );
+		$priority = is_array( $priority ) ? array_values( array_filter( array_map( 'strval', $priority ) ) ) : array();
+
+		// Sort: pinned (in $priority order) → authenticated → alphabetical by label.
 		usort(
 			$platforms,
-			static function ( array $a, array $b ): int {
+			static function ( array $a, array $b ) use ( $priority ): int {
+				$a_idx = array_search( $a['slug'], $priority, true );
+				$b_idx = array_search( $b['slug'], $priority, true );
+
+				// 1. Pinned beats unpinned.
+				if ( false !== $a_idx && false === $b_idx ) {
+					return -1;
+				}
+				if ( false !== $b_idx && false === $a_idx ) {
+					return 1;
+				}
+
+				// 2. Both pinned: declared priority order.
+				if ( false !== $a_idx && false !== $b_idx ) {
+					return $a_idx - $b_idx;
+				}
+
+				// 3. Both unpinned: authenticated first.
 				if ( $a['authenticated'] !== $b['authenticated'] ) {
 					return $a['authenticated'] ? -1 : 1;
 				}
+
+				// 4. Then alphabetical by label.
 				return strcasecmp( $a['label'], $b['label'] );
 			}
 		);


### PR DESCRIPTION
## Summary

Adds a `datamachine_socials_platform_priority` filter so any plugin can pin platform slugs to the top of the `/datamachine/v1/socials/platforms` response in declared order. Default behavior unchanged when nothing hooks the filter.

This is **PR D** of a 2-PR pair — [extrachill-studio#25](https://github.com/Extra-Chill/extrachill-studio/pull/25) hooks the filter to pin Instagram first.

## Background

The previous `/platforms` contract sorted platforms `(authenticated DESC, label ASC)`. That's the right default but not the right answer for every consumer. Studio wants Instagram pinned to the top because Extra Chill's social workflow centers on Instagram.

Two approaches were considered:

- **Studio-local sort in React** — re-introduces the client-side sort logic we just deleted in [#131](https://github.com/Extra-Chill/data-machine-socials/pull/131). Studio-only, so DM Socials' own Gutenberg sidebar wouldn't benefit.
- **Server-side filter primitive** — any plugin can hook in. Pure WP idiom. Future consumers (artist platform, venue dashboards, etc.) get the same primitive for free.

We picked the filter primitive.

## Filter contract

```php
/**
 * @param array $priority Ordered list of platform slugs to pin to the top. Default empty.
 */
$priority = apply_filters( 'datamachine_socials_platform_priority', array() );
```

Returns an ordered `string[]` of platform slugs. Slugs not in the list fall through to the default sort (authenticated → A-Z).

### Behavior

```
1. Pinned slugs (in declared order)        ← from filter
2. Unpinned, authenticated (A-Z)
3. Unpinned, unauthenticated (A-Z)
```

### Pinned + unauthenticated

Pinned slugs **bypass the authenticated-first rule**. If a caller pins an unauthenticated platform, it still appears at the top. This honors caller intent. Clients that only want to render authenticated platforms should filter on `authenticated` themselves (Studio's React already does this).

### Defensive normalization

The filter result is run through `array_filter(array_map('strval', ...))` and `array_values(...)` so plugins can't accidentally inject non-strings or sparse arrays. Empty/invalid filter results fall back to the default sort.

## Verified locally

With `add_filter('datamachine_socials_platform_priority', fn($p) => array_merge(['instagram'], $p))`:

```
1. instagram   pinned
2. bluesky     unpinned authed A-Z
3. twitter     unpinned authed A-Z
4. facebook    unpinned unauthed A-Z
5. linkedin    unpinned unauthed A-Z
6. pinterest   unpinned unauthed A-Z
7. threads     unpinned unauthed A-Z
```

Without the filter (default behavior): unchanged from v0.13.0.

## Test plan

- ✅ `php -l` clean
- ✅ Live preview with simulated Studio filter confirms Instagram pin
- ✅ Default (no filter) preserves v0.13.0 sort order
- ⏳ Studio sidebar manual check after PR E deploy