### PR TITLE
refactor: extract AbstractSocialAbility + AbstractSocialTool (closes #149)

### DIFF
--- a/inc/Abilities/AbstractSocialAbility.php
+++ b/inc/Abilities/AbstractSocialAbility.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Abstract Social Ability
+ *
+ * Base class for the social primitive abilities in inc/Abilities. Centralizes
+ * the register scaffold (the `$registered` guard plus the
+ * did_action/doing_action dispatch), the auth-resolve preamble, and the
+ * wp_remote response normalization that every platform ability repeated.
+ *
+ * The base intentionally exposes reusable helpers rather than a rigid template
+ * method: the per-platform execute bodies differ substantially (endpoints,
+ * payloads, multi-step media flows, error field paths), so subclasses keep
+ * their own execute logic and opt into the shared scaffold via:
+ *
+ * - registerAbility()        Register one or more abilities once, guarded.
+ * - resolveProvider()        Resolve + authenticate the platform provider.
+ * - normalizeJsonResponse()  Decode a wp_remote response into data + status.
+ * - apiError()               Build the standard api_error WP_Error.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities
+ * @since      0.6.0
+ */
+
+namespace DataMachineSocials\Abilities;
+
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract base for social abilities.
+ */
+abstract class AbstractSocialAbility {
+
+	/**
+	 * Whether this ability has been registered.
+	 *
+	 * @var bool
+	 */
+	protected static bool $registered = false;
+
+	/**
+	 * Register the ability's wp_register_ability() calls exactly once.
+	 *
+	 * Wraps the duplicated registration scaffold: the static $registered guard,
+	 * the optional WP_Ability availability check, and the
+	 * did_action/doing_action dispatch onto wp_abilities_api_init.
+	 *
+	 * @param callable $register_callback Closure that performs the
+	 *                                    wp_register_ability() call(s).
+	 * @param bool     $require_wp_ability When true, bail if WP_Ability is not
+	 *                                     yet available (matches the instance-
+	 *                                     callback ability flavor).
+	 * @return void
+	 */
+	protected function registerAbility( callable $register_callback, bool $require_wp_ability = false ): void {
+		if ( $require_wp_ability && ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( static::$registered ) {
+			return;
+		}
+
+		if ( did_action( 'wp_abilities_api_init' ) || doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+
+		static::$registered = true;
+	}
+
+	/**
+	 * Resolve and authenticate the platform auth provider.
+	 *
+	 * @param string $platform              Provider key (e.g. 'threads').
+	 * @param string $label                 Human-readable platform label for errors.
+	 * @param bool   $require_authenticated When true, enforce is_authenticated().
+	 * @return object|\WP_Error The provider on success, WP_Error otherwise.
+	 */
+	protected function resolveProvider( string $platform, string $label, bool $require_authenticated = true ) {
+		$auth     = new AuthAbilities();
+		$provider = $auth->getProvider( $platform );
+
+		if ( ! $provider ) {
+			return new \WP_Error( 'missing_auth', $label . ' not authenticated', array( 'status' => 401 ) );
+		}
+
+		if ( $require_authenticated && ! $provider->is_authenticated() ) {
+			return new \WP_Error( 'missing_auth', $label . ' not authenticated', array( 'status' => 401 ) );
+		}
+
+		return $provider;
+	}
+
+	/**
+	 * Normalize a wp_remote_* response into decoded data and status code.
+	 *
+	 * Returns a WP_Error('api_error') when the request itself errored. On a
+	 * transport-level success it returns an array with the decoded body and the
+	 * HTTP status code, leaving status interpretation to the caller (platforms
+	 * differ on success codes and error field paths).
+	 *
+	 * @param array|\WP_Error $response Result of wp_remote_post()/wp_remote_get().
+	 * @return array{data: mixed, status_code: int, body: string}|\WP_Error
+	 */
+	protected function normalizeJsonResponse( $response ) {
+		if ( is_wp_error( $response ) ) {
+			return $this->apiError( $response->get_error_message() );
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+
+		return array(
+			'data'        => json_decode( $body, true ),
+			'status_code' => (int) $status_code,
+			'body'        => $body,
+		);
+	}
+
+	/**
+	 * Whether an HTTP status code is in the 2xx success range.
+	 *
+	 * @param int $status_code HTTP status code.
+	 * @return bool
+	 */
+	protected function isSuccessStatus( int $status_code ): bool {
+		return $status_code >= 200 && $status_code < 300;
+	}
+
+	/**
+	 * Build the standard api_error WP_Error returned by social abilities.
+	 *
+	 * @param string $message Error message.
+	 * @param int    $status  HTTP status to attach. Default 500.
+	 * @return \WP_Error
+	 */
+	protected function apiError( string $message, int $status = 500 ): \WP_Error {
+		return new \WP_Error( 'api_error', $message, array( 'status' => $status ) );
+	}
+}

--- a/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
@@ -13,28 +13,20 @@ namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class BlueskyDeleteAbility {
+class BlueskyDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/bluesky-delete',
 				array(
@@ -65,12 +57,6 @@ class BlueskyDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Bluesky/BlueskyPublishAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyPublishAbility.php
@@ -12,40 +12,31 @@ namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Bluesky Publish Ability
  */
-class BlueskyPublishAbility {
+class BlueskyPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Bluesky publish ability.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/bluesky-publish',
 				array(
@@ -120,12 +111,6 @@ class BlueskyPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Bluesky/BlueskyReadAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyReadAbility.php
@@ -15,28 +15,20 @@ namespace DataMachineSocials\Abilities\Bluesky;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class BlueskyReadAbility {
+class BlueskyReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/bluesky-read',
 				array(
@@ -81,12 +73,6 @@ class BlueskyReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
@@ -14,28 +14,20 @@ namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class BlueskyUpdateAbility {
+class BlueskyUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/bluesky-update',
 				array(
@@ -71,12 +63,6 @@ class BlueskyUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -93,12 +93,13 @@ class FacebookDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		$normalized = $this->normalizeJsonResponse( $response );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = $normalized['status_code'];
+		$body        = $normalized['data'];
 
 		if ( 200 === $status_code || ( isset( $body['success'] ) && $body['success'] ) ) {
 			return array(
@@ -110,7 +111,7 @@ class FacebookDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to delete post', array( 'status' => 500 ) );
+		return $this->apiError( $body['error']['message'] ?? 'Failed to delete post' );
 	}
 
 	private function getAuthProvider(): ?FacebookAuth {

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -13,30 +13,22 @@ namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class FacebookDeleteAbility {
+class FacebookDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const GRAPH_API_URL = FacebookAuth::GRAPH_API_URL;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/facebook-delete',
 				array(
@@ -67,12 +59,6 @@ class FacebookDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Facebook/FacebookPublishAbility.php
+++ b/inc/Abilities/Facebook/FacebookPublishAbility.php
@@ -13,40 +13,31 @@ namespace DataMachineSocials\Abilities\Facebook;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Facebook Publish Ability
  */
-class FacebookPublishAbility {
+class FacebookPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Facebook publish ability.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/facebook-publish',
 				array(
@@ -131,12 +122,6 @@ class FacebookPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Facebook/FacebookReadAbility.php
+++ b/inc/Abilities/Facebook/FacebookReadAbility.php
@@ -15,32 +15,24 @@ namespace DataMachineSocials\Abilities\Facebook;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class FacebookReadAbility {
+class FacebookReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const LIST_FIELDS = 'id,message,created_time,permalink_url,full_picture,shares,likes.summary(true),comments.summary(true)';
 
 	const DETAIL_FIELDS = 'id,message,created_time,permalink_url,full_picture,shares,likes.summary(true),comments.summary(true),type,status_type';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/facebook-read',
 				array(
@@ -85,12 +77,6 @@ class FacebookReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Facebook/FacebookUpdateAbility.php
+++ b/inc/Abilities/Facebook/FacebookUpdateAbility.php
@@ -14,30 +14,22 @@ namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class FacebookUpdateAbility {
+class FacebookUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const GRAPH_API_URL = FacebookAuth::GRAPH_API_URL;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/facebook-update',
 				array(
@@ -77,12 +69,6 @@ class FacebookUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
+++ b/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
@@ -14,32 +14,24 @@ namespace DataMachineSocials\Abilities\Instagram;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class InstagramCommentReplyAbility {
+class InstagramCommentReplyAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	const MAX_REPLY_LENGTH = 1000;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/instagram-comment-reply',
 				array(
@@ -75,12 +67,6 @@ class InstagramCommentReplyAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -129,12 +129,13 @@ class InstagramDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		$normalized = $this->normalizeJsonResponse( $response );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = $normalized['status_code'];
+		$body        = $normalized['data'];
 
 		if ( 200 === $status_code || 204 === $status_code ) {
 			return array(
@@ -146,6 +147,6 @@ class InstagramDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Delete failed. The Instagram API may not support deletion for this media type. Consider archiving instead.', array( 'status' => 500 ) );
+		return $this->apiError( $body['error']['message'] ?? 'Delete failed. The Instagram API may not support deletion for this media type. Consider archiving instead.' );
 	}
 }

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -14,12 +14,13 @@ namespace DataMachineSocials\Abilities\Instagram;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class InstagramDeleteAbility {
+class InstagramDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
@@ -30,20 +31,11 @@ class InstagramDeleteAbility {
 	const GRAPH_API_URL = 'https://graph.facebook.com/' . FacebookAuth::GRAPH_API_VERSION;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/instagram-delete',
 				array(
@@ -74,12 +66,6 @@ class InstagramDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -17,6 +17,7 @@ namespace DataMachineSocials\Abilities\Instagram;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -25,14 +26,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Instagram Publish Ability
  */
-class InstagramPublishAbility {
+class InstagramPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Instagram Graph API base URL.
@@ -71,21 +72,11 @@ class InstagramPublishAbility {
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Instagram publish abilities.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/instagram-publish',
 				array(
@@ -195,12 +186,6 @@ class InstagramPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Instagram/InstagramReadAbility.php
+++ b/inc/Abilities/Instagram/InstagramReadAbility.php
@@ -16,12 +16,13 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class InstagramReadAbility {
+class InstagramReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
@@ -47,20 +48,11 @@ class InstagramReadAbility {
 	const DETAIL_FIELDS = 'id,caption,media_type,media_url,thumbnail_url,permalink,timestamp,like_count,comments_count,media_product_type,is_shared_to_feed';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			// List media ability.
 			wp_register_ability(
 				'datamachine/instagram-read',
@@ -106,12 +98,6 @@ class InstagramReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -15,12 +15,13 @@ namespace DataMachineSocials\Abilities\Instagram;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class InstagramUpdateAbility {
+class InstagramUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Uses Facebook Graph API because our OAuth flow issues FB-flavored tokens.
@@ -36,20 +37,11 @@ class InstagramUpdateAbility {
 	const MAX_CAPTION_LENGTH = 2200;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/instagram-update',
 				array(
@@ -90,12 +82,6 @@ class InstagramUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInDeleteAbility.php
@@ -15,28 +15,20 @@ namespace DataMachineSocials\Abilities\LinkedIn;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\LinkedIn\LinkedInAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class LinkedInDeleteAbility {
+class LinkedInDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/linkedin-delete',
 				array(
@@ -67,12 +59,6 @@ class LinkedInDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInPublishAbility.php
@@ -14,6 +14,7 @@ namespace DataMachineSocials\Abilities\LinkedIn;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\LinkedIn\LinkedInAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,34 +23,24 @@ defined( 'ABSPATH' ) || exit;
  *
  * Self-contained ability class for LinkedIn publishing.
  */
-class LinkedInPublishAbility {
+class LinkedInPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register LinkedIn publish ability.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/linkedin-publish',
 				array(
@@ -131,12 +122,6 @@ class LinkedInPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/LinkedIn/LinkedInReadAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInReadAbility.php
@@ -15,28 +15,20 @@ namespace DataMachineSocials\Abilities\LinkedIn;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\LinkedIn\LinkedInAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class LinkedInReadAbility {
+class LinkedInReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/linkedin-read',
 				array(
@@ -82,12 +74,6 @@ class LinkedInReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
+++ b/inc/Abilities/LinkedIn/LinkedInUpdateAbility.php
@@ -15,28 +15,20 @@ namespace DataMachineSocials\Abilities\LinkedIn;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\LinkedIn\LinkedInAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class LinkedInUpdateAbility {
+class LinkedInUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/linkedin-update',
 				array(
@@ -71,12 +63,6 @@ class LinkedInUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestAnalyticsAbility.php
@@ -15,12 +15,13 @@ namespace DataMachineSocials\Abilities\Pinterest;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class PinterestAnalyticsAbility {
+class PinterestAnalyticsAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const API_URL = 'https://api.pinterest.com/v5';
 
@@ -46,20 +47,11 @@ class PinterestAnalyticsAbility {
 	);
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/pinterest-analytics',
 				array(
@@ -113,12 +105,6 @@ class PinterestAnalyticsAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Pinterest/PinterestBoardsAbility.php
+++ b/inc/Abilities/Pinterest/PinterestBoardsAbility.php
@@ -14,6 +14,7 @@ namespace DataMachineSocials\Abilities\Pinterest;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Self-contained ability class following core patterns.
  */
-class PinterestBoardsAbility {
+class PinterestBoardsAbility extends AbstractSocialAbility {
 
 	/**
 	 * Option key for storing cached Pinterest boards.
@@ -43,27 +44,17 @@ class PinterestBoardsAbility {
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Pinterest board abilities.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			// Sync boards ability
 			wp_register_ability(
 				'datamachine/pinterest-sync-boards',
@@ -140,12 +131,6 @@ class PinterestBoardsAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Pinterest/PinterestDeleteAbility.php
+++ b/inc/Abilities/Pinterest/PinterestDeleteAbility.php
@@ -13,30 +13,22 @@ namespace DataMachineSocials\Abilities\Pinterest;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class PinterestDeleteAbility {
+class PinterestDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const API_URL = 'https://api.pinterest.com/v5';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/pinterest-delete',
 				array(
@@ -67,12 +59,6 @@ class PinterestDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Pinterest/PinterestPublishAbility.php
+++ b/inc/Abilities/Pinterest/PinterestPublishAbility.php
@@ -13,40 +13,31 @@ namespace DataMachineSocials\Abilities\Pinterest;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Pinterest Publish Ability
  */
-class PinterestPublishAbility {
+class PinterestPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Pinterest publish ability.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/pinterest-publish',
 				array(
@@ -101,12 +92,6 @@ class PinterestPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Pinterest/PinterestReadAbility.php
+++ b/inc/Abilities/Pinterest/PinterestReadAbility.php
@@ -15,30 +15,22 @@ namespace DataMachineSocials\Abilities\Pinterest;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class PinterestReadAbility {
+class PinterestReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const API_URL = 'https://api.pinterest.com/v5';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/pinterest-read',
 				array(
@@ -87,12 +79,6 @@ class PinterestReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Pinterest/PinterestUpdateAbility.php
+++ b/inc/Abilities/Pinterest/PinterestUpdateAbility.php
@@ -14,30 +14,22 @@ namespace DataMachineSocials\Abilities\Pinterest;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class PinterestUpdateAbility {
+class PinterestUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const API_URL = 'https://api.pinterest.com/v5';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/pinterest-update',
 				array(
@@ -73,12 +65,6 @@ class PinterestUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -16,28 +16,20 @@ namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Steps\Fetch\FreshCandidateCollector;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class FetchRedditAbility {
+class FetchRedditAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/fetch-reddit',
 				array(
@@ -125,12 +117,6 @@ class FetchRedditAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Reddit/ReplyRedditAbility.php
+++ b/inc/Abilities/Reddit/ReplyRedditAbility.php
@@ -13,12 +13,13 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class ReplyRedditAbility {
+class ReplyRedditAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Reddit OAuth API base URL.
@@ -31,20 +32,11 @@ class ReplyRedditAbility {
 	private const MAX_COMMENT_LENGTH = 10000;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/reply-reddit',
 				array(
@@ -84,12 +76,6 @@ class ReplyRedditAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Reddit/SubmitRedditAbility.php
+++ b/inc/Abilities/Reddit/SubmitRedditAbility.php
@@ -13,12 +13,13 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class SubmitRedditAbility {
+class SubmitRedditAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Reddit OAuth API base URL.
@@ -36,20 +37,11 @@ class SubmitRedditAbility {
 	private const MAX_TEXT_LENGTH = 40000;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/submit-reddit',
 				array(
@@ -120,12 +112,6 @@ class SubmitRedditAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Reddit/VoteRedditAbility.php
+++ b/inc/Abilities/Reddit/VoteRedditAbility.php
@@ -12,12 +12,13 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class VoteRedditAbility {
+class VoteRedditAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Reddit OAuth API base URL.
@@ -25,20 +26,11 @@ class VoteRedditAbility {
 	private const API_BASE = 'https://oauth.reddit.com';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/vote-reddit',
 				array(
@@ -78,12 +70,6 @@ class VoteRedditAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Threads/ThreadsDeleteAbility.php
+++ b/inc/Abilities/Threads/ThreadsDeleteAbility.php
@@ -12,31 +12,23 @@
 namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 use DataMachineSocials\Handlers\Threads\ThreadsAuth;
 
 defined( 'ABSPATH' ) || exit;
 
-class ThreadsDeleteAbility {
+class ThreadsDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const GRAPH_API_URL = 'https://graph.threads.net/v1.0';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/threads-delete',
 				array(
@@ -67,12 +59,6 @@ class ThreadsDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {
@@ -106,12 +92,13 @@ class ThreadsDeleteAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		$normalized = $this->normalizeJsonResponse( $response );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = $normalized['status_code'];
+		$body        = $normalized['data'];
 
 		if ( 200 === $status_code || 204 === $status_code ) {
 			return array(
@@ -123,7 +110,7 @@ class ThreadsDeleteAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to delete thread', array( 'status' => 500 ) );
+		return $this->apiError( $body['error']['message'] ?? 'Failed to delete thread' );
 	}
 
 	private function getAuthProvider(): ?ThreadsAuth {

--- a/inc/Abilities/Threads/ThreadsPublishAbility.php
+++ b/inc/Abilities/Threads/ThreadsPublishAbility.php
@@ -12,40 +12,36 @@ namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Threads Publish Ability
  */
-class ThreadsPublishAbility {
+class ThreadsPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
 	/**
-	 * Register Threads publish ability.
+	 * Build the Threads publish ability registration callback.
 	 *
-	 * @return void
+	 * @return callable
 	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/threads-publish',
 				array(
@@ -117,12 +113,6 @@ class ThreadsPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Threads/ThreadsReadAbility.php
+++ b/inc/Abilities/Threads/ThreadsReadAbility.php
@@ -14,13 +14,14 @@ namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\HttpClient;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 use DataMachineSocials\Handlers\Threads\ThreadsAuth;
 
 defined( 'ABSPATH' ) || exit;
 
-class ThreadsReadAbility {
+class ThreadsReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const API_URL = 'https://graph.threads.net/v1.0';
 
@@ -29,20 +30,11 @@ class ThreadsReadAbility {
 	const DETAIL_FIELDS = 'id,text,timestamp,media_type,media_url,permalink,like_count,is_quote_post,shortcode';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/threads-read',
 				array(
@@ -87,12 +79,6 @@ class ThreadsReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Threads/ThreadsUpdateAbility.php
+++ b/inc/Abilities/Threads/ThreadsUpdateAbility.php
@@ -13,31 +13,23 @@
 namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 use DataMachineSocials\Handlers\Threads\ThreadsAuth;
 
 defined( 'ABSPATH' ) || exit;
 
-class ThreadsUpdateAbility {
+class ThreadsUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const GRAPH_API_URL = 'https://graph.threads.net/v1.0';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/threads-update',
 				array(
@@ -73,12 +65,6 @@ class ThreadsUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {
@@ -141,12 +127,13 @@ class ThreadsUpdateAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		$normalized = $this->normalizeJsonResponse( $response );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = $normalized['status_code'];
+		$body        = $normalized['data'];
 
 		if ( 200 === $status_code || 204 === $status_code ) {
 			return array(
@@ -158,6 +145,6 @@ class ThreadsUpdateAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to delete thread', array( 'status' => 500 ) );
+		return $this->apiError( $body['error']['message'] ?? 'Failed to delete thread' );
 	}
 }

--- a/inc/Abilities/Twitter/TwitterDeleteAbility.php
+++ b/inc/Abilities/Twitter/TwitterDeleteAbility.php
@@ -13,28 +13,20 @@ namespace DataMachineSocials\Abilities\Twitter;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Twitter\TwitterAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class TwitterDeleteAbility {
+class TwitterDeleteAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/twitter-delete',
 				array(
@@ -65,12 +57,6 @@ class TwitterDeleteAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Twitter/TwitterPublishAbility.php
+++ b/inc/Abilities/Twitter/TwitterPublishAbility.php
@@ -13,6 +13,7 @@ namespace DataMachineSocials\Abilities\Twitter;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\EngineData;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,34 +22,24 @@ defined( 'ABSPATH' ) || exit;
  *
  * Self-contained ability class for Twitter publishing.
  */
-class TwitterPublishAbility {
+class TwitterPublishAbility extends AbstractSocialAbility {
 
 	/**
 	 * Whether the ability has been registered.
 	 *
 	 * @var bool
 	 */
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback() );
 	}
 
-	/**
-	 * Register Twitter publish ability.
-	 *
-	 * @return void
-	 */
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/twitter-publish',
 				array(
@@ -130,12 +121,6 @@ class TwitterPublishAbility {
 				)
 			);
 		};
-
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Abilities/Twitter/TwitterReadAbility.php
+++ b/inc/Abilities/Twitter/TwitterReadAbility.php
@@ -14,32 +14,24 @@ namespace DataMachineSocials\Abilities\Twitter;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Twitter\TwitterAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class TwitterReadAbility {
+class TwitterReadAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	const TWEET_FIELDS = 'id,text,created_at,public_metrics,source,lang,conversation_id';
 
 	const USER_FIELDS = 'id,name,username,profile_image_url,public_metrics,description';
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/twitter-read',
 				array(
@@ -84,12 +76,6 @@ class TwitterReadAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Twitter/TwitterUpdateAbility.php
+++ b/inc/Abilities/Twitter/TwitterUpdateAbility.php
@@ -14,28 +14,20 @@ namespace DataMachineSocials\Abilities\Twitter;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineSocials\Handlers\Twitter\TwitterAuth;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
 
-class TwitterUpdateAbility {
+class TwitterUpdateAbility extends AbstractSocialAbility {
 
-	private static bool $registered = false;
+	protected static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
-			return;
-		}
-
-		if ( self::$registered ) {
-			return;
-		}
-
-		$this->registerAbilities();
-		self::$registered = true;
+		$this->registerAbility( $this->registerCallback(), true );
 	}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
+	private function registerCallback(): callable {
+		return function () {
 			wp_register_ability(
 				'datamachine/twitter-update',
 				array(
@@ -71,12 +63,6 @@ class TwitterUpdateAbility {
 				)
 			);
 		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
 	}
 
 	/**

--- a/inc/Chat/Tools/AbstractSocialTool.php
+++ b/inc/Chat/Tools/AbstractSocialTool.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Abstract Social Chat Tool
+ *
+ * Base class for the social chat-tool wrappers in inc/Chat/Tools. Centralizes
+ * the duplicated tool-registration boilerplate and the auth-guard (provider
+ * resolution + the two diagnostic error blocks) that every social chat tool
+ * repeated verbatim.
+ *
+ * Subclasses supply:
+ * - $tool_name      The chat tool identifier (e.g. 'publish_threads').
+ * - $platform       The auth provider key (e.g. 'threads').
+ * - getToolDefinition()  The tool schema for the AI agent.
+ * - handle_tool_call()   The per-tool validation, input build, ability
+ *                        dispatch and result shaping.
+ *
+ * The auth-guard is invoked from handle_tool_call() via guardAuth(); it returns
+ * null when the platform is authenticated (and caches the resolved provider on
+ * $this->provider) or a diagnostic error response array when it is not.
+ *
+ * @package    DataMachineSocials
+ * @subpackage Chat\Tools
+ * @since      0.6.0
+ */
+
+namespace DataMachineSocials\Chat\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\AuthAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract base for social chat tools.
+ */
+abstract class AbstractSocialTool extends BaseTool {
+
+	/**
+	 * Chat tool identifier (e.g. 'publish_threads').
+	 *
+	 * @var string
+	 */
+	protected string $tool_name = '';
+
+	/**
+	 * Auth provider key for this platform (e.g. 'threads').
+	 *
+	 * @var string
+	 */
+	protected string $platform = '';
+
+	/**
+	 * Human-readable platform label for diagnostic messages (e.g. 'Threads').
+	 *
+	 * @var string
+	 */
+	protected string $platform_label = '';
+
+	/**
+	 * Resolved auth provider, populated by guardAuth().
+	 *
+	 * @var mixed
+	 */
+	protected $provider = null;
+
+	/**
+	 * Constructor registers the tool in the 'chat' mode.
+	 */
+	public function __construct() {
+		$this->registerTool( $this->tool_name, array( $this, 'getToolDefinition' ), array( 'chat' ) );
+	}
+
+	/**
+	 * Tool definition for the AI agent.
+	 *
+	 * @return array Tool definition.
+	 */
+	abstract public function getToolDefinition(): array;
+
+	/**
+	 * Handle the chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from the AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for the AI agent.
+	 */
+	abstract public function handle_tool_call( array $parameters, array $tool_def = array() ): array;
+
+	/**
+	 * Get the platform label used in diagnostic messages.
+	 *
+	 * Defaults to a title-cased platform key when not explicitly set.
+	 *
+	 * @return string
+	 */
+	protected function platformLabel(): string {
+		if ( '' !== $this->platform_label ) {
+			return $this->platform_label;
+		}
+
+		return ucfirst( $this->platform );
+	}
+
+	/**
+	 * Resolve and authenticate the platform provider.
+	 *
+	 * Returns null when the provider is available and authenticated (with the
+	 * provider cached on $this->provider), or a diagnostic error response array
+	 * to be returned from handle_tool_call() when it is not.
+	 *
+	 * @param bool $require_authenticated When true, also enforces is_authenticated().
+	 * @return array|null Diagnostic error response, or null on success.
+	 */
+	protected function guardAuth( bool $require_authenticated = true ): ?array {
+		$label          = $this->platformLabel();
+		$auth_abilities = new AuthAbilities();
+		$this->provider = $auth_abilities->getProvider( $this->platform );
+
+		if ( ! $this->provider ) {
+			return $this->buildDiagnosticErrorResponse(
+				$label . ' auth provider not available',
+				'prerequisite_missing',
+				$this->tool_name,
+				array(
+					'provider' => $this->platform,
+					'status'   => 'not_registered',
+				),
+				array(
+					'action'    => 'configure_' . $this->platform . '_auth',
+					'message'   => $label . ' OAuth needs to be configured in Data Machine Settings > Auth.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		if ( $require_authenticated && ! $this->provider->is_authenticated() ) {
+			return $this->buildDiagnosticErrorResponse(
+				$label . ' is not authenticated',
+				'prerequisite_missing',
+				$this->tool_name,
+				array(
+					'provider' => $this->platform,
+					'status'   => 'not_authenticated',
+				),
+				array(
+					'action'    => 'authenticate_' . $this->platform,
+					'message'   => $label . ' OAuth needs to be connected. Go to Data Machine Settings > Auth > ' . $label . '.',
+					'tool_hint' => 'authenticate_handler',
+				)
+			);
+		}
+
+		return null;
+	}
+}

--- a/inc/Chat/Tools/DeleteBluesky.php
+++ b/inc/Chat/Tools/DeleteBluesky.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteBluesky extends BaseTool {
+class DeleteBluesky extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_bluesky';
+
+	protected string $platform = 'bluesky';
+
+	protected string $platform_label = 'Bluesky';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeleteBluesky extends BaseTool {
 			return $this->buildErrorResponse( 'post_uri is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'bluesky' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'bluesky' ),
-				array( 'action' => 'configure_bluesky' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/bluesky-delete' );

--- a/inc/Chat/Tools/DeleteFacebook.php
+++ b/inc/Chat/Tools/DeleteFacebook.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteFacebook extends BaseTool {
+class DeleteFacebook extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_facebook';
+
+	protected string $platform = 'facebook';
+
+	protected string $platform_label = 'Facebook';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeleteFacebook extends BaseTool {
 			return $this->buildErrorResponse( 'post_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'facebook' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'facebook' ),
-				array( 'action' => 'configure_facebook' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/facebook-delete' );

--- a/inc/Chat/Tools/DeleteInstagram.php
+++ b/inc/Chat/Tools/DeleteInstagram.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteInstagram extends BaseTool {
+class DeleteInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeleteInstagram extends BaseTool {
 			return $this->buildErrorResponse( 'media_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'instagram' ),
-				array( 'action' => 'configure_instagram' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/instagram-delete' );

--- a/inc/Chat/Tools/DeleteLinkedIn.php
+++ b/inc/Chat/Tools/DeleteLinkedIn.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteLinkedIn extends BaseTool {
+class DeleteLinkedIn extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_linkedin', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_linkedin';
+
+	protected string $platform = 'linkedin';
+
+	protected string $platform_label = 'LinkedIn';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,41 +44,9 @@ class DeleteLinkedIn extends BaseTool {
 			return $this->buildErrorResponse( 'post_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'linkedin' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_linkedin_auth',
-					'message'   => 'Configure LinkedIn OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_linkedin',
-					'message'   => 'Connect LinkedIn via Data Machine Settings > Auth > LinkedIn.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/linkedin-delete' );

--- a/inc/Chat/Tools/DeletePinterest.php
+++ b/inc/Chat/Tools/DeletePinterest.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeletePinterest extends BaseTool {
+class DeletePinterest extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_pinterest';
+
+	protected string $platform = 'pinterest';
+
+	protected string $platform_label = 'Pinterest';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeletePinterest extends BaseTool {
 			return $this->buildErrorResponse( 'pin_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'pinterest' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'pinterest' ),
-				array( 'action' => 'configure_pinterest' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/pinterest-delete' );

--- a/inc/Chat/Tools/DeleteThreads.php
+++ b/inc/Chat/Tools/DeleteThreads.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteThreads extends BaseTool {
+class DeleteThreads extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_threads';
+
+	protected string $platform = 'threads';
+
+	protected string $platform_label = 'Threads';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeleteThreads extends BaseTool {
 			return $this->buildErrorResponse( 'thread_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'threads' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'threads' ),
-				array( 'action' => 'configure_threads' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/threads-delete' );

--- a/inc/Chat/Tools/DeleteTwitter.php
+++ b/inc/Chat/Tools/DeleteTwitter.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class DeleteTwitter extends BaseTool {
+class DeleteTwitter extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'delete_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'delete_twitter';
+
+	protected string $platform = 'twitter';
+
+	protected string $platform_label = 'Twitter';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -45,17 +44,9 @@ class DeleteTwitter extends BaseTool {
 			return $this->buildErrorResponse( 'tweet_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'twitter' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter auth not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'twitter' ),
-				array( 'action' => 'configure_twitter' )
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/twitter-delete' );

--- a/inc/Chat/Tools/FetchReddit.php
+++ b/inc/Chat/Tools/FetchReddit.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class FetchReddit extends BaseTool {
+class FetchReddit extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'fetch_reddit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'fetch_reddit';
+
+	protected string $platform = 'reddit';
+
+	protected string $platform_label = 'Reddit';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -90,44 +89,12 @@ class FetchReddit extends BaseTool {
 		}
 
 		// Get auth provider and valid token.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'reddit' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'reddit',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_reddit_auth',
-					'message'   => 'Reddit OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'reddit',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_reddit',
-					'message'   => 'Reddit OAuth needs to be connected. Go to Data Machine Settings > Auth > Reddit.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		$access_token = $provider->get_valid_access_token();
+		$access_token = $this->provider->get_valid_access_token();
 		if ( empty( $access_token ) ) {
 			return $this->buildDiagnosticErrorResponse(
 				'Reddit access token expired and refresh failed',

--- a/inc/Chat/Tools/PublishBluesky.php
+++ b/inc/Chat/Tools/PublishBluesky.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishBluesky extends BaseTool {
+class PublishBluesky extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_bluesky';
+
+	protected string $platform = 'bluesky';
+
+	protected string $platform_label = 'Bluesky';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -72,42 +71,9 @@ class PublishBluesky extends BaseTool {
 			return $this->buildErrorResponse( 'content is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'bluesky' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_bluesky_auth',
-					'message'   => 'Bluesky authentication needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_bluesky',
-					'message'   => 'Bluesky needs to be connected. Go to Data Machine Settings > Auth > Bluesky.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishFacebook.php
+++ b/inc/Chat/Tools/PublishFacebook.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishFacebook extends BaseTool {
+class PublishFacebook extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_facebook';
+
+	protected string $platform = 'facebook';
+
+	protected string $platform_label = 'Facebook';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -76,42 +75,9 @@ class PublishFacebook extends BaseTool {
 			return $this->buildErrorResponse( 'content is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'facebook' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_facebook_auth',
-					'message'   => 'Facebook OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_facebook',
-					'message'   => 'Facebook OAuth needs to be connected. Go to Data Machine Settings > Auth > Facebook.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishInstagram.php
+++ b/inc/Chat/Tools/PublishInstagram.php
@@ -13,16 +13,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishInstagram extends BaseTool {
+class PublishInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -80,42 +79,9 @@ class PublishInstagram extends BaseTool {
 			return $this->buildErrorResponse( 'image_urls is required (array of image URLs)', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishLinkedIn.php
+++ b/inc/Chat/Tools/PublishLinkedIn.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishLinkedIn extends BaseTool {
+class PublishLinkedIn extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_linkedin', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_linkedin';
+
+	protected string $platform = 'linkedin';
+
+	protected string $platform_label = 'LinkedIn';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -72,42 +71,9 @@ class PublishLinkedIn extends BaseTool {
 			return $this->buildErrorResponse( 'content is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'linkedin' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_linkedin_auth',
-					'message'   => 'LinkedIn OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_linkedin',
-					'message'   => 'LinkedIn OAuth needs to be connected. Go to Data Machine Settings > Auth > LinkedIn.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishPinterest.php
+++ b/inc/Chat/Tools/PublishPinterest.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishPinterest extends BaseTool {
+class PublishPinterest extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_pinterest';
+
+	protected string $platform = 'pinterest';
+
+	protected string $platform_label = 'Pinterest';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -84,42 +83,9 @@ class PublishPinterest extends BaseTool {
 			return $this->buildErrorResponse( 'image_url is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'pinterest' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'pinterest',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_pinterest_auth',
-					'message'   => 'Pinterest OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'pinterest',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_pinterest',
-					'message'   => 'Pinterest OAuth needs to be connected. Go to Data Machine Settings > Auth > Pinterest.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishReelInstagram.php
+++ b/inc/Chat/Tools/PublishReelInstagram.php
@@ -13,16 +13,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishReelInstagram extends BaseTool {
+class PublishReelInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_reel_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_reel_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -82,42 +81,9 @@ class PublishReelInstagram extends BaseTool {
 			return $this->buildErrorResponse( 'video_url is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishStoryInstagram.php
+++ b/inc/Chat/Tools/PublishStoryInstagram.php
@@ -13,16 +13,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishStoryInstagram extends BaseTool {
+class PublishStoryInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_story_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_story_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -68,42 +67,9 @@ class PublishStoryInstagram extends BaseTool {
 			return $this->buildErrorResponse( 'image_url or video_url is required for Story publishing', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishThreads.php
+++ b/inc/Chat/Tools/PublishThreads.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishThreads extends BaseTool {
+class PublishThreads extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_threads';
+
+	protected string $platform = 'threads';
+
+	protected string $platform_label = 'Threads';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -68,42 +67,9 @@ class PublishThreads extends BaseTool {
 			return $this->buildErrorResponse( 'content is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'threads' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_threads_auth',
-					'message'   => 'Threads OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_threads',
-					'message'   => 'Threads OAuth needs to be connected. Go to Data Machine Settings > Auth > Threads.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/PublishTwitter.php
+++ b/inc/Chat/Tools/PublishTwitter.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class PublishTwitter extends BaseTool {
+class PublishTwitter extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'publish_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'publish_twitter';
+
+	protected string $platform = 'twitter';
+
+	protected string $platform_label = 'Twitter';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -68,42 +67,9 @@ class PublishTwitter extends BaseTool {
 			return $this->buildErrorResponse( 'content is required', $tool_name );
 		}
 
-		// Get auth provider and check authentication.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'twitter' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_twitter_auth',
-					'message'   => 'Twitter OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_twitter',
-					'message'   => 'Twitter OAuth needs to be connected. Go to Data Machine Settings > Auth > Twitter.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Build ability input.

--- a/inc/Chat/Tools/ReadBluesky.php
+++ b/inc/Chat/Tools/ReadBluesky.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadBluesky extends BaseTool {
+class ReadBluesky extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_bluesky';
+
+	protected string $platform = 'bluesky';
+
+	protected string $platform_label = 'Bluesky';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -58,41 +57,9 @@ class ReadBluesky extends BaseTool {
 			return $this->buildErrorResponse( 'post_uri is required for the get action', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'bluesky' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_bluesky_auth',
-					'message'   => 'Configure Bluesky app password in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_bluesky',
-					'message'   => 'Configure Bluesky handle and app password in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/bluesky-read' );

--- a/inc/Chat/Tools/ReadFacebook.php
+++ b/inc/Chat/Tools/ReadFacebook.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadFacebook extends BaseTool {
+class ReadFacebook extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_facebook';
+
+	protected string $platform = 'facebook';
+
+	protected string $platform_label = 'Facebook';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -58,41 +57,9 @@ class ReadFacebook extends BaseTool {
 			return $this->buildErrorResponse( "post_id is required for the {$action} action", $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'facebook' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_facebook_auth',
-					'message'   => 'Configure Facebook OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_facebook',
-					'message'   => 'Connect Facebook via Data Machine Settings > Auth > Facebook.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/facebook-read' );

--- a/inc/Chat/Tools/ReadInstagram.php
+++ b/inc/Chat/Tools/ReadInstagram.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadInstagram extends BaseTool {
+class ReadInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -74,42 +73,9 @@ class ReadInstagram extends BaseTool {
 			return $this->buildErrorResponse( "media_id is required for the {$action} action", $tool_name );
 		}
 
-		// Get auth provider and valid token.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Get the ability.

--- a/inc/Chat/Tools/ReadLinkedIn.php
+++ b/inc/Chat/Tools/ReadLinkedIn.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadLinkedIn extends BaseTool {
+class ReadLinkedIn extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_linkedin', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_linkedin';
+
+	protected string $platform = 'linkedin';
+
+	protected string $platform_label = 'LinkedIn';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -54,41 +53,9 @@ class ReadLinkedIn extends BaseTool {
 			return $this->buildErrorResponse( 'post_id is required for the get action', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'linkedin' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_linkedin_auth',
-					'message'   => 'Configure LinkedIn OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_linkedin',
-					'message'   => 'Connect LinkedIn via Data Machine Settings > Auth > LinkedIn.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/linkedin-read' );

--- a/inc/Chat/Tools/ReadPinterest.php
+++ b/inc/Chat/Tools/ReadPinterest.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadPinterest extends BaseTool {
+class ReadPinterest extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_pinterest';
+
+	protected string $platform = 'pinterest';
+
+	protected string $platform_label = 'Pinterest';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -65,41 +64,9 @@ class ReadPinterest extends BaseTool {
 			return $this->buildErrorResponse( 'board_id is required for the board_pins action', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'pinterest' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'pinterest',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_pinterest_auth',
-					'message'   => 'Configure Pinterest access token in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'pinterest',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_pinterest',
-					'message'   => 'Set Pinterest access token in Data Machine Settings > Auth > Pinterest.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/pinterest-read' );

--- a/inc/Chat/Tools/ReadThreads.php
+++ b/inc/Chat/Tools/ReadThreads.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadThreads extends BaseTool {
+class ReadThreads extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_threads';
+
+	protected string $platform = 'threads';
+
+	protected string $platform_label = 'Threads';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -58,41 +57,9 @@ class ReadThreads extends BaseTool {
 			return $this->buildErrorResponse( "thread_id is required for the {$action} action", $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'threads' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_threads_auth',
-					'message'   => 'Configure Threads OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_threads',
-					'message'   => 'Connect Threads via Data Machine Settings > Auth > Threads.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/threads-read' );

--- a/inc/Chat/Tools/ReadTwitter.php
+++ b/inc/Chat/Tools/ReadTwitter.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReadTwitter extends BaseTool {
+class ReadTwitter extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'read_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'read_twitter';
+
+	protected string $platform = 'twitter';
+
+	protected string $platform_label = 'Twitter';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -58,41 +57,9 @@ class ReadTwitter extends BaseTool {
 			return $this->buildErrorResponse( 'tweet_id is required for the get action', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'twitter' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_twitter_auth',
-					'message'   => 'Configure Twitter OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_twitter',
-					'message'   => 'Connect Twitter via Data Machine Settings > Auth > Twitter.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/twitter-read' );

--- a/inc/Chat/Tools/ReplyInstagramComment.php
+++ b/inc/Chat/Tools/ReplyInstagramComment.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Abilities\AuthAbilities;
-use DataMachine\Engine\AI\Tools\BaseTool;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReplyInstagramComment extends BaseTool {
+class ReplyInstagramComment extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'reply_instagram_comment', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'reply_instagram_comment';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -56,41 +55,9 @@ class ReplyInstagramComment extends BaseTool {
 			return $this->buildErrorResponse( 'message is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/instagram-comment-reply' );

--- a/inc/Chat/Tools/ReplyReddit.php
+++ b/inc/Chat/Tools/ReplyReddit.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class ReplyReddit extends BaseTool {
+class ReplyReddit extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'reply_reddit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'reply_reddit';
+
+	protected string $platform = 'reddit';
+
+	protected string $platform_label = 'Reddit';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -56,36 +55,12 @@ class ReplyReddit extends BaseTool {
 			return $this->buildErrorResponse( 'text is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'reddit' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_registered' ),
-				array(
-					'action'  => 'configure_reddit_auth',
-					'message' => 'Reddit OAuth needs to be configured in Data Machine Settings > Auth.',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_authenticated' ),
-				array(
-					'action'  => 'authenticate_reddit',
-					'message' => 'Reddit OAuth needs to be connected with submit scope.',
-				)
-			);
-		}
-
-		$access_token = $provider->get_valid_access_token();
+		$access_token = $this->provider->get_valid_access_token();
 		if ( empty( $access_token ) ) {
 			return $this->buildDiagnosticErrorResponse(
 				'Reddit access token expired and refresh failed',

--- a/inc/Chat/Tools/SubmitReddit.php
+++ b/inc/Chat/Tools/SubmitReddit.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class SubmitReddit extends BaseTool {
+class SubmitReddit extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'submit_reddit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'submit_reddit';
+
+	protected string $platform = 'reddit';
+
+	protected string $platform_label = 'Reddit';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -72,36 +71,12 @@ class SubmitReddit extends BaseTool {
 			return $this->buildErrorResponse( 'title is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'reddit' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_registered' ),
-				array(
-					'action'  => 'configure_reddit_auth',
-					'message' => 'Reddit OAuth needs to be configured in Data Machine Settings > Auth.',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_authenticated' ),
-				array(
-					'action'  => 'authenticate_reddit',
-					'message' => 'Reddit OAuth needs to be connected with submit scope.',
-				)
-			);
-		}
-
-		$access_token = $provider->get_valid_access_token();
+		$access_token = $this->provider->get_valid_access_token();
 		if ( empty( $access_token ) ) {
 			return $this->buildDiagnosticErrorResponse(
 				'Reddit access token expired and refresh failed',

--- a/inc/Chat/Tools/UpdateBluesky.php
+++ b/inc/Chat/Tools/UpdateBluesky.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateBluesky extends BaseTool {
+class UpdateBluesky extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_bluesky', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_bluesky';
+
+	protected string $platform = 'bluesky';
+
+	protected string $platform_label = 'Bluesky';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -50,39 +49,9 @@ class UpdateBluesky extends BaseTool {
 			return $this->buildErrorResponse( 'post_uri is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'bluesky' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'  => 'configure_bluesky_auth',
-					'message' => 'Bluesky app password needs to be configured.',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Bluesky is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'bluesky',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'  => 'authenticate_bluesky',
-					'message' => 'Bluesky app password needs to be connected.',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/bluesky-update' );

--- a/inc/Chat/Tools/UpdateFacebook.php
+++ b/inc/Chat/Tools/UpdateFacebook.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateFacebook extends BaseTool {
+class UpdateFacebook extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_facebook', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_facebook';
+
+	protected string $platform = 'facebook';
+
+	protected string $platform_label = 'Facebook';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -59,42 +58,9 @@ class UpdateFacebook extends BaseTool {
 			return $this->buildErrorResponse( 'message is required for edit action', $tool_name );
 		}
 
-		// Get auth provider.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'facebook' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_facebook_auth',
-					'message'   => 'Facebook OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Facebook is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'facebook',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_facebook',
-					'message'   => 'Facebook OAuth needs to be connected. Go to Data Machine Settings > Auth > Facebook.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Get the ability.

--- a/inc/Chat/Tools/UpdateInstagram.php
+++ b/inc/Chat/Tools/UpdateInstagram.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateInstagram extends BaseTool {
+class UpdateInstagram extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_instagram', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_instagram';
+
+	protected string $platform = 'instagram';
+
+	protected string $platform_label = 'Instagram';
 
 	/**
 	 * Get tool definition for AI agent.
@@ -75,42 +74,9 @@ class UpdateInstagram extends BaseTool {
 			return $this->buildErrorResponse( 'caption is required for edit action', $tool_name );
 		}
 
-		// Get auth provider and valid token.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'instagram' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_instagram_auth',
-					'message'   => 'Instagram OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Instagram is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'instagram',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_instagram',
-					'message'   => 'Instagram OAuth needs to be connected. Go to Data Machine Settings > Auth > Instagram.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Get the ability.

--- a/inc/Chat/Tools/UpdateLinkedIn.php
+++ b/inc/Chat/Tools/UpdateLinkedIn.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateLinkedIn extends BaseTool {
+class UpdateLinkedIn extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_linkedin', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_linkedin';
+
+	protected string $platform = 'linkedin';
+
+	protected string $platform_label = 'LinkedIn';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -53,41 +52,9 @@ class UpdateLinkedIn extends BaseTool {
 			return $this->buildErrorResponse( 'commentary is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'linkedin' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_linkedin_auth',
-					'message'   => 'Configure LinkedIn OAuth in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'LinkedIn is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'linkedin',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_linkedin',
-					'message'   => 'Connect LinkedIn via Data Machine Settings > Auth > LinkedIn.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/linkedin-update' );

--- a/inc/Chat/Tools/UpdatePinterest.php
+++ b/inc/Chat/Tools/UpdatePinterest.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdatePinterest extends BaseTool {
+class UpdatePinterest extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_pinterest', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_pinterest';
+
+	protected string $platform = 'pinterest';
+
+	protected string $platform_label = 'Pinterest';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -50,23 +49,9 @@ class UpdatePinterest extends BaseTool {
 			return $this->buildErrorResponse( 'pin_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'pinterest' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Pinterest auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'pinterest',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'  => 'configure_pinterest_auth',
-					'message' => 'Pinterest API token needs to be configured.',
-				)
-			);
+		$auth_error = $this->guardAuth( false );
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/pinterest-update' );

--- a/inc/Chat/Tools/UpdateThreads.php
+++ b/inc/Chat/Tools/UpdateThreads.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateThreads extends BaseTool {
+class UpdateThreads extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_threads', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_threads';
+
+	protected string $platform = 'threads';
+
+	protected string $platform_label = 'Threads';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -50,39 +49,9 @@ class UpdateThreads extends BaseTool {
 			return $this->buildErrorResponse( 'thread_id is required', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'threads' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'  => 'configure_threads_auth',
-					'message' => 'Threads OAuth needs to be configured.',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Threads is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'threads',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'  => 'authenticate_threads',
-					'message' => 'Threads OAuth needs to be connected.',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		$ability = wp_get_ability( 'datamachine/threads-update' );

--- a/inc/Chat/Tools/UpdateTwitter.php
+++ b/inc/Chat/Tools/UpdateTwitter.php
@@ -9,16 +9,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class UpdateTwitter extends BaseTool {
+class UpdateTwitter extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'update_twitter', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'update_twitter';
+
+	protected string $platform = 'twitter';
+
+	protected string $platform_label = 'Twitter';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -51,42 +50,9 @@ class UpdateTwitter extends BaseTool {
 			return $this->buildErrorResponse( 'tweet_id is required', $tool_name );
 		}
 
-		// Get auth provider.
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'twitter' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_registered',
-				),
-				array(
-					'action'    => 'configure_twitter_auth',
-					'message'   => 'Twitter OAuth needs to be configured in Data Machine Settings > Auth.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
-		}
-
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Twitter is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array(
-					'provider' => 'twitter',
-					'status'   => 'not_authenticated',
-				),
-				array(
-					'action'    => 'authenticate_twitter',
-					'message'   => 'Twitter OAuth needs to be connected. Go to Data Machine Settings > Auth > Twitter.',
-					'tool_hint' => 'authenticate_handler',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
 		// Get the ability.

--- a/inc/Chat/Tools/VoteReddit.php
+++ b/inc/Chat/Tools/VoteReddit.php
@@ -12,16 +12,15 @@
 
 namespace DataMachineSocials\Chat\Tools;
 
-use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\AuthAbilities;
-
 defined( 'ABSPATH' ) || exit;
 
-class VoteReddit extends BaseTool {
+class VoteReddit extends AbstractSocialTool {
 
-	public function __construct() {
-		$this->registerTool( 'vote_reddit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
-	}
+	protected string $tool_name = 'vote_reddit';
+
+	protected string $platform = 'reddit';
+
+	protected string $platform_label = 'Reddit';
 
 	public function getToolDefinition(): array {
 		return array(
@@ -56,36 +55,12 @@ class VoteReddit extends BaseTool {
 			return $this->buildErrorResponse( 'direction is required (1, 0, or -1)', $tool_name );
 		}
 
-		$auth_abilities = new AuthAbilities();
-		$provider       = $auth_abilities->getProvider( 'reddit' );
-
-		if ( ! $provider ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit auth provider not available',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_registered' ),
-				array(
-					'action'  => 'configure_reddit_auth',
-					'message' => 'Reddit OAuth needs to be configured in Data Machine Settings > Auth.',
-				)
-			);
+		$auth_error = $this->guardAuth();
+		if ( null !== $auth_error ) {
+			return $auth_error;
 		}
 
-		if ( ! $provider->is_authenticated() ) {
-			return $this->buildDiagnosticErrorResponse(
-				'Reddit is not authenticated',
-				'prerequisite_missing',
-				$tool_name,
-				array( 'provider' => 'reddit', 'status' => 'not_authenticated' ),
-				array(
-					'action'  => 'authenticate_reddit',
-					'message' => 'Reddit OAuth needs to be connected with vote scope.',
-				)
-			);
-		}
-
-		$access_token = $provider->get_valid_access_token();
+		$access_token = $this->provider->get_valid_access_token();
 		if ( empty( $access_token ) ) {
 			return $this->buildDiagnosticErrorResponse(
 				'Reddit access token expired and refresh failed',


### PR DESCRIPTION
## Summary

Collapses the largest single duplication cluster on the platform (#149): ~73 files that copy-pasted the same register/auth/HTTP/dispatch scaffolding. Two new base classes — mirroring the existing `BaseOAuth2Provider` pattern that the OAuth layer already uses — now own the duplicated shell, and all 35 abilities + 35 chat tools were migrated onto them.

**Net result vs `main`: 72 files changed, ~854 insertions, ~2022 deletions (~1168 lines removed).**

## Base class design

### `inc/Chat/Tools/AbstractSocialTool.php` (extends DM core `BaseTool`)
Owns the boilerplate every social chat tool repeated:
- **Registration**: constructor calls `registerTool($tool_name, [$this,'getToolDefinition'], ['chat'])`. Subclasses just declare `protected string $tool_name/$platform/$platform_label`.
- **Auth-guard**: `guardAuth(bool $require_authenticated = true)` resolves the provider via `AuthAbilities::getProvider()`, runs the two ~30-line diagnostic blocks (`!$provider` → `not_registered`, `!is_authenticated()` → `not_authenticated`), caches the provider on `$this->provider`, and returns `null` on success or the diagnostic error array to return early. `guardAuth(false)` covers the delete-style tools that only checked provider presence.

### `inc/Abilities/AbstractSocialAbility.php`
Exposes reusable helpers rather than a rigid template method (the per-platform execute bodies differ too much — multi-step media flows, different endpoints/payloads/error paths — to force one shape without a redesign):
- **`registerAbility(callable $cb, bool $require_wp_ability = false)`** — owns the `static $registered` guard, the optional `class_exists('WP_Ability')` check, and the `did_action`/`doing_action` dispatch onto `wp_abilities_api_init`.
- **`resolveProvider($platform, $label, $require_authenticated = true)`** — the `new AuthAbilities() → getProvider → is_authenticated` preamble, returning the provider or the standard `missing_auth`/401 `WP_Error`.
- **`normalizeJsonResponse($response)`** — decodes a `wp_remote_*` result into `{ data, status_code, body }` or the standard `api_error` `WP_Error` on transport failure.
- **`isSuccessStatus()` / `apiError()`** — the 2xx check and the canonical `WP_Error('api_error', …, ['status'=>…])` builder.

## What was migrated

**Chat tools (35):** every `Publish/Read/Update/Delete` across Bluesky, Facebook, Instagram, LinkedIn, Pinterest, Twitter, Threads, plus Reddit (`fetch/reply/submit/vote`) and the Instagram `reel/story/comment` variants. Each now declares `$tool_name/$platform/$platform_label` and calls `guardAuth()` instead of repeating the auth shell. Reddit tools keep their platform-specific token-expired diagnostic, now reading the provider cached by `guardAuth()`.

**Abilities (35):** every ability migrated onto `registerAbility()`, removing the duplicated guard + dispatch scaffold. Threads (all 4) plus Facebook/Instagram delete additionally route their `wp_remote` handling through `normalizeJsonResponse()/apiError()` as cross-platform proof of the HTTP shell.

## Behavior preservation

- **Endpoints, payloads, auth flows, success shapes, and ability inputs are unchanged.**
- **Auth-error response *shape* is identical** (`buildDiagnosticErrorResponse` with the same keys); the per-tool remediation *text* is normalized to the dominant pattern across all platforms (cosmetic guidance for the AI agent, not control flow).
- **Registration dispatch**: the two pre-existing flavors (publish used `if(did_action) call; else add_action`; instance used `doing_action`/`!did_action`) are unified onto the immediate-call-if-already-fired path. Abilities self-register on `plugins_loaded` priority 20 — **before** `wp_abilities_api_init` fires — so the boot path is unchanged. The unification only removes a latent silent-non-registration edge case in the instance flavor.

## Verification

- `php -l` clean across the entire `inc/` tree.
- `homeboy lint --changed-since main`: **zero new findings** introduced. The new base files are lint-clean, and no findings land on any rewritten scaffold line. All findings surfaced by the changed-file lint are pre-existing violations deep in untouched execute bodies (confirmed against `main`).

## Follow-up (mechanical)

The shared `normalizeJsonResponse()/apiError()` helpers are proven on Threads + FB/IG delete but not yet applied to every ability's HTTP body. The remaining `wp_remote` handlers (varying multi-call flows and error field paths — `$body['error']['message']` for Meta, `$body['message']` for Pinterest, `$body['error']` for Bluesky) are a low-risk mechanical follow-up; the register-scaffold extraction (the largest duplication, and the explicit ask) is complete across all 70 files in this PR.

Closes #149