### PR TITLE
feat: declare preview shape on SocialPlatformConfig (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,71 @@ This plugin follows the Data Machine extension pattern:
 - **Discovery:** Core `HandlerAbilities` discovers handlers via WordPress filters
 - **Auth:** Core `AuthAbilities` manages OAuth flows and token storage
 
+## Handler API
+
+Each handler registers itself via `HandlerRegistrationTrait::registerHandler()` with
+a `meta` config array (the trailing `array(...)` argument). The shape exposed to
+clients via `GET /datamachine/v1/socials/platforms` is:
+
+```php
+array(
+    'charLimit'          => 280,                 // optional int
+    'maxImages'          => 4,                   // optional int
+    'aspectRatios'       => array( 'any' ),      // optional string[]
+    'defaultAspectRatio' => 'any',               // optional string
+    'supportsCarousel'   => false,               // optional bool
+    'supportsVideo'      => true,                // optional bool
+    'capabilities'       => array(               // optional, canonicalised server-side
+        array( 'slug' => 'publish', 'label' => 'Publish' ),
+    ),
+    'preview'            => array(               // optional — see "Preview shape" below
+        'aspectRatio'     => '16:9',
+        'captionPosition' => 'above',
+        'previewSurface'  => 'feed',
+    ),
+)
+```
+
+### Preview shape
+
+The `preview` field declares how clients should render a post preview for the
+platform. It exists so consumers (e.g. the Studio publish pane) can render
+platform-canonical previews **without any per-platform branching** — the client
+renders whatever shape the server declares.
+
+| Field | Values | Meaning |
+|---|---|---|
+| `aspectRatio` | `1:1`, `4:5`, `16:9`, `native` | How images are framed in the preview |
+| `captionPosition` | `above`, `below`, `overlay` | Where the caption renders relative to media |
+| `previewSurface` | `card`, `feed`, `square` | Visual chrome around the preview |
+
+Per-platform defaults declared in this plugin:
+
+| Platform | `aspectRatio` | `captionPosition` | `previewSurface` |
+|---|---|---|---|
+| Twitter / X | `16:9` | `above` | `feed` |
+| Bluesky | `16:9` | `above` | `feed` |
+| Threads | `native` | `below` | `feed` |
+| Instagram | `1:1` | `below` | `square` |
+| Facebook | `native` | `above` | `card` |
+| LinkedIn | `native` | `above` | `card` |
+| Pinterest | `4:5` | `below` | `square` |
+| Reddit | `native` | `above` | `card` |
+
+**Backwards compatibility.** `preview` is optional. Handlers that don't declare
+it (or older DM-Socials installs running against newer clients) get a generic
+feed-shaped default applied server-side:
+
+```php
+array(
+    'aspectRatio'     => 'native',
+    'captionPosition' => 'above',
+    'previewSurface'  => 'feed',
+)
+```
+
+The field is always present on the response — clients never have to default it.
+
 ## File Structure
 
 ```

--- a/inc/Handlers/Bluesky/Bluesky.php
+++ b/inc/Handlers/Bluesky/Bluesky.php
@@ -65,6 +65,11 @@ class Bluesky extends PublishHandler {
 			'capabilities'       => array(
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => '16:9',
+				'captionPosition' => 'above',
+				'previewSurface'  => 'feed',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/Facebook/Facebook.php
+++ b/inc/Handlers/Facebook/Facebook.php
@@ -75,6 +75,11 @@ class Facebook extends PublishHandler {
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 				array( 'slug' => 'comments', 'label' => 'Comments' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => 'native',
+				'captionPosition' => 'above',
+				'previewSurface'  => 'card',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/Instagram/Instagram.php
+++ b/inc/Handlers/Instagram/Instagram.php
@@ -94,6 +94,11 @@ class Instagram extends PublishHandler {
 				array( 'slug' => 'comments', 'label' => 'Comments' ),
 				array( 'slug' => 'giveaway', 'label' => 'Giveaway' ),
 			),
+			'preview'             => array(
+				'aspectRatio'     => '1:1',
+				'captionPosition' => 'below',
+				'previewSurface'  => 'square',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/LinkedIn/LinkedIn.php
+++ b/inc/Handlers/LinkedIn/LinkedIn.php
@@ -77,6 +77,11 @@ class LinkedIn extends PublishHandler {
 			'capabilities'       => array(
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => 'native',
+				'captionPosition' => 'above',
+				'previewSurface'  => 'card',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/Pinterest/Pinterest.php
+++ b/inc/Handlers/Pinterest/Pinterest.php
@@ -101,6 +101,11 @@ class Pinterest extends PublishHandler {
 			'capabilities'       => array(
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => '4:5',
+				'captionPosition' => 'below',
+				'previewSurface'  => 'square',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/Reddit/Reddit.php
+++ b/inc/Handlers/Reddit/Reddit.php
@@ -47,6 +47,11 @@ class Reddit extends FetchHandler {
 			array(
 				'charLimit' => 40000,
 				'scopes'    => 'identity read',
+				'preview'   => array(
+					'aspectRatio'     => 'native',
+					'captionPosition' => 'above',
+					'previewSurface'  => 'card',
+				),
 			)
 		);
 	}

--- a/inc/Handlers/Threads/Threads.php
+++ b/inc/Handlers/Threads/Threads.php
@@ -74,6 +74,11 @@ class Threads extends PublishHandler {
 			'capabilities'       => array(
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => 'native',
+				'captionPosition' => 'below',
+				'previewSurface'  => 'feed',
+			),
 			)
 		);
 	}

--- a/inc/Handlers/Twitter/Twitter.php
+++ b/inc/Handlers/Twitter/Twitter.php
@@ -76,6 +76,11 @@ class Twitter extends PublishHandler {
 			'capabilities'       => array(
 				array( 'slug' => 'publish', 'label' => 'Publish' ),
 			),
+			'preview'            => array(
+				'aspectRatio'     => '16:9',
+				'captionPosition' => 'above',
+				'previewSurface'  => 'feed',
+			),
 			)
 		);
 	}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -959,6 +959,11 @@ class RestApi {
 	 *         "authenticated": true,
 	 *         "username": "extrachill",
 	 *         "capabilities": [{ "slug": "publish", "label": "Publish" }, ...],
+	 *         "preview": {
+	 *           "aspectRatio":     "1:1" | "4:5" | "16:9" | "native",
+	 *           "captionPosition": "above" | "below" | "overlay",
+	 *           "previewSurface":  "card" | "feed" | "square"
+	 *         },
 	 *         ...meta fields like charLimit, maxImages, supportsCarousel
 	 *       },
 	 *       ...
@@ -972,6 +977,10 @@ class RestApi {
 	 *     it from object keys.
 	 *   - `capabilities` is canonicalised to `[{slug, label}]`. The legacy
 	 *     bare-string form is no longer accepted.
+	 *   - `preview` is always present. Handlers that don't declare it get a
+	 *     generic feed-shaped default (`aspectRatio=native`, `captionPosition=above`,
+	 *     `previewSurface=feed`). Clients should rely on this field — never
+	 *     branch on `slug` to pick preview chrome.
 	 *   - Sort: authenticated first, then alphabetical by label. This is the
 	 *     canonical display order; clients should render in array order.
 	 *   - The `{ platforms: [...] }` envelope leaves room to add metadata
@@ -1025,6 +1034,7 @@ class RestApi {
 			);
 
 			$entry['capabilities'] = self::normalize_capabilities( $entry['capabilities'] ?? null );
+			$entry['preview']      = self::normalize_preview( $entry['preview'] ?? null );
 
 			$platforms[] = $entry;
 		}
@@ -1137,6 +1147,49 @@ class RestApi {
 		}
 
 		return $normalised ?: $default;
+	}
+
+	/**
+	 * Normalise the `preview` shape declared by handlers.
+	 *
+	 * Each handler MAY declare a `preview` array describing how clients should
+	 * render a post preview for the platform. The shape is:
+	 *
+	 *   array(
+	 *       'aspectRatio'     => '1:1' | '4:5' | '16:9' | 'native',
+	 *       'captionPosition' => 'above' | 'below' | 'overlay',
+	 *       'previewSurface'  => 'card' | 'feed' | 'square',
+	 *   )
+	 *
+	 * Handlers that don't declare it (or declare an incomplete shape) get a
+	 * generic feed-shaped default applied server-side. This keeps clients
+	 * 100% data-driven — no per-platform branching for preview rendering.
+	 *
+	 * @param mixed $raw Raw value from the handler's `meta['preview']`.
+	 * @return array{aspectRatio: string, captionPosition: string, previewSurface: string}
+	 */
+	private static function normalize_preview( $raw ): array {
+		$default = array(
+			'aspectRatio'     => 'native',
+			'captionPosition' => 'above',
+			'previewSurface'  => 'feed',
+		);
+
+		if ( ! is_array( $raw ) ) {
+			return $default;
+		}
+
+		return array(
+			'aspectRatio'     => isset( $raw['aspectRatio'] ) && is_string( $raw['aspectRatio'] ) && '' !== $raw['aspectRatio']
+				? (string) $raw['aspectRatio']
+				: $default['aspectRatio'],
+			'captionPosition' => isset( $raw['captionPosition'] ) && is_string( $raw['captionPosition'] ) && '' !== $raw['captionPosition']
+				? (string) $raw['captionPosition']
+				: $default['captionPosition'],
+			'previewSurface'  => isset( $raw['previewSurface'] ) && is_string( $raw['previewSurface'] ) && '' !== $raw['previewSurface']
+				? (string) $raw['previewSurface']
+				: $default['previewSurface'],
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements Extra-Chill/data-machine-socials#140 — declares a `preview` shape on each handler's `SocialPlatformConfig` so downstream clients (Studio publish-pane preview, mobile app, etc.) can render platform-canonical post previews **without any per-platform branching**. The client renders whatever shape the server declares.

## Changes

- **8 handlers** under `inc/Handlers/{Twitter,Bluesky,Instagram,Threads,Facebook,LinkedIn,Pinterest,Reddit}/*.php` declare a `preview` array in their meta config, following the per-platform mapping in #140.
- **REST assembly** (`RestApi::get_platforms()`) gains a `normalize_preview()` step applied to every entry. Handlers that don't declare it (or declare an incomplete shape) get a generic feed-shaped default:

  ```php
  array(
      'aspectRatio'     => 'native',
      'captionPosition' => 'above',
      'previewSurface'  => 'feed',
  )
  ```

  The field is **always present** on the response — clients never default it.
- **README** gets a new "Handler API" section documenting the meta config shape with the per-platform preview mapping.

## Per-platform mapping

| Platform | aspectRatio | captionPosition | previewSurface |
|---|---|---|---|
| Twitter | 16:9 | above | feed |
| Bluesky | 16:9 | above | feed |
| Threads | native | below | feed |
| Instagram | 1:1 | below | square |
| Facebook | native | above | card |
| LinkedIn | native | above | card |
| Pinterest | 4:5 | below | square |
| Reddit | native | above | card |

## Companion PR — must merge together

This is the data-contract foundation for the Studio publish-pane preview architecture. The TypeScript types in `@extrachill/api-client` are updated in a companion PR — both should land together so consumers see a consistent surface:

- **api-client companion**: https://github.com/Extra-Chill/extrachill-api-client/pull/13

Downstream consumers (extrachill-studio#43, #44) are unblocked once both merge.

## Backwards compat

- `preview` is purely additive on the response. Existing publish-pane behavior is unchanged.
- Older clients that don't know about `preview` ignore it (extra JSON fields are tolerated).
- Newer clients running against an older DM-Socials install that pre-dates this would see `preview` missing — but this PR ships alongside the api-client companion; once both land, the server always emits the field.

## Verification

- [x] `php -l` clean on all 9 modified files
- [x] Handler entries inspected — `preview` keys placed inside the `meta` array passed to `registerHandler()` so they flow through to the REST response naturally
- [x] `RestApi::get_platforms()` docblock updated to document the new field

## Constraints

- No CHANGELOG.md edits — homeboy owns the changelog.
- No version bumps — homeboy owns version targets.
- Conventional commits used throughout (3 commits: 2 `feat:`, 1 `docs:`).

Refs: #140
