### PR TITLE
feat: register a reflected AGENTS.md section for the data-machine-socials CLI surface

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -158,6 +158,33 @@ function datamachine_socials_bootstrap() {
 }
 add_action( 'plugins_loaded', 'datamachine_socials_bootstrap', 20 );
 
+/**
+ * Register the Data Machine Socials CLI section in the composable AGENTS.md
+ * file so external agent runtimes discover the social CLI surface
+ * automatically.
+ *
+ * Runs outside the WP_CLI guard because compose/auto-regeneration may fire in
+ * non-CLI WordPress contexts (web/cron). The section generator reflects over
+ * the command class files directly (resolved from disk via CommandRegistry),
+ * so it never depends on the live WP-CLI runner being loaded.
+ */
+function datamachine_socials_register_agents_md_section() {
+	if ( ! class_exists( '\DataMachine\Engine\AI\SectionRegistry' ) ) {
+		return;
+	}
+
+	$wp = 'wp --allow-root --path=' . ABSPATH;
+
+	\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'data-machine-socials', 60, function () use ( $wp ) {
+		return \DataMachineSocials\Cli\AgentsMdSection::render( $wp );
+	}, array(
+		'label'       => 'Data Machine Socials CLI',
+		'description' => 'Cross-platform social media WP-CLI commands.',
+		'freshness'   => 'generated',
+	) );
+}
+add_action( 'plugins_loaded', 'datamachine_socials_register_agents_md_section', 22 );
+
 // Temp file cleanup runs independently (doesn't need DM core)
 \DataMachineSocials\Cleanup::register();
 
@@ -218,26 +245,13 @@ add_action( 'admin_enqueue_scripts', 'datamachine_socials_enqueue_assets' );
  * Register WP-CLI commands.
  */
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/PinterestCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/RedditCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/InstagramCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/ThreadsCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/FacebookCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/TwitterCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/BlueskyCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/LinkedInCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/SharesCommand.php';
-	require_once DATAMACHINE_SOCIALS_PATH . 'inc/Cli/Commands/CommentsCommand.php';
-	WP_CLI::add_command( 'datamachine-socials comments', \DataMachineSocials\Cli\Commands\CommentsCommand::class );
-	WP_CLI::add_command( 'datamachine-socials linkedin', \DataMachineSocials\Cli\Commands\LinkedInCommand::class );
-	WP_CLI::add_command( 'datamachine-socials pinterest', \DataMachineSocials\Cli\Commands\PinterestCommand::class );
-	WP_CLI::add_command( 'datamachine-socials reddit', \DataMachineSocials\Cli\Commands\RedditCommand::class );
-	WP_CLI::add_command( 'datamachine-socials instagram', \DataMachineSocials\Cli\Commands\InstagramCommand::class );
-	WP_CLI::add_command( 'datamachine-socials threads', \DataMachineSocials\Cli\Commands\ThreadsCommand::class );
-	WP_CLI::add_command( 'datamachine-socials facebook', \DataMachineSocials\Cli\Commands\FacebookCommand::class );
-	WP_CLI::add_command( 'datamachine-socials twitter', \DataMachineSocials\Cli\Commands\TwitterCommand::class );
-	WP_CLI::add_command( 'datamachine-socials bluesky', \DataMachineSocials\Cli\Commands\BlueskyCommand::class );
-	WP_CLI::add_command( 'datamachine-socials shares', \DataMachineSocials\Cli\Commands\SharesCommand::class );
+	// Single source of truth: CommandRegistry maps every command string to its
+	// class. The AGENTS.md section generator reads the same map, so the
+	// documented CLI surface can never drift from what is registered here.
+	foreach ( \DataMachineSocials\Cli\CommandRegistry::map() as $command => $class ) {
+		require_once \DataMachineSocials\Cli\CommandRegistry::file_for_class( $class );
+		WP_CLI::add_command( $command, $class );
+	}
 }
 
 /**

--- a/inc/Cli/AgentsMdSection.php
+++ b/inc/Cli/AgentsMdSection.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * AGENTS.md Section Generator
+ *
+ * Generates the "Data Machine Socials CLI" section of the composed AGENTS.md
+ * file by introspecting the real registered command tree instead of
+ * hand-maintaining a heredoc. Walks every command registered in
+ * CommandRegistry, reflects over each command class's subcommand methods, and
+ * emits each namespace with its real subcommands and their PHPDoc short
+ * descriptions.
+ *
+ * Context-safe: the section callback runs on `datamachine_sections` /
+ * `plugins_loaded` in web/cron compose contexts where the WP_CLI-guarded
+ * command `require_once` block (and the live WP-CLI runner) is NOT loaded. This
+ * generator resolves command class files directly from disk via CommandRegistry
+ * and reflects over them, never relying on the live WP-CLI runner.
+ *
+ * Reflection is delegated to the shared
+ * `\DataMachine\Engine\AI\CliCommandIntrospector` when present (the canonical
+ * home for this logic, Extra-Chill/data-machine#2613), with a self-contained
+ * local fallback so this plugin never hard-depends on an unreleased core class.
+ * The local fallback additionally handles `__invoke` leaf commands regardless
+ * of whether the shared helper's `__invoke` support (data-machine#2639) has
+ * landed.
+ *
+ * @package DataMachineSocials\Cli
+ */
+
+namespace DataMachineSocials\Cli;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentsMdSection {
+
+	/**
+	 * Build the Markdown body for the Data Machine Socials CLI AGENTS.md section.
+	 *
+	 * @param string $wp The `wp --allow-root --path=...` invocation prefix.
+	 * @return string
+	 */
+	public static function render( $wp ) {
+		$lines   = array();
+		$lines[] = '### Data Machine Socials CLI';
+		$lines[] = '';
+		$lines[] = 'Cross-platform social media commands — read, publish, and engage across Instagram, Twitter/X, Facebook, Bluesky, Threads, Pinterest, LinkedIn, and Reddit, plus unified comments and per-item share tracking.';
+		$lines[] = "Discover everything: `{$wp} datamachine-socials --help`";
+		$lines[] = '';
+
+		foreach ( self::collect_commands() as $command => $subcommands ) {
+			$summary = self::summarize_subcommands( $subcommands );
+
+			if ( '' !== $summary ) {
+				$lines[] = "- `{$wp} {$command}` — {$summary}";
+			} else {
+				$lines[] = "- `{$wp} {$command}`";
+			}
+
+			foreach ( $subcommands as $sub ) {
+				if ( '__default' === $sub['name'] ) {
+					continue;
+				}
+				$desc = $sub['description'];
+				if ( '' !== $desc ) {
+					$lines[] = "  - `{$sub['name']}` — {$desc}";
+				} else {
+					$lines[] = "  - `{$sub['name']}`";
+				}
+			}
+		}
+
+		$lines[] = '';
+		$lines[] = 'All commands support `--help` for full options and subcommand discovery.';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Walk the CommandRegistry and reflect each class into its subcommands.
+	 *
+	 * @return array<string, array<int, array{name:string, description:string}>>
+	 *               command string => ordered list of subcommands.
+	 */
+	private static function collect_commands() {
+		$out = array();
+
+		foreach ( CommandRegistry::map() as $command => $class ) {
+			self::ensure_class_loaded( $class );
+			$out[ $command ] = self::reflect_subcommands( $class );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Ensure a command class is loaded for reflection.
+	 *
+	 * Triggers the composer autoloader first (the plugin requires
+	 * vendor/autoload.php unconditionally); falls back to requiring the class
+	 * file directly from disk via CommandRegistry when the autoloader is not
+	 * available (e.g. a minimal compose context). The class files guard only on
+	 * ABSPATH, never on WP_CLI, so loading them outside WP-CLI is safe.
+	 *
+	 * @param class-string $class Command class.
+	 * @return void
+	 */
+	private static function ensure_class_loaded( $class ) {
+		if ( class_exists( $class ) ) {
+			return;
+		}
+
+		$file = CommandRegistry::file_for_class( $class );
+		if ( is_readable( $file ) ) {
+			require_once $file;
+		}
+	}
+
+	/**
+	 * Reflect a command class into its list of subcommands.
+	 *
+	 * Prefers the shared core introspector when available; otherwise uses the
+	 * self-contained local reflection fallback. Subcommand names are normalized
+	 * to WP-CLI's runtime convention (trailing underscore stripped, remaining
+	 * underscores converted to hyphens) so the documented names match what an
+	 * operator actually types.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name:string, description:string}>
+	 */
+	private static function reflect_subcommands( $class ) {
+		if ( ! class_exists( $class ) ) {
+			return array();
+		}
+
+		$shared = self::reflect_via_shared_helper( $class );
+		$subs   = null !== $shared ? $shared : self::reflect_locally( $class );
+
+		foreach ( $subs as &$sub ) {
+			if ( '__default' !== $sub['name'] ) {
+				$sub['name'] = self::normalize_subcommand_name( $sub['name'] );
+			}
+		}
+		unset( $sub );
+
+		return $subs;
+	}
+
+	/**
+	 * Reflect subcommands via the shared core CliCommandIntrospector.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name:string, description:string}>|null Subcommands,
+	 *         or null when the shared helper is unavailable.
+	 */
+	private static function reflect_via_shared_helper( $class ) {
+		$helper = '\DataMachine\Engine\AI\CliCommandIntrospector';
+
+		if ( ! class_exists( $helper ) || ! method_exists( $helper, 'describe_class' ) ) {
+			return null;
+		}
+
+		$subs = $helper::describe_class( $class );
+
+		if ( ! is_array( $subs ) ) {
+			return null;
+		}
+
+		// The shared helper (pre data-machine#2639) does not enumerate
+		// __invoke leaf commands. Detect that case and append it locally so the
+		// surface is complete regardless of which core version is installed.
+		if ( self::class_has_invoke_subcommand( $class ) && ! self::list_has_default( $subs ) ) {
+			$subs[] = array(
+				'name'        => '__default',
+				'description' => '',
+			);
+		}
+
+		return $subs;
+	}
+
+	/**
+	 * Self-contained reflection fallback over a command class.
+	 *
+	 * Public, non-static, non-magic methods are WP-CLI subcommands. The
+	 * subcommand name is taken from `@subcommand <name>` when present, otherwise
+	 * the method name. `__invoke` (or `@subcommand __default`) represents the
+	 * directly-invokable namespace itself.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name:string, description:string}>
+	 */
+	private static function reflect_locally( $class ) {
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
+				continue;
+			}
+
+			if ( $method->isStatic() || $method->isConstructor() || $method->isDestructor() ) {
+				continue;
+			}
+
+			$method_name = $method->getName();
+			$doc         = $method->getDocComment() ?: '';
+			$annotated   = self::parse_subcommand_annotation( $doc );
+
+			if ( '__invoke' === $method_name && '' === $annotated ) {
+				$annotated = '__default';
+			}
+
+			if ( '' !== $annotated ) {
+				$name = $annotated;
+			} else {
+				if ( 0 === strpos( $method_name, '__' ) ) {
+					continue;
+				}
+				$name = $method_name;
+			}
+
+			$subcommands[] = array(
+				'name'        => $name,
+				'description' => self::parse_short_description( $doc ),
+			);
+		}
+
+		return $subcommands;
+	}
+
+	/**
+	 * Whether a class exposes an `__invoke` (or `@subcommand __default`) command.
+	 *
+	 * @param class-string $class Command class.
+	 * @return bool
+	 */
+	private static function class_has_invoke_subcommand( $class ) {
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		if ( $reflection->hasMethod( '__invoke' ) ) {
+			return true;
+		}
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
+				continue;
+			}
+			if ( '__default' === self::parse_subcommand_annotation( $method->getDocComment() ?: '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether a subcommand list already contains the namespace default.
+	 *
+	 * @param array<int, array{name:string, description:string}> $subs Subcommands.
+	 * @return bool
+	 */
+	private static function list_has_default( array $subs ) {
+		foreach ( $subs as $sub ) {
+			if ( isset( $sub['name'] ) && '__default' === $sub['name'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Normalize a raw method/subcommand name to WP-CLI's runtime convention.
+	 *
+	 * WP-CLI strips a single trailing underscore (so `list_` is invoked as
+	 * `list`) and converts remaining underscores to hyphens (so `list_boards`
+	 * is invoked as `list-boards`).
+	 *
+	 * @param string $name Raw name.
+	 * @return string
+	 */
+	private static function normalize_subcommand_name( $name ) {
+		if ( '' !== $name && '_' === substr( $name, -1 ) ) {
+			$name = substr( $name, 0, -1 );
+		}
+
+		return str_replace( '_', '-', $name );
+	}
+
+	/**
+	 * Build a comma-separated summary of subcommand names for the headline.
+	 *
+	 * @param array<int, array{name:string, description:string}> $subcommands Subcommands.
+	 * @return string
+	 */
+	private static function summarize_subcommands( $subcommands ) {
+		$names = array();
+		foreach ( $subcommands as $sub ) {
+			if ( '__default' === $sub['name'] ) {
+				continue;
+			}
+			$names[] = $sub['name'];
+		}
+
+		return implode( ', ', $names );
+	}
+
+	/**
+	 * Parse the `@subcommand <name>` annotation from a docblock.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string Subcommand name, or '' when not annotated.
+	 */
+	private static function parse_subcommand_annotation( $doc ) {
+		if ( preg_match( '/@subcommand\s+(\S+)/', $doc, $m ) ) {
+			return $m[1];
+		}
+		return '';
+	}
+
+	/**
+	 * Parse the short description (first prose line) from a docblock.
+	 *
+	 * Mirrors how WP-CLI derives a command's summary for `--help`: the first
+	 * non-empty content line of the docblock, before any `## SECTION` heading or
+	 * `@tag` annotation.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string
+	 */
+	private static function parse_short_description( $doc ) {
+		if ( '' === $doc ) {
+			return '';
+		}
+
+		$doc   = preg_replace( '#^/\*\*|\*/$#', '', $doc );
+		$lines = preg_split( '/\r\n|\r|\n/', $doc );
+
+		foreach ( $lines as $line ) {
+			$line = preg_replace( '/^\s*\*\s?/', '', $line );
+			$line = trim( $line );
+
+			if ( '' === $line ) {
+				continue;
+			}
+
+			if ( 0 === strpos( $line, '##' ) || 0 === strpos( $line, '@' ) ) {
+				return '';
+			}
+
+			return rtrim( $line, '.' );
+		}
+
+		return '';
+	}
+}

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WP-CLI Command Registry
+ *
+ * Single source of truth mapping `datamachine-socials ...` command strings to
+ * their implementing command classes. Both the WP-CLI bootstrap (which calls
+ * WP_CLI::add_command for each entry) and the AGENTS.md section generator
+ * (which reflects over each class to enumerate real subcommands) read from this
+ * map, so the documented CLI surface can never drift from what is actually
+ * registered.
+ *
+ * @package DataMachineSocials\Cli
+ */
+
+namespace DataMachineSocials\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+class CommandRegistry {
+
+	/**
+	 * Map of command string => fully-qualified command class.
+	 *
+	 * Keys are the exact strings passed to WP_CLI::add_command (the command
+	 * namespace, e.g. "datamachine-socials reddit"). Order here determines both
+	 * registration order and documentation order.
+	 *
+	 * @return array<string, class-string>
+	 */
+	public static function map() {
+		return array(
+			'datamachine-socials comments'  => Commands\CommentsCommand::class,
+			'datamachine-socials linkedin'  => Commands\LinkedInCommand::class,
+			'datamachine-socials pinterest' => Commands\PinterestCommand::class,
+			'datamachine-socials reddit'    => Commands\RedditCommand::class,
+			'datamachine-socials instagram' => Commands\InstagramCommand::class,
+			'datamachine-socials threads'   => Commands\ThreadsCommand::class,
+			'datamachine-socials facebook'  => Commands\FacebookCommand::class,
+			'datamachine-socials twitter'   => Commands\TwitterCommand::class,
+			'datamachine-socials bluesky'   => Commands\BlueskyCommand::class,
+			'datamachine-socials shares'    => Commands\SharesCommand::class,
+		);
+	}
+
+	/**
+	 * Resolve the absolute file path for a registered command class.
+	 *
+	 * The command classes live under the plugin's PSR-4 root
+	 * (`DataMachineSocials\Cli\Commands\FooCommand` => `inc/Cli/Commands/FooCommand.php`).
+	 * The section generator uses this to require the class file directly from
+	 * disk in web/cron compose contexts where the WP_CLI-guarded `require_once`
+	 * block has not run. The class files guard only on ABSPATH, never on WP_CLI,
+	 * so loading them outside WP-CLI is safe.
+	 *
+	 * @param class-string $class Fully-qualified command class.
+	 * @return string Absolute file path (may not exist).
+	 */
+	public static function file_for_class( $class ) {
+		$relative = substr( $class, strlen( 'DataMachineSocials\\' ) );
+		$relative = str_replace( '\\', '/', $relative );
+
+		return DATAMACHINE_SOCIALS_PATH . 'inc/' . $relative . '.php';
+	}
+}


### PR DESCRIPTION
## Summary

Closes #172. data-machine-socials registers 10 WP-CLI commands but had **zero AGENTS.md presence** — the entire `datamachine-socials comments|linkedin|pinterest|reddit|instagram|threads|facebook|twitter|bluesky|shares` surface was invisible to agents. This adds a reflected AGENTS.md section copying the gold-standard pattern from `extrachill-cli` (`CommandRegistry` + `AgentsMdSection`) and `intelligence` (prefer-shared-helper-with-local-fallback).

## What changed

- **`inc/Cli/CommandRegistry.php`** — single `command string => class` map that is now the one source of truth. The WP_CLI bootstrap (`data-machine-socials.php`) was refactored to loop over this map for `require_once` + `WP_CLI::add_command`, replacing 20 hand-maintained lines. Adds `file_for_class()` to resolve a class's file from the PSR-4 layout for disk-based loading.
- **`inc/Cli/AgentsMdSection.php`** — reflected section generator. Walks `CommandRegistry::map()`, reflects each command class's subcommand methods + PHPDoc short descriptions, and renders the namespace tree. **No hand-typed command lists** — adding a new social command surfaces automatically.
- **`data-machine-socials.php`** — registers the section via `\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'data-machine-socials', 60, ... )` on `plugins_loaded` (outside the WP_CLI guard).

## Design notes (matches the issue's acceptance criteria)

- **Prefers the shared `\DataMachine\Engine\AI\CliCommandIntrospector`** when present (class_exists/method_exists guard), with a self-contained local reflection fallback so the plugin never hard-depends on an unreleased core class.
- **`__invoke` handled regardless** — the local fallback enumerates `__invoke`/`@subcommand __default` leaf commands, and when the shared helper is used the generator detects and appends an `__invoke` leaf so it works whether or not data-machine#2639 (shared-helper `__invoke` support) has landed. (The current socials commands all use named subcommand methods, but this keeps the pattern correct.)
- **Context-safe** — the callback resolves command class files from disk via `CommandRegistry::file_for_class()` and reflects over them; it never touches the live WP-CLI runner, so it composes correctly in web/cron contexts where the WP_CLI-guarded `require_once` block has not run.
- **WP-CLI name normalization** — subcommand names are normalized to WP-CLI's runtime convention (`list_` → `list`, `list_boards` → `list-boards`) so the documented names match what an operator actually types.

## Verification

Rendered the section against the real command classes via both paths (local fallback and a shared-helper stub). Both enumerate all 10 commands with accurate subcommands and short descriptions, e.g.:

```
- `wp ... datamachine-socials comments` — list, reply
  - `list` — List comments on a social media post
  - `reply` — Reply to a comment on a social media post
- `wp ... datamachine-socials reddit` — info, search, posts, trending, fetch, status, reply, submit, vote
  ...
- `wp ... datamachine-socials shares` — list, check, platforms, clear
```

`php -l` clean on all three files.

Part of the #2613 (Extra-Chill/data-machine) AGENTS.md dynamic-CLI fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)