### PR TITLE
fix: use Facebook Graph API for Instagram media operations

### DIFF
--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -20,7 +20,13 @@ class InstagramDeleteAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.instagram.com';
+	/**
+	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
+	 * graph.instagram.com rejects these with "Cannot parse access token" (code 190).
+	 *
+	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
+	 */
+	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
 
 	public function __construct() {
 		if ( ! class_exists( 'WP_Ability' ) ) {

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -34,9 +34,16 @@ class InstagramPublishAbility {
 	private static bool $registered = false;
 
 	/**
-	 * Instagram Graph API base URL
+	 * Instagram Graph API base URL.
+	 *
+	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens
+	 * via Facebook Login. graph.instagram.com rejects these with "Cannot parse
+	 * access token" (code 190). graph.facebook.com accepts both FB-flavored and
+	 * legacy IG Basic Display tokens for all Instagram Content Publishing endpoints.
+	 *
+	 * @see InstagramAuth — same reasoning as the v0.12.1 username lookup fix.
 	 */
-	const GRAPH_API_URL = 'https://graph.instagram.com';
+	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
 
 	/**
 	 * Maximum images per carousel

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -22,7 +22,13 @@ class InstagramReadAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.instagram.com';
+	/**
+	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
+	 * graph.instagram.com rejects these with "Cannot parse access token" (code 190).
+	 *
+	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
+	 */
+	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
 
 	/**
 	 * Regex for extracting @mentions from comment text.

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -21,7 +21,13 @@ class InstagramUpdateAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.instagram.com';
+	/**
+	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
+	 * graph.instagram.com rejects these with "Cannot parse access token" (code 190).
+	 *
+	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
+	 */
+	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
 
 	/**
 	 * Max caption length.


### PR DESCRIPTION
## Summary

- **Switch all Instagram media API calls from `graph.instagram.com` to `graph.facebook.com/v18.0`** — our OAuth flow uses Facebook Login which mints FB-flavored tokens; `graph.instagram.com` rejects these with error code 190 ("Cannot parse access token")
- Same root cause already fixed in v0.12.1 for username lookup (`InstagramAuth`), now applied to the media operations layer
- Affects: container creation, status polling, `media_publish`, permalink fetch, media listing, caption editing, deletion, and archiving

## Changed files

| File | Change |
|------|--------|
| `InstagramPublishAbility.php` | `GRAPH_API_URL` → `graph.facebook.com/v18.0` |
| `InstagramReadAbility.php` | `GRAPH_API_URL` → `graph.facebook.com/v18.0` |
| `InstagramUpdateAbility.php` | `GRAPH_API_URL` → `graph.facebook.com/v18.0` |
| `InstagramDeleteAbility.php` | `GRAPH_API_URL` → `graph.facebook.com/v18.0` |

## Residual risk

1. **Token refresh** — `InstagramAuth::do_refresh_token()` still uses `graph.instagram.com/refresh_access_token` with `ig_refresh_token` grant. May also reject FB-flavored tokens. Separate fix needed.
2. **API version** — v18.0 matches `InstagramAuth`. `InstagramCommentReplyAbility` and Facebook abilities use v23.0. Future alignment PR.
3. **No integration test** — URL constant swap only; request shapes unchanged. Needs a real publish test post-deploy.