### PR TITLE
Refactor Reddit fetches onto core fresh candidates

### DIFF
--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -15,6 +15,7 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Steps\Fetch\FreshCandidateCollector;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -92,11 +93,6 @@ class FetchRedditAbility {
 								'default'     => '',
 								'description' => __( 'Search term to filter posts', 'data-machine-socials' ),
 							),
-							'processed_items'   => array(
-								'type'        => 'array',
-								'default'     => array(),
-								'description' => __( 'Array of already processed item IDs to skip', 'data-machine-socials' ),
-							),
 							'fetch_batch_size'  => array(
 								'type'        => 'integer',
 								'default'     => 100,
@@ -147,15 +143,57 @@ class FetchRedditAbility {
 	}
 
 	/**
-	 * Execute Reddit fetch ability.
+	 * Execute Reddit fetch ability without selection-time eligibility filtering.
 	 *
-	 * Returns all eligible posts across all pages. The pipeline engine
-	 * fans each one out into its own child job automatically.
+	 * Used for direct ability invocations (REST, MCP, ad-hoc PHP calls) where
+	 * there is no Data Machine pipeline context to consult for processed/claim
+	 * state. Returns every Reddit-side eligible post the pagination loop
+	 * surfaces, capped only by `max_pages` and Reddit's natural pagination.
+	 *
+	 * Pipeline-driven fetches go through `executeWithCollector()` so that the
+	 * Data Machine core `FreshCandidateCollector` owns processed/claimed/
+	 * reprocess eligibility decisions and pagination keeps scanning until the
+	 * collector fills up or the source is exhausted.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with fetched data or error.
+	 * @return array|\WP_Error Result with fetched data or error.
 	 */
 	public function execute( array $input ): array|\WP_Error {
+		return $this->runFetch( $input, null );
+	}
+
+	/**
+	 * Execute Reddit fetch ability with a Data Machine fresh-candidate collector.
+	 *
+	 * The collector receives every Reddit-side eligible candidate as we paginate,
+	 * and decides processed/claimed/reprocess eligibility using
+	 * `ExecutionContext::isItemProcessed()` / `isItemClaimed()` (so the
+	 * `datamachine_should_reprocess_item` filter applies consistently with the
+	 * authoritative `FetchHandler::get_fetch_data()` final dedupe). Pagination
+	 * continues until the collector is full or Reddit pagination terminates.
+	 *
+	 * @param array                   $input     Input parameters.
+	 * @param FreshCandidateCollector $collector Selection-time collector.
+	 * @return array|\WP_Error Result with fetched data or error.
+	 */
+	public function executeWithCollector( array $input, FreshCandidateCollector $collector ): array|\WP_Error {
+		return $this->runFetch( $input, $collector );
+	}
+
+	/**
+	 * Internal pagination loop shared by `execute()` and `executeWithCollector()`.
+	 *
+	 * @param array                        $input     Input parameters.
+	 * @param FreshCandidateCollector|null $collector Optional core fresh-candidate
+	 *                                                collector. When provided,
+	 *                                                pagination stops once the
+	 *                                                collector is full and the
+	 *                                                returned `items` come from
+	 *                                                `$collector->getAccepted()`.
+	 *                                                When null, every Reddit-side
+	 *                                                eligible candidate is returned.
+	 */
+	private function runFetch( array $input, ?FreshCandidateCollector $collector ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -168,7 +206,6 @@ class FetchRedditAbility {
 		$min_comment_count     = $config['min_comment_count'];
 		$comment_count_setting = $config['comment_count'];
 		$search_term           = $config['search'];
-		$processed_items       = $config['processed_items'];
 		$fetch_batch_size      = $config['fetch_batch_size'];
 		$max_pages             = $config['max_pages'];
 		$download_images       = $config['download_images'];
@@ -183,7 +220,14 @@ class FetchRedditAbility {
 				'level'   => 'error',
 				'message' => 'Reddit: Either subreddit or query must be provided.',
 			);
-			return new \WP_Error( 'missing_param', 'Either subreddit or query must be provided', array( 'status' => 400, 'logs' => $logs ) );
+			return new \WP_Error(
+				'missing_param',
+				'Either subreddit or query must be provided',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		if ( ! empty( $subreddit ) && ! preg_match( '/^[a-zA-Z0-9_]+$/', $subreddit ) ) {
@@ -192,7 +236,14 @@ class FetchRedditAbility {
 				'message' => 'Reddit: Invalid subreddit name format.',
 				'data'    => array( 'subreddit' => $subreddit ),
 			);
-			return new \WP_Error( 'missing_param', 'Invalid subreddit name format', array( 'status' => 400, 'logs' => $logs ) );
+			return new \WP_Error(
+				'missing_param',
+				'Invalid subreddit name format',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		$valid_sorts = array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' );
@@ -205,7 +256,14 @@ class FetchRedditAbility {
 					'valid_sorts'  => $valid_sorts,
 				),
 			);
-			return new \WP_Error( 'missing_param', 'Invalid sort parameter', array( 'status' => 400, 'logs' => $logs ) );
+			return new \WP_Error(
+				'missing_param',
+				'Invalid sort parameter',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		$mode_label = $is_global_search ? 'global search' : ( $is_subreddit_search ? "r/{$subreddit} search" : "r/{$subreddit}" );
@@ -270,7 +328,14 @@ class FetchRedditAbility {
 						'message' => 'Reddit: API request failed.',
 						'data'    => array( 'error' => $result['error'] ),
 					);
-					return new \WP_Error( 'api_error', $result['error'], array( 'status' => 500, 'logs' => $logs ) );
+					return new \WP_Error(
+						'api_error',
+						$result['error'],
+						array(
+							'status' => 500,
+							'logs'   => $logs,
+						)
+					);
 				} else {
 					break;
 				}
@@ -299,7 +364,14 @@ class FetchRedditAbility {
 						'message' => 'Reddit: Invalid JSON response.',
 						'data'    => array( 'error' => $error_message ),
 					);
-					return new \WP_Error( 'api_error', $error_message, array( 'status' => 500, 'logs' => $logs ) );
+					return new \WP_Error(
+						'api_error',
+						$error_message,
+						array(
+							'status' => 500,
+							'logs'   => $logs,
+						)
+					);
 				} else {
 					break;
 				}
@@ -354,15 +426,6 @@ class FetchRedditAbility {
 						);
 						continue;
 					}
-				}
-
-				if ( in_array( $current_item_id, $processed_items, true ) ) {
-					$logs[] = array(
-						'level'   => 'debug',
-						'message' => 'Reddit: Skipping item (already processed).',
-						'data'    => array( 'item_id' => $current_item_id ),
-					);
-					continue;
 				}
 
 				if ( $min_comment_count > 0 ) {
@@ -467,21 +530,66 @@ class FetchRedditAbility {
 					),
 				);
 
-				$eligible_items[] = array(
+				$candidate = array(
 					'data'       => $raw_data,
 					'source_url' => $source_url,
 					'item_id'    => $current_item_id,
 				);
+
+				if ( null === $collector ) {
+					// Direct REST/MCP/ad-hoc invocation — no DM core eligibility
+					// surface to consult; surface every Reddit-side eligible item.
+					$eligible_items[] = $candidate;
+					continue;
+				}
+
+				// Pipeline-driven fetch: defer processed/claimed/reprocess
+				// decisions to the core fresh-candidate collector. The
+				// collector also de-duplicates within this scan, so we don't
+				// need to track seen IDs ourselves.
+				if ( ! $collector->offer( (string) $current_item_id, $candidate ) ) {
+					if ( $collector->isFull() ) {
+						break;
+					}
+					continue;
+				}
+
+				if ( $collector->isFull() ) {
+					break;
+				}
+			}
+
+			if ( null !== $collector && $collector->isFull() ) {
+				$logs[] = array(
+					'level'   => 'debug',
+					'message' => 'Reddit: Fresh-candidate collector full, ending pagination.',
+					'data'    => array( 'page' => $pages_fetched ),
+				);
+				break;
 			}
 
 			$after_param = $response_data['data']['after'] ?? null;
 			if ( ! $after_param ) {
+				if ( null !== $collector ) {
+					$collector->markExhausted();
+				}
 				$logs[] = array(
 					'level'   => 'debug',
 					'message' => "Reddit: No 'after' parameter found, ending pagination.",
 				);
 				break;
 			}
+		}
+
+		// If we exited the pagination loop because we hit `max_pages` without
+		// either filling the collector or running out of Reddit `after`
+		// cursors, that is "scan budget exhausted", not source exhaustion —
+		// leave `source_exhausted=false` so callers can distinguish the two.
+
+		// Pipeline path: emit collector accepted set as the result so handler
+		// post-processing iterates only the items the core primitive blessed.
+		if ( null !== $collector ) {
+			$eligible_items = $collector->getAccepted();
 		}
 
 		if ( empty( $eligible_items ) ) {
@@ -531,7 +639,6 @@ class FetchRedditAbility {
 			'min_comment_count' => 0,
 			'comment_count'     => 0,
 			'search'            => '',
-			'processed_items'   => array(),
 			'fetch_batch_size'  => 100,
 			'max_pages'         => 5,
 			'download_images'   => true,

--- a/inc/Chat/Tools/FetchReddit.php
+++ b/inc/Chat/Tools/FetchReddit.php
@@ -170,7 +170,6 @@ class FetchReddit extends BaseTool {
 			'min_comment_count' => absint( $parameters['min_comment_count'] ?? 0 ),
 			'comment_count'     => absint( $parameters['comment_count'] ?? 0 ),
 			'search'            => $parameters['search'] ?? '',
-			'processed_items'   => array(),
 			'fetch_batch_size'  => 100,
 			'max_pages'         => 5,
 			'download_images'   => false,
@@ -183,11 +182,8 @@ class FetchReddit extends BaseTool {
 			return $this->buildErrorResponse( $error, $tool_name );
 		}
 
-		// The ability returns 'items' for multiple results, 'data' for single.
+		// The ability returns an 'items' array for all Reddit fetch results.
 		$items = $result['items'] ?? array();
-		if ( empty( $items ) && ! empty( $result['data'] ) ) {
-			$items = array( array( 'data' => $result['data'], 'source_url' => $result['source_url'] ?? '', 'item_id' => $result['item_id'] ?? '' ) );
-		}
 
 		if ( empty( $items ) ) {
 			$context_label = ! empty( $input['subreddit'] ) ? 'r/' . $input['subreddit'] : 'Reddit';

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -561,7 +561,6 @@ class RedditCommand {
 			'min_comment_count' => absint( $assoc_args['min-comments'] ?? 0 ),
 			'comment_count'     => absint( $assoc_args['comments'] ?? 0 ),
 			'search'            => $assoc_args['search'] ?? '',
-			'processed_items'   => array(),
 			'fetch_batch_size'  => 100,
 			'max_pages'         => 5,
 			'download_images'   => false, // CLI doesn't download images by default.
@@ -588,11 +587,6 @@ class RedditCommand {
 
 		// The ability returns 'items' array for multiple results.
 		$items = $result['items'] ?? array();
-
-		// Backward compat: single-result 'data' key.
-		if ( empty( $items ) && ! empty( $result['data'] ) ) {
-			$items = is_array( $result['data'] ) ? array( array( 'data' => $result['data'], 'source_url' => $result['source_url'] ?? '', 'item_id' => $result['item_id'] ?? '' ) ) : array();
-		}
 
 		if ( empty( $items ) ) {
 			WP_CLI::warning( 'No eligible posts found with the given filters.' );

--- a/inc/Handlers/Reddit/Reddit.php
+++ b/inc/Handlers/Reddit/Reddit.php
@@ -14,6 +14,7 @@
 namespace DataMachineSocials\Handlers\Reddit;
 
 use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\FreshCandidateCollector;
 use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 use DataMachineSocials\Abilities\Reddit\FetchRedditAbility;
@@ -98,8 +99,18 @@ class Reddit extends FetchHandler {
 	/**
 	 * Fetch Reddit posts with timeframe and keyword filtering.
 	 *
-	 * Delegates to FetchRedditAbility for core logic. Returns all eligible
-	 * posts as raw arrays for batch fan-out.
+	 * Delegates to FetchRedditAbility for Reddit-specific concerns
+	 * (pagination, API parameters, source filtering, identifier extraction)
+	 * and to the Data Machine core FreshCandidateCollector primitive for
+	 * processed/claimed/reprocess eligibility decisions.
+	 *
+	 * The collector lets pagination keep scanning past already-processed
+	 * top-of-feed results until it has enough fresh candidates for this
+	 * fetch cycle, instead of returning a no-item run when the most recent
+	 * subreddit posts have all already been imported.
+	 *
+	 * Final dedupe/claim/cap remain authoritative inside
+	 * `FetchHandler::get_fetch_data()`.
 	 *
 	 * Uses get_valid_access_token() for automatic token lifecycle management.
 	 */
@@ -117,10 +128,15 @@ class Reddit extends FetchHandler {
 			return array();
 		}
 
-		// Build processed items array from context
-		$processed_items = array();
+		// Build the core fresh-candidate collector. Selection-time eligibility
+		// (processed/claimed/reprocess) is decided by Data Machine core, not by
+		// Reddit. The ability paginates Reddit and offers each candidate to the
+		// collector; the collector stops the scan once we have enough fresh
+		// candidates to satisfy this fetch cycle's max_items target.
+		$max_items = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
+		$collector = new FreshCandidateCollector( $context, $max_items );
 
-		// Delegate to ability
+		// Delegate Reddit-specific concerns to the ability.
 		$ability_input = array(
 			'subreddit'         => $config['subreddit'] ?? '',
 			'access_token'      => $access_token,
@@ -130,14 +146,13 @@ class Reddit extends FetchHandler {
 			'min_comment_count' => isset( $config['min_comment_count'] ) ? absint( $config['min_comment_count'] ) : 0,
 			'comment_count'     => isset( $config['comment_count'] ) ? absint( $config['comment_count'] ) : 0,
 			'search'            => $config['search'] ?? '',
-			'processed_items'   => $processed_items,
 			'fetch_batch_size'  => 100,
 			'max_pages'         => 5,
 			'download_images'   => true,
 		);
 
 		$ability = new FetchRedditAbility();
-		$result  = $ability->execute( $ability_input );
+		$result  = $ability->executeWithCollector( $ability_input, $collector );
 
 		// Log ability logs
 		if ( ! empty( $result['logs'] ) && is_array( $result['logs'] ) ) {
@@ -154,7 +169,16 @@ class Reddit extends FetchHandler {
 			return array();
 		}
 
-		// No eligible items
+		// Surface collector diagnostics so an operator can tell whether a
+		// no-item run was caused by full top-of-feed processing vs. natural
+		// source exhaustion.
+		$context->log(
+			'debug',
+			'Reddit: Fresh-candidate scan complete',
+			$collector->getDiagnostics()
+		);
+
+		// No eligible items after selection-time filtering.
 		if ( empty( $result['items'] ) ) {
 			return array();
 		}
@@ -165,9 +189,11 @@ class Reddit extends FetchHandler {
 			$data    = $item['data'];
 			$item_id = $item['item_id'] ?? ( $data['metadata']['original_id'] ?? '' );
 
-			// Set dedup_key for centralized dedup in FetchHandler::dedup().
+			// Wire the canonical Data Machine dedupe key so
+			// FetchHandler::get_fetch_data() can run final
+			// dedupe/claim/cap on these items.
 			if ( $item_id ) {
-				$data['metadata']['dedup_key'] = $item_id;
+				$data['metadata']['item_identifier'] = (string) $item_id;
 			}
 
 			// Download image if present

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * FetchRedditAbility Tests
+ *
+ * Tests Reddit pagination against the Data Machine core fresh-candidate
+ * collector integration.
+ *
+ * @package DataMachineSocials\Tests\Unit\Abilities\Reddit
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities\Reddit;
+
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\FreshCandidateCollector;
+use DataMachineSocials\Abilities\Reddit\FetchRedditAbility;
+use WP_UnitTestCase;
+
+class FetchRedditAbilityTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	public function test_collector_skips_processed_first_result_and_accepts_later_fresh_result(): void {
+		$this->mockRedditPages(
+			array(
+				array(
+					'after' => null,
+					'posts' => array(
+						$this->redditPost( 'processed-1', 'Already imported' ),
+						$this->redditPost( 'fresh-1', 'Fresh post' ),
+					),
+				),
+			)
+		);
+
+		$collector = new FreshCandidateCollector(
+			$this->buildContext( array( 'processed-1' => true ) ),
+			1
+		);
+
+		$result = ( new FetchRedditAbility() )->executeWithCollector(
+			$this->fetchInput(),
+			$collector
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['items'] );
+		$this->assertSame( 'fresh-1', $result['items'][0]['item_id'] );
+
+		$diagnostics = $collector->getDiagnostics();
+		$this->assertSame( 2, $diagnostics['raw_seen'] );
+		$this->assertSame( 1, $diagnostics['processed_skipped'] );
+		$this->assertSame( 1, $diagnostics['accepted'] );
+	}
+
+	public function test_collector_paginates_until_fresh_candidate_is_found(): void {
+		$request_count = 0;
+		$this->mockRedditPages(
+			array(
+				array(
+					'after' => 'page-2',
+					'posts' => array(
+						$this->redditPost( 'processed-1', 'Already imported' ),
+					),
+				),
+				array(
+					'after' => null,
+					'posts' => array(
+						$this->redditPost( 'fresh-1', 'Fresh post' ),
+					),
+				),
+			),
+			$request_count
+		);
+
+		$collector = new FreshCandidateCollector(
+			$this->buildContext( array( 'processed-1' => true ) ),
+			1
+		);
+
+		$result = ( new FetchRedditAbility() )->executeWithCollector(
+			$this->fetchInput(),
+			$collector
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['items'] );
+		$this->assertSame( 'fresh-1', $result['items'][0]['item_id'] );
+		$this->assertSame( 2, $request_count );
+	}
+
+	/**
+	 * @param array<int,array{after:?string,posts:array<int,array<string,mixed>>}> $pages
+	 */
+	private function mockRedditPages( array $pages, ?int &$request_count = null ): void {
+		$request_count = 0;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $pages, &$request_count ) {
+				$page_index = $request_count;
+				++$request_count;
+
+				$page = $pages[ $page_index ] ?? array(
+					'after' => null,
+					'posts' => array(),
+				);
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'data' => array(
+								'after'    => $page['after'],
+								'children' => array_map(
+									static function ( array $post ): array {
+										return array(
+											'kind' => 't3',
+											'data' => $post,
+										);
+									},
+									$page['posts']
+								),
+							),
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * @param array<string,bool> $processed_map identifier => isItemProcessed result
+	 */
+	private function buildContext( array $processed_map = array() ): ExecutionContext {
+		$context = $this->getMockBuilder( ExecutionContext::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'isItemProcessed', 'isItemClaimed', 'isDirect', 'isStandalone' ) )
+			->getMock();
+
+		$context->method( 'isItemProcessed' )->willReturnCallback(
+			static function ( string $identifier ) use ( $processed_map ): bool {
+				return $processed_map[ $identifier ] ?? false;
+			}
+		);
+		$context->method( 'isItemClaimed' )->willReturn( false );
+		$context->method( 'isDirect' )->willReturn( true );
+		$context->method( 'isStandalone' )->willReturn( false );
+
+		return $context;
+	}
+
+	private function fetchInput(): array {
+		return array(
+			'subreddit'        => 'WordPress',
+			'access_token'     => 'reddit-token',
+			'fetch_batch_size' => 100,
+			'max_pages'        => 5,
+			'download_images'  => false,
+		);
+	}
+
+	private function redditPost( string $id, string $title ): array {
+		return array(
+			'id'           => $id,
+			'title'        => $title,
+			'selftext'     => 'Body for ' . $title,
+			'created_utc'  => time(),
+			'score'        => 10,
+			'num_comments' => 3,
+			'permalink'    => '/r/WordPress/comments/' . $id . '/',
+			'subreddit'    => 'WordPress',
+			'author'       => 'reddit_user',
+			'is_self'      => true,
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Refactors pipeline-driven Reddit fetches to use Data Machine core `FreshCandidateCollector` for selection-time processed/claimed/reprocess eligibility.
- Removes the old Reddit `processed_items` ability handoff and direct CLI/chat compatibility fallbacks.
- Adds focused coverage for processed top-of-feed results and pagination to later fresh candidates.

Fixes #135.

## Tests
- `php -l inc/Handlers/Reddit/Reddit.php && php -l inc/Abilities/Reddit/FetchRedditAbility.php && php -l inc/Cli/Commands/RedditCommand.php && php -l inc/Chat/Tools/FetchReddit.php && php -l tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-socials@refactor-core-candidate-collector --changed-only --errors-only --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine-socials@refactor-core-candidate-collector --file tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php --errors-only --summary`
- `homeboy test --path /Users/chubes/Developer/data-machine-socials@refactor-core-candidate-collector -- tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php` — 2 passed, 0 failed
- `npm run build`

## Caveats
- Full repo lint still reports unrelated pre-existing findings outside this change; changed runtime PHP and new test lint pass.
- Test run emitted a non-fatal Action Scheduler bootstrap notice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Refactoring Reddit candidate selection onto the Data Machine core fresh-candidate primitive and updating tests. Chris remains responsible for review and merge.