### PR TITLE
refactor: centralize Meta Graph API version (closes #150)

### DIFF
--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -20,7 +20,7 @@ class FacebookDeleteAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
+	const GRAPH_API_URL = FacebookAuth::GRAPH_API_URL;
 
 	public function __construct() {
 		if ( ! class_exists( 'WP_Ability' ) ) {

--- a/inc/Abilities/Facebook/FacebookPublishAbility.php
+++ b/inc/Abilities/Facebook/FacebookPublishAbility.php
@@ -12,6 +12,7 @@ namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -356,6 +357,6 @@ class FacebookPublishAbility {
 	 * @return string Full URL.
 	 */
 	private static function build_graph_url( string $path ): string {
-		return 'https://graph.facebook.com/v23.0/' . ltrim( $path, '/' );
+		return FacebookAuth::GRAPH_API_URL . '/' . ltrim( $path, '/' );
 	}
 }

--- a/inc/Abilities/Facebook/FacebookUpdateAbility.php
+++ b/inc/Abilities/Facebook/FacebookUpdateAbility.php
@@ -21,7 +21,7 @@ class FacebookUpdateAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
+	const GRAPH_API_URL = FacebookAuth::GRAPH_API_URL;
 
 	public function __construct() {
 		if ( ! class_exists( 'WP_Ability' ) ) {

--- a/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
+++ b/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +21,7 @@ class InstagramCommentReplyAbility {
 
 	private static bool $registered = false;
 
-	const GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
+	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	const MAX_REPLY_LENGTH = 1000;
 

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 
 defined( 'ABSPATH' ) || exit;
@@ -26,7 +27,7 @@ class InstagramDeleteAbility {
 	 *
 	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
 	 */
-	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
+	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	public function __construct() {
 		if ( ! class_exists( 'WP_Ability' ) ) {

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -16,6 +16,7 @@ namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -43,7 +44,7 @@ class InstagramPublishAbility {
 	 *
 	 * @see InstagramAuth — same reasoning as the v0.12.1 username lookup fix.
 	 */
-	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
+	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	/**
 	 * Maximum images per carousel

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -14,6 +14,7 @@ namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +29,7 @@ class InstagramReadAbility {
 	 *
 	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
 	 */
-	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
+	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	/**
 	 * Regex for extracting @mentions from comment text.

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,7 +28,7 @@ class InstagramUpdateAbility {
 	 *
 	 * @see InstagramPublishAbility::GRAPH_API_URL for full rationale.
 	 */
-	const GRAPH_API_URL = 'https://graph.facebook.com/v18.0';
+	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	/**
 	 * Max caption length.

--- a/inc/Handlers/Instagram/InstagramAuth.php
+++ b/inc/Handlers/Instagram/InstagramAuth.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Handlers\Instagram;
 
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,10 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class InstagramAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
-	const AUTH_URL      = 'https://www.facebook.com/v18.0/dialog/oauth';
-	const TOKEN_URL     = 'https://graph.facebook.com/v18.0/oauth/access_token';
+	const AUTH_URL      = 'https://www.facebook.com/' . FacebookAuth::GRAPH_API_VERSION . '/dialog/oauth';
+	const TOKEN_URL     = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION . '/oauth/access_token';
 	const GRAPH_API_URL = 'https://graph.instagram.com';
-	const FB_API_URL    = 'https://graph.facebook.com/v18.0';
+	const FB_API_URL    = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 	const SCOPES        = 'instagram_basic,instagram_content_publish,instagram_manage_messages,instagram_manage_comments,pages_read_engagement';
 
 	public function __construct() {

--- a/inc/Handlers/Threads/ThreadsAuth.php
+++ b/inc/Handlers/Threads/ThreadsAuth.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Handlers\Threads;
 
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -24,6 +25,17 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	const TOKEN_URL   = 'https://graph.threads.net/oauth/access_token';
 	const REFRESH_URL = 'https://graph.threads.net/refresh_access_token';
 	const SCOPES      = 'threads_basic,threads_content_publish';
+
+	/**
+	 * Meta Graph API base URL for graph.facebook.com calls (profile/permissions).
+	 *
+	 * Threads OAuth issues Meta-flavored tokens, so account profile and permission
+	 * endpoints hit graph.facebook.com. The Graph version is centralized on
+	 * {@see FacebookAuth::GRAPH_API_VERSION}. The Threads content API
+	 * (graph.threads.net/v1.0) is a separate host/API and is intentionally not
+	 * derived from this constant.
+	 */
+	const META_GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	public function __construct() {
 		parent::__construct( 'threads' );
@@ -252,7 +264,7 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	* @return array|\WP_Error Profile data or error
 	*/
 	private function get_user_profile( string $access_token ): array|\WP_Error {
-		$url = 'https://graph.facebook.com/v19.0/me?fields=id,name';
+		$url = self::META_GRAPH_API_URL . '/me?fields=id,name';
 
 		$result = HttpClient::get(
 			$url,
@@ -329,7 +341,7 @@ class ThreadsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		}
 
 		if ( $token ) {
-			$url    = 'https://graph.facebook.com/v19.0/me/permissions';
+			$url    = self::META_GRAPH_API_URL . '/me/permissions';
 			$result = HttpClient::delete(
 				$url,
 				array(


### PR DESCRIPTION
## Summary
Fixes #150 — the Meta Graph API version was hardcoded inconsistently across the plugin (v18.0, v19.0, and v23.0 all coexisting, even within a single provider). This refactor reconciles every `graph.facebook.com` / `www.facebook.com` call onto a **single source of truth**.

## Single source
`FacebookAuth::GRAPH_API_VERSION` (`'v23.0'`) is now the canonical Meta Graph version. It already drove all Facebook auth URLs (`AUTH_URL`, `TOKEN_URL`, `GRAPH_API_URL`); now Instagram and Threads derive from it too. No new base class was added — the constant lives where the correct pattern already existed, and consumers reference it directly (matching the pre-existing `FacebookReadAbility` → `FacebookAuth::GRAPH_API_URL` usage).

> Note: `BaseOAuth2Provider` lives in **data-machine core**, which must stay generic and Meta-agnostic per platform rules — so the centralization is kept entirely within data-machine-socials rather than pushed into core.

## Version reconciled to
**v23.0** — matching Facebook and the already-correct `InstagramCommentReplyAbility`.

## Files migrated
**Instagram** (was `v18.0`, except CommentReply already `v23.0`):
- `Handlers/Instagram/InstagramAuth.php` — `AUTH_URL`, `TOKEN_URL`, `FB_API_URL` now derived
- `Abilities/Instagram/InstagramPublishAbility.php`
- `Abilities/Instagram/InstagramReadAbility.php`
- `Abilities/Instagram/InstagramUpdateAbility.php`
- `Abilities/Instagram/InstagramDeleteAbility.php`
- `Abilities/Instagram/InstagramCommentReplyAbility.php` (was already `v23.0`, now derived for consistency)

**Threads** (was `v19.0`):
- `Handlers/Threads/ThreadsAuth.php` — added `META_GRAPH_API_URL` const (derived) for the `graph.facebook.com` profile/permissions calls

**Facebook** (re-hardcoded `v23.0` in 3 places — now derived so even Facebook has one source):
- `Abilities/Facebook/FacebookPublishAbility.php`
- `Abilities/Facebook/FacebookUpdateAbility.php`
- `Abilities/Facebook/FacebookDeleteAbility.php`

## Left separate (intentional — different host/API)
- `graph.threads.net/v1.0` — the Threads **content** API (publish/read/update/delete). Different host, different API surface; **not** part of the Meta Graph version. Left fully unchanged.
- `graph.instagram.com` — `InstagramAuth::GRAPH_API_URL`, a distinct host. Unchanged.

## Verification
- `grep 'graph.facebook.com/vNN' inc/` → **0 hardcodes** remain.
- All `graph.threads.net` URLs confirmed untouched.
- `php -l` passes on all 10 changed files.
- The existing `InstagramCommentReplyAbilityTest` assertion (`graph.facebook.com/v23.0/...`) still holds — the const resolves to `v23.0`.

cc <@532385681268408341>