### PR TITLE
fix: bind job_id context to social publish tools

### DIFF
--- a/inc/Handlers/Bluesky/Bluesky.php
+++ b/inc/Handlers/Bluesky/Bluesky.php
@@ -38,7 +38,8 @@ class Bluesky extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'bluesky_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to Bluesky. Supports text and images.',

--- a/inc/Handlers/Facebook/Facebook.php
+++ b/inc/Handlers/Facebook/Facebook.php
@@ -47,7 +47,8 @@ class Facebook extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'facebook_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to a Facebook Page. Supports text and images.',

--- a/inc/Handlers/Instagram/Instagram.php
+++ b/inc/Handlers/Instagram/Instagram.php
@@ -49,7 +49,8 @@ class Instagram extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'instagram_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to Instagram. Supports single images and carousels (up to 10 images). Images are processed async.',

--- a/inc/Handlers/LinkedIn/LinkedIn.php
+++ b/inc/Handlers/LinkedIn/LinkedIn.php
@@ -50,7 +50,8 @@ class LinkedIn extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'linkedin_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to LinkedIn. Supports text (up to 3000 chars), images, and article sharing.',

--- a/inc/Handlers/Pinterest/Pinterest.php
+++ b/inc/Handlers/Pinterest/Pinterest.php
@@ -66,7 +66,8 @@ class Pinterest extends PublishHandler {
 
 				return array(
 					'pinterest_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Pin content to Pinterest with image, title, description, and link.',

--- a/inc/Handlers/Threads/Threads.php
+++ b/inc/Handlers/Threads/Threads.php
@@ -47,7 +47,8 @@ class Threads extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'threads_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to Meta Threads. Supports text and images.',

--- a/inc/Handlers/Twitter/Twitter.php
+++ b/inc/Handlers/Twitter/Twitter.php
@@ -49,7 +49,8 @@ class Twitter extends PublishHandler {
 			function ( $handler_slug, $handler_config, $engine_data ) {
 				return array(
 					'twitter_publish' => array(
-						'class'       => self::class,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
 						'method'      => 'handle_tool_call',
 						'handler'     => $handler_slug,
 						'description' => 'Post content to Twitter. Supports text (280 chars), images, and URL handling.',


### PR DESCRIPTION
## Summary
Companion fix for Extra-Chill/data-machine#2560.

The Bluesky, Facebook, Instagram, LinkedIn, Pinterest, Threads, and Twitter publish handlers all extend `PublishHandler`, whose `handle_tool_call()` requires the run's `job_id` to load engine_data. Their tool definitions omitted `client_context_bindings`, so after data-machine's explicit-context-bindings migration `job_id` would never reach them and every publish call would bounce at the base `job_id` guard the moment these handlers ran in a pipeline (same failure class as the events upsert storm).

## What changed
- Declare `'client_context_bindings' => array( 'job_id' )` on each of the 7 social publish tool defs.

## Note
data-machine core also now auto-binds `job_id` for handler-class tools (Extra-Chill/data-machine#2561), but declaring it here is correct regardless of deployed core version.

## Testing
- `php -l` clean on all 7 changed handler files.

Refs Extra-Chill/data-machine#2560