### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -32,6 +32,17 @@ require_once __DIR__ . '/vendor/autoload.php';
  * available before any social abilities are registered.
  */
 function datamachine_socials_register_ability_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	// wp_abilities_api_categories_init can fire more than once per request on
+	// multisite; guard against re-registering an already-registered category,
+	// which trips a _doing_it_wrong notice in core's categories registry.
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'datamachine-socials' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'datamachine-socials',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "datamachine-socials" is already registered.
```

## Root cause

On the multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. This plugin called `wp_register_ability_category( 'datamachine-socials', ... )` **unconditionally** inside its categories-init callback, so the second hook fire re-registered the already-registered category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` (plus a `function_exists()` guard for the API itself), so a repeat fire is a clean no-op. Slug, label, description, and hook are unchanged.

This is one of ~15 plugins fixed in parallel for the same network-wide root cause.