### PR TITLE
refactor: route write-path abilities through shared HttpClient

### DIFF
--- a/inc/Abilities/AbstractSocialAbility.php
+++ b/inc/Abilities/AbstractSocialAbility.php
@@ -4,8 +4,12 @@
  *
  * Base class for the social primitive abilities in inc/Abilities. Centralizes
  * the register scaffold (the `$registered` guard plus the
- * did_action/doing_action dispatch), the auth-resolve preamble, and the
- * wp_remote response normalization that every platform ability repeated.
+ * did_action/doing_action dispatch) and the auth-resolve preamble that every
+ * platform ability repeated.
+ *
+ * HTTP transport (request dispatch + response normalization) is handled by the
+ * shared DataMachine\Core\HttpClient, which every read, auth, and write ability
+ * now calls directly — so the base no longer carries a wp_remote normalizer.
  *
  * The base intentionally exposes reusable helpers rather than a rigid template
  * method: the per-platform execute bodies differ substantially (endpoints,
@@ -14,7 +18,6 @@
  *
  * - registerAbility()        Register one or more abilities once, guarded.
  * - resolveProvider()        Resolve + authenticate the platform provider.
- * - normalizeJsonResponse()  Decode a wp_remote response into data + status.
  * - apiError()               Build the standard api_error WP_Error.
  *
  * @package    DataMachineSocials
@@ -93,42 +96,6 @@ abstract class AbstractSocialAbility {
 		}
 
 		return $provider;
-	}
-
-	/**
-	 * Normalize a wp_remote_* response into decoded data and status code.
-	 *
-	 * Returns a WP_Error('api_error') when the request itself errored. On a
-	 * transport-level success it returns an array with the decoded body and the
-	 * HTTP status code, leaving status interpretation to the caller (platforms
-	 * differ on success codes and error field paths).
-	 *
-	 * @param array|\WP_Error $response Result of wp_remote_post()/wp_remote_get().
-	 * @return array{data: mixed, status_code: int, body: string}|\WP_Error
-	 */
-	protected function normalizeJsonResponse( $response ) {
-		if ( is_wp_error( $response ) ) {
-			return $this->apiError( $response->get_error_message() );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-
-		return array(
-			'data'        => json_decode( $body, true ),
-			'status_code' => (int) $status_code,
-			'body'        => $body,
-		);
-	}
-
-	/**
-	 * Whether an HTTP status code is in the 2xx success range.
-	 *
-	 * @param int $status_code HTTP status code.
-	 * @return bool
-	 */
-	protected function isSuccessStatus( int $status_code ): bool {
-		return $status_code >= 200 && $status_code < 300;
 	}
 
 	/**

--- a/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -89,9 +90,10 @@ class BlueskyDeleteAbility extends AbstractSocialAbility {
 			return new \WP_Error( 'api_error', 'Could not extract rkey from post URI: ' . $post_uri, array( 'status' => 500 ) );
 		}
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			'https://bsky.social/xrpc/com.atproto.repo.deleteRecord',
 			array(
+				'context' => 'Bluesky Delete',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $session['accessJwt'],
@@ -105,13 +107,7 @@ class BlueskyDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -121,8 +117,7 @@ class BlueskyDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		return new \WP_Error( 'api_error', $body['error'] ?? 'Failed to delete post', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to delete post', array( 'status' => 500 ) );
 	}
 
 	private function getAuthProvider(): ?BlueskyAuth {

--- a/inc/Abilities/Bluesky/BlueskyPublishAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyPublishAbility.php
@@ -12,6 +12,7 @@ namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
@@ -203,9 +204,10 @@ class BlueskyPublishAbility extends AbstractSocialAbility {
 		}
 
 		// Create post
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			'https://bsky.social/xrpc/com.atproto.repo.createRecord',
 			array(
+				'context' => 'Bluesky Publish',
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
 					'Content-Type'  => 'application/json',
@@ -219,30 +221,23 @@ class BlueskyPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( ! empty( $result['success'] ) ) {
+			$data = json_decode( $result['data'], true );
+
+			if ( isset( $data['uri'] ) ) {
+				$parts    = explode( '/', $data['uri'] );
+				$post_id  = end( $parts );
+				$post_url = "https://bsky.app/profile/{$handle}/post/{$post_id}";
+
+				return array(
+					'success'  => true,
+					'post_id'  => $post_id,
+					'post_url' => $post_url,
+				);
+			}
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['uri'] ) ) {
-			$parts    = explode( '/', $data['uri'] );
-			$post_id  = end( $parts );
-			$post_url = "https://bsky.app/profile/{$handle}/post/{$post_id}";
-
-			return array(
-				'success'  => true,
-				'post_id'  => $post_id,
-				'post_url' => $post_url,
-			);
-		}
-
-		$error_msg = 'Bluesky API error';
-		if ( isset( $data['message'] ) ) {
-			$error_msg = $data['message'];
-		}
+		$error_msg = $result['error'] ?? 'Bluesky API error';
 
 		return new \WP_Error( 'api_error', $error_msg, array( 'status' => 500 ) );
 	}
@@ -280,18 +275,31 @@ class BlueskyPublishAbility extends AbstractSocialAbility {
 	 */
 	private static function upload_image( string $access_token, string $image_url ): ?array {
 		// Download image
-		$response = wp_remote_get( $image_url, array( 'timeout' => 30 ) );
-		if ( is_wp_error( $response ) ) {
+		$download = HttpClient::get(
+			$image_url,
+			array(
+				'context' => 'Bluesky Image Download',
+				'timeout' => 30,
+			)
+		);
+		if ( empty( $download['success'] ) ) {
 			return null;
 		}
 
-		$image_data   = wp_remote_retrieve_body( $response );
-		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		$image_data   = $download['data'];
+		$content_type = '';
+		if ( ! empty( $download['headers'] ) ) {
+			$headers      = $download['headers'];
+			$content_type = is_object( $headers ) && method_exists( $headers, 'offsetGet' )
+				? (string) ( $headers['content-type'] ?? '' )
+				: (string) ( is_array( $headers ) ? ( $headers['content-type'] ?? '' ) : '' );
+		}
 
 		// Upload blob
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			'https://bsky.social/xrpc/com.atproto.repo.uploadBlob',
 			array(
+				'context' => 'Bluesky Blob Upload',
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
 					'Content-Type'  => $content_type ? $content_type : 'image/jpeg',
@@ -301,15 +309,13 @@ class BlueskyPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
+		if ( empty( $result['success'] ) ) {
 			return null;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
+		$data = json_decode( $result['data'], true );
 
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['blob'] ) ) {
+		if ( isset( $data['blob'] ) ) {
 			return $data['blob'];
 		}
 
@@ -375,16 +381,22 @@ class BlueskyPublishAbility extends AbstractSocialAbility {
 			'image'       => '',
 		);
 
-		$response = wp_remote_get( $url, array(
-			'timeout'    => 10,
-			'user-agent' => 'DataMachineSocials/1.0 (link card preview)',
-		) );
+		$response = HttpClient::get(
+			$url,
+			array(
+				'context' => 'Bluesky OG Tags',
+				'timeout' => 10,
+				'headers' => array(
+					'User-Agent' => 'DataMachineSocials/1.0 (link card preview)',
+				),
+			)
+		);
 
-		if ( is_wp_error( $response ) ) {
+		if ( empty( $response['success'] ) ) {
 			return $defaults;
 		}
 
-		$html = wp_remote_retrieve_body( $response );
+		$html = $response['data'];
 		if ( empty( $html ) ) {
 			return $defaults;
 		}

--- a/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
+++ b/inc/Abilities/Bluesky/BlueskyUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Bluesky;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Bluesky\BlueskyAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -134,10 +135,10 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 			'rkey'       => $rkey,
 		);
 
-		$response = wp_remote_request(
+		$result = HttpClient::delete(
 			$url,
 			array(
-				'method'  => 'DELETE',
+				'context' => 'Bluesky Delete',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $session['accessJwt'],
@@ -147,13 +148,7 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -163,8 +158,7 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 			);
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		return new \WP_Error( 'api_error', $body['error'] ?? 'Failed to delete post', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to delete post', array( 'status' => 500 ) );
 	}
 
 	private function likePost( array $session, string $post_uri ): array|\WP_Error {
@@ -173,9 +167,10 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 
 		$url = $pds_url . '/xrpc/app.bsky.feed.like';
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Bluesky Like',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $session['accessJwt'],
@@ -195,14 +190,8 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
+			$body = json_decode( $result['data'], true );
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -213,7 +202,7 @@ class BlueskyUpdateAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error'] ?? 'Failed to like post', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to like post', array( 'status' => 500 ) );
 	}
 
 	private function unlikePost( array $session): array|\WP_Error {

--- a/inc/Abilities/Facebook/FacebookDeleteAbility.php
+++ b/inc/Abilities/Facebook/FacebookDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -82,9 +83,10 @@ class FacebookDeleteAbility extends AbstractSocialAbility {
 
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $input['post_id'] );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -93,15 +95,9 @@ class FacebookDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		$normalized = $this->normalizeJsonResponse( $response );
-		if ( is_wp_error( $normalized ) ) {
-			return $normalized;
-		}
+		$body = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = $normalized['status_code'];
-		$body        = $normalized['data'];
-
-		if ( 200 === $status_code || ( isset( $body['success'] ) && $body['success'] ) ) {
+		if ( ! empty( $result['success'] ) || ( isset( $body['success'] ) && $body['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -111,7 +107,7 @@ class FacebookDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return $this->apiError( $body['error']['message'] ?? 'Failed to delete post' );
+		return $this->apiError( $result['error'] ?? 'Failed to delete post' );
 	}
 
 	private function getAuthProvider(): ?FacebookAuth {

--- a/inc/Abilities/Facebook/FacebookPublishAbility.php
+++ b/inc/Abilities/Facebook/FacebookPublishAbility.php
@@ -12,6 +12,7 @@ namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -183,23 +184,18 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 		// Make API request
 		$api_url = self::build_graph_url( "{$page_id}/feed" );
 
-		$response = wp_remote_post(
+		$http = HttpClient::post(
 			$api_url,
 			array(
+				'context' => 'Facebook Publish',
 				'body'    => $post_data,
 				'timeout' => 30,
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
+		$data = ! empty( $http['success'] ) ? json_decode( $http['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( ! empty( $http['success'] ) && isset( $data['id'] ) ) {
 			$post_id  = $data['id'];
 			$post_url = "https://www.facebook.com/{$page_id}/posts/{$post_id}";
 
@@ -224,6 +220,8 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 		$error_msg = 'Facebook API error';
 		if ( isset( $data['error']['message'] ) ) {
 			$error_msg = $data['error']['message'];
+		} elseif ( ! empty( $http['error'] ) ) {
+			$error_msg = $http['error'];
 		}
 
 		return new \WP_Error( 'api_error', $error_msg, array( 'status' => 500 ) );
@@ -264,9 +262,10 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 	private static function upload_photo( string $page_id, string $access_token, string $image_url ): ?string {
 		$url = self::build_graph_url( "{$page_id}/photos" );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Photo Upload',
 				'body'    => array(
 					'url'          => $image_url,
 					'published'    => 'false',
@@ -276,15 +275,13 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
+		if ( empty( $result['success'] ) ) {
 			return null;
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
+		$data = json_decode( $result['data'], true );
 
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( isset( $data['id'] ) ) {
 			return $data['id'];
 		}
 
@@ -302,9 +299,10 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 	private static function post_comment( string $post_id, string $message, string $access_token ): array|\WP_Error {
 		$url = self::build_graph_url( "{$post_id}/comments" );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Comment',
 				'body'    => array(
 					'message'      => $message,
 					'access_token' => $access_token,
@@ -313,15 +311,9 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
+		$data = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( ! empty( $result['success'] ) && isset( $data['id'] ) ) {
 			$comment_id  = $data['id'];
 			$comment_url = "https://www.facebook.com/{$post_id}/?comment_id={$comment_id}";
 
@@ -332,7 +324,7 @@ class FacebookPublishAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $data['error']['message'] ?? 'Failed to post comment', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $data['error']['message'] ?? ( $result['error'] ?? 'Failed to post comment' ), array( 'status' => 500 ) );
 	}
 
 	/**

--- a/inc/Abilities/Facebook/FacebookUpdateAbility.php
+++ b/inc/Abilities/Facebook/FacebookUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Facebook;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -158,9 +159,10 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 	private function editPost( string $access_token, string $post_id, string $message ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $post_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Edit',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -169,16 +171,11 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to edit post', array( 'status' => 500 ) );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $status_code ) {
-			return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to edit post', array( 'status' => 500 ) );
-		}
+		$body = json_decode( $result['data'], true );
 
 		return array(
 			'success' => true,
@@ -200,9 +197,10 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 	private function hidePost( string $access_token, string $post_id, bool $hide ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $post_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Visibility',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -211,15 +209,8 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $status_code ) {
-			return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to update post visibility', array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to update post visibility', array( 'status' => 500 ) );
 		}
 
 		return array(
@@ -241,9 +232,10 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 	private function deletePost( string $access_token, string $post_id ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $post_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Facebook Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -252,14 +244,9 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
+		$body = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 === $status_code || ( isset( $body['success'] ) && $body['success'] ) ) {
+		if ( ! empty( $result['success'] ) || ( isset( $body['success'] ) && $body['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -269,6 +256,6 @@ class FacebookUpdateAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to delete post', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to delete post', array( 'status' => 500 ) );
 	}
 }

--- a/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
+++ b/inc/Abilities/Instagram/InstagramCommentReplyAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
@@ -120,9 +121,10 @@ class InstagramCommentReplyAbility extends AbstractSocialAbility {
 	private function replyToComment( string $access_token, string $comment_id, string $message ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $comment_id ) . '/replies';
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Instagram Comment Reply',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -131,15 +133,10 @@ class InstagramCommentReplyAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
+		$body = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $status_code || isset( $body['error'] ) ) {
-			return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to reply to Instagram comment', array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) || isset( $body['error'] ) ) {
+			return new \WP_Error( 'api_error', $body['error']['message'] ?? ( $result['error'] ?? 'Failed to reply to Instagram comment' ), array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/inc/Abilities/Instagram/InstagramDeleteAbility.php
+++ b/inc/Abilities/Instagram/InstagramDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
@@ -118,10 +119,10 @@ class InstagramDeleteAbility extends AbstractSocialAbility {
 	private function deleteMedia( string $access_token, string $media_id ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $media_id );
 
-		$response = wp_remote_request(
+		$result = HttpClient::delete(
 			$url,
 			array(
-				'method'  => 'DELETE',
+				'context' => 'Instagram Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -129,15 +130,7 @@ class InstagramDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		$normalized = $this->normalizeJsonResponse( $response );
-		if ( is_wp_error( $normalized ) ) {
-			return $normalized;
-		}
-
-		$status_code = $normalized['status_code'];
-		$body        = $normalized['data'];
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -147,6 +140,6 @@ class InstagramDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return $this->apiError( $body['error']['message'] ?? 'Delete failed. The Instagram API may not support deletion for this media type. Consider archiving instead.' );
+		return $this->apiError( $result['error'] ?? 'Delete failed. The Instagram API may not support deletion for this media type. Consider archiving instead.' );
 	}
 }

--- a/inc/Abilities/Instagram/InstagramPublishAbility.php
+++ b/inc/Abilities/Instagram/InstagramPublishAbility.php
@@ -16,6 +16,7 @@ namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -290,19 +291,20 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 				$container_body['caption'] = $caption;
 			}
 
-			$response = wp_remote_post(
+			$result = HttpClient::post(
 				self::GRAPH_API_URL . "/{$user_id}/media",
 				array(
+					'context' => 'Instagram Media Container',
 					'body'    => $container_body,
 					'timeout' => 40,
 				)
 			);
 
-			if ( is_wp_error( $response ) ) {
-				return new \WP_Error( 'api_error', 'Error creating media container: ' . $response->get_error_message(), array( 'status' => 500 ) );
+			if ( empty( $result['success'] ) ) {
+				return new \WP_Error( 'api_error', 'Error creating media container: ' . ( $result['error'] ?? 'unknown error' ), array( 'status' => 500 ) );
 			}
 
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			$body = json_decode( $result['data'], true );
 
 			if ( empty( $body['id'] ) ) {
 				$error_msg = 'No container ID returned for image';
@@ -315,14 +317,17 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 			$container_id = $body['id'];
 
 			// Check initial status.
-			$status_resp = wp_remote_get(
+			$status_result = HttpClient::get(
 				self::GRAPH_API_URL . "/{$container_id}?fields=status_code&access_token={$access_token}",
-				array( 'timeout' => 40 )
+				array(
+					'context' => 'Instagram Container Status',
+					'timeout' => 40,
+				)
 			);
 
 			$status = 'IN_PROGRESS';
-			if ( ! is_wp_error( $status_resp ) ) {
-				$status_body = json_decode( wp_remote_retrieve_body( $status_resp ), true );
+			if ( ! empty( $status_result['success'] ) ) {
+				$status_body = json_decode( $status_result['data'], true );
 				if ( ! empty( $status_body['status_code'] ) ) {
 					$status = $status_body['status_code'];
 				}
@@ -347,10 +352,11 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 		$main_container_id = null;
 		$media_kind        = 'image';
 		if ( $is_carousel && count( $container_ids ) > 1 ) {
-			$children      = implode( ',', $container_ids );
-			$carousel_resp = wp_remote_post(
+			$children       = implode( ',', $container_ids );
+			$carousel_result = HttpClient::post(
 				self::GRAPH_API_URL . "/{$user_id}/media",
 				array(
+					'context' => 'Instagram Carousel Container',
 					'body'    => array(
 						'media_type'   => 'CAROUSEL',
 						'children'     => $children,
@@ -361,11 +367,11 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 				)
 			);
 
-			if ( is_wp_error( $carousel_resp ) ) {
-				return new \WP_Error( 'api_error', 'Error creating carousel container: ' . $carousel_resp->get_error_message(), array( 'status' => 500 ) );
+			if ( empty( $carousel_result['success'] ) ) {
+				return new \WP_Error( 'api_error', 'Error creating carousel container: ' . ( $carousel_result['error'] ?? 'unknown error' ), array( 'status' => 500 ) );
 			}
 
-			$carousel_body = json_decode( wp_remote_retrieve_body( $carousel_resp ), true );
+			$carousel_body = json_decode( $carousel_result['data'], true );
 			if ( empty( $carousel_body['id'] ) ) {
 				$error_msg = 'No carousel container ID returned';
 				if ( isset( $carousel_body['error']['message'] ) ) {
@@ -441,19 +447,20 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 		}
 
 		// Step 1: Create the Reel container.
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			self::GRAPH_API_URL . "/{$user_id}/media",
 			array(
+				'context' => 'Instagram Reel Container',
 				'body'    => $container_body,
 				'timeout' => 60,
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', 'Error creating Reel container: ' . $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', 'Error creating Reel container: ' . ( $result['error'] ?? 'unknown error' ), array( 'status' => 500 ) );
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( $result['data'], true );
 
 		if ( empty( $body['id'] ) ) {
 			$error_msg = 'No container ID returned for Reel';
@@ -523,19 +530,20 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 		}
 
 		// Step 1: Create the Story container.
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			self::GRAPH_API_URL . "/{$user_id}/media",
 			array(
+				'context' => 'Instagram Story Container',
 				'body'    => $container_body,
 				'timeout' => 60,
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', 'Error creating Story container: ' . $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', 'Error creating Story container: ' . ( $result['error'] ?? 'unknown error' ), array( 'status' => 500 ) );
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( $result['data'], true );
 
 		if ( empty( $body['id'] ) ) {
 			$error_msg = 'No container ID returned for Story';
@@ -573,9 +581,10 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 	 * @return array Result with success, media_id, media_kind, permalink.
 	 */
 	private static function publish_container( string $user_id, string $access_token, string $container_id, string $media_kind ): array|\WP_Error {
-		$publish_resp = wp_remote_post(
+		$publish_result = HttpClient::post(
 			self::GRAPH_API_URL . "/{$user_id}/media_publish",
 			array(
+				'context' => 'Instagram Media Publish',
 				'body'    => array(
 					'creation_id'  => $container_id,
 					'access_token' => $access_token,
@@ -584,11 +593,11 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $publish_resp ) ) {
-			return new \WP_Error( 'api_error', 'Error publishing to Instagram: ' . $publish_resp->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $publish_result['success'] ) ) {
+			return new \WP_Error( 'api_error', 'Error publishing to Instagram: ' . ( $publish_result['error'] ?? 'unknown error' ), array( 'status' => 500 ) );
 		}
 
-		$publish_body = json_decode( wp_remote_retrieve_body( $publish_resp ), true );
+		$publish_body = json_decode( $publish_result['data'], true );
 		if ( empty( $publish_body['id'] ) ) {
 			$error_msg = 'No media ID returned after publishing';
 			if ( isset( $publish_body['error']['message'] ) ) {
@@ -600,14 +609,17 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 		$media_id = $publish_body['id'];
 
 		// Fetch permalink.
-		$permalink      = null;
-		$permalink_resp = wp_remote_get(
+		$permalink        = null;
+		$permalink_result = HttpClient::get(
 			self::GRAPH_API_URL . "/{$media_id}?fields=id,permalink&access_token={$access_token}",
-			array( 'timeout' => 40 )
+			array(
+				'context' => 'Instagram Permalink',
+				'timeout' => 40,
+			)
 		);
 
-		if ( ! is_wp_error( $permalink_resp ) ) {
-			$permalink_body = json_decode( wp_remote_retrieve_body( $permalink_resp ), true );
+		if ( ! empty( $permalink_result['success'] ) ) {
+			$permalink_body = json_decode( $permalink_result['data'], true );
 			if ( isset( $permalink_body['permalink'] ) ) {
 				$permalink = $permalink_body['permalink'];
 			}
@@ -634,13 +646,19 @@ class InstagramPublishAbility extends AbstractSocialAbility {
 		$url = self::GRAPH_API_URL . "/{$container_id}?fields=status_code&access_token={$access_token}";
 
 		for ( $i = 0; $i < $max_retries; $i++ ) {
-			$response = wp_remote_get( $url, array( 'timeout' => 10 ) );
+			$result = HttpClient::get(
+				$url,
+				array(
+					'context' => 'Instagram Container Status',
+					'timeout' => 10,
+				)
+			);
 
-			if ( is_wp_error( $response ) ) {
+			if ( empty( $result['success'] ) ) {
 				return false;
 			}
 
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			$body = json_decode( $result['data'], true );
 
 			if ( isset( $body['status_code'] ) && 'FINISHED' === $body['status_code'] ) {
 				return true;

--- a/inc/Abilities/Instagram/InstagramUpdateAbility.php
+++ b/inc/Abilities/Instagram/InstagramUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Instagram;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Facebook\FacebookAuth;
 use DataMachineSocials\Handlers\Instagram\InstagramAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
@@ -173,9 +174,10 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $media_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Instagram Edit Caption',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -184,16 +186,11 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to edit caption', array( 'status' => 500 ) );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $status_code ) {
-			return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to edit caption', array( 'status' => 500 ) );
-		}
+		$body = json_decode( $result['data'], true );
 
 		return array(
 			'success' => true,
@@ -214,9 +211,10 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 	private function deleteMedia( string $access_token, string $media_id ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $media_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Instagram Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -229,14 +227,7 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 		// We need to use the user media edge to delete. This is a limitation.
 		// For now, return an error with guidance.
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -248,7 +239,7 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 
 		// Instagram doesn't support direct delete via API for all media types.
 		// Return informative error.
-		return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Delete not supported for this media type via API. Consider archiving instead.', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Delete not supported for this media type via API. Consider archiving instead.', array( 'status' => 500 ) );
 	}
 
 	/**
@@ -261,9 +252,10 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 	private function archiveMedia( string $access_token, string $media_id ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $media_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Instagram Archive',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -272,16 +264,11 @@ class InstagramUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to archive media', array( 'status' => 500 ) );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $status_code ) {
-			return new \WP_Error( 'api_error', $body['error']['message'] ?? 'Failed to archive media', array( 'status' => 500 ) );
-		}
+		$body = json_decode( $result['data'], true );
 
 		return array(
 			'success' => true,

--- a/inc/Abilities/Pinterest/PinterestDeleteAbility.php
+++ b/inc/Abilities/Pinterest/PinterestDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Pinterest;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -83,10 +84,10 @@ class PinterestDeleteAbility extends AbstractSocialAbility {
 
 		$url = self::API_URL . '/pins/' . rawurlencode( $input['pin_id'] );
 
-		$response = wp_remote_request(
+		$result = HttpClient::delete(
 			$url,
 			array(
-				'method'  => 'DELETE',
+				'context' => 'Pinterest Delete',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
@@ -94,13 +95,7 @@ class PinterestDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-
-		if ( 204 === $status_code || 200 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -110,8 +105,7 @@ class PinterestDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		return new \WP_Error( 'api_error', $body['message'] ?? 'Failed to delete pin', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to delete pin', array( 'status' => 500 ) );
 	}
 
 	private function getAuthProvider(): ?PinterestAuth {

--- a/inc/Abilities/Pinterest/PinterestUpdateAbility.php
+++ b/inc/Abilities/Pinterest/PinterestUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Pinterest;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Handlers\Pinterest\PinterestAuth;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
@@ -118,10 +119,10 @@ class PinterestUpdateAbility extends AbstractSocialAbility {
 	private function deletePin( string $access_token, string $pin_id ): array|\WP_Error {
 		$url = self::API_URL . '/pins/' . rawurlencode( $pin_id );
 
-		$response = wp_remote_request(
+		$result = HttpClient::delete(
 			$url,
 			array(
-				'method'  => 'DELETE',
+				'context' => 'Pinterest Delete',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
@@ -129,13 +130,7 @@ class PinterestUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-
-		if ( 204 === $status_code || 200 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -145,7 +140,6 @@ class PinterestUpdateAbility extends AbstractSocialAbility {
 			);
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		return new \WP_Error( 'api_error', $body['message'] ?? 'Failed to delete pin', array( 'status' => 500 ) );
+		return new \WP_Error( 'api_error', $result['error'] ?? 'Failed to delete pin', array( 'status' => 500 ) );
 	}
 }

--- a/inc/Abilities/Reddit/ReplyRedditAbility.php
+++ b/inc/Abilities/Reddit/ReplyRedditAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
@@ -128,9 +129,10 @@ class ReplyRedditAbility extends AbstractSocialAbility {
 	private function postComment( string $access_token, string $thing_id, string $text ): array|\WP_Error {
 		$url = self::API_BASE . '/api/comment';
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Reddit Reply',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
@@ -144,14 +146,13 @@ class ReplyRedditAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Reddit API request failed', array( 'status' => 500 ) );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( $result['data'], true );
 
-		// Reddit returns errors in json.errors array.
+		// Reddit returns errors in json.errors array (HTTP 200 with logical errors).
 		$errors = $body['json']['errors'] ?? array();
 		if ( ! empty( $errors ) ) {
 			$error_messages = array_map(
@@ -161,10 +162,6 @@ class ReplyRedditAbility extends AbstractSocialAbility {
 				$errors
 			);
 			return new \WP_Error( 'api_error', implode( '; ', $error_messages ), array( 'status' => 500 ) );
-		}
-
-		if ( $status_code < 200 || $status_code >= 300 ) {
-			return new \WP_Error( 'api_error', "Reddit API returned HTTP {$status_code}", array( 'status' => 500 ) );
 		}
 
 		// Extract the new comment data.

--- a/inc/Abilities/Reddit/SubmitRedditAbility.php
+++ b/inc/Abilities/Reddit/SubmitRedditAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
@@ -220,9 +221,10 @@ class SubmitRedditAbility extends AbstractSocialAbility {
 			$body['spoiler'] = true;
 		}
 
-		$response = wp_remote_post(
+		$http = HttpClient::post(
 			$api_url,
 			array(
+				'context' => 'Reddit Submit',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
@@ -232,14 +234,13 @@ class SubmitRedditAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+		if ( empty( $http['success'] ) ) {
+			return new \WP_Error( 'api_error', $http['error'] ?? 'Reddit API request failed', array( 'status' => 500 ) );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$result      = json_decode( wp_remote_retrieve_body( $response ), true );
+		$result = json_decode( $http['data'], true );
 
-		// Reddit returns errors in json.errors array.
+		// Reddit returns errors in json.errors array (HTTP 200 with logical errors).
 		$errors = $result['json']['errors'] ?? array();
 		if ( ! empty( $errors ) ) {
 			$error_messages = array_map(
@@ -249,10 +250,6 @@ class SubmitRedditAbility extends AbstractSocialAbility {
 				$errors
 			);
 			return new \WP_Error( 'api_error', implode( '; ', $error_messages ), array( 'status' => 500 ) );
-		}
-
-		if ( $status_code < 200 || $status_code >= 300 ) {
-			return new \WP_Error( 'api_error', "Reddit API returned HTTP {$status_code}", array( 'status' => 500 ) );
 		}
 
 		$post_data = $result['json']['data'] ?? array();

--- a/inc/Abilities/Reddit/VoteRedditAbility.php
+++ b/inc/Abilities/Reddit/VoteRedditAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Reddit;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
@@ -105,9 +106,10 @@ class VoteRedditAbility extends AbstractSocialAbility {
 
 		$url = self::API_BASE . '/api/vote';
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Reddit Vote',
 				'timeout' => 30,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
@@ -120,15 +122,8 @@ class VoteRedditAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-
-		if ( $status_code < 200 || $status_code >= 300 ) {
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-			return new \WP_Error( 'api_error', $body['message'] ?? "Reddit API returned HTTP {$status_code}", array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'api_error', $result['error'] ?? 'Reddit API request failed', array( 'status' => 500 ) );
 		}
 
 		$direction_labels = array(

--- a/inc/Abilities/Threads/ThreadsDeleteAbility.php
+++ b/inc/Abilities/Threads/ThreadsDeleteAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 use DataMachineSocials\Handlers\Threads\ThreadsAuth;
 
@@ -82,9 +83,10 @@ class ThreadsDeleteAbility extends AbstractSocialAbility {
 
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $input['thread_id'] );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Threads Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -92,15 +94,7 @@ class ThreadsDeleteAbility extends AbstractSocialAbility {
 			)
 		);
 
-		$normalized = $this->normalizeJsonResponse( $response );
-		if ( is_wp_error( $normalized ) ) {
-			return $normalized;
-		}
-
-		$status_code = $normalized['status_code'];
-		$body        = $normalized['data'];
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -110,7 +104,7 @@ class ThreadsDeleteAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return $this->apiError( $body['error']['message'] ?? 'Failed to delete thread' );
+		return $this->apiError( $result['error'] ?? 'Failed to delete thread' );
 	}
 
 	private function getAuthProvider(): ?ThreadsAuth {

--- a/inc/Abilities/Threads/ThreadsPublishAbility.php
+++ b/inc/Abilities/Threads/ThreadsPublishAbility.php
@@ -12,6 +12,7 @@ namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 
 defined( 'ABSPATH' ) || exit;
@@ -183,23 +184,18 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 
 		$url = "https://graph.threads.net/v1.0/{$user_id}/threads";
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Threads Publish',
 				'body'    => $post_data,
 				'timeout' => 30,
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
-		}
+		$data = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( ! empty( $result['success'] ) && isset( $data['id'] ) ) {
 			$creation_id = $data['id'];
 
 			// Step 3: Publish the thread
@@ -221,6 +217,8 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 		$error_msg = 'Threads API error';
 		if ( isset( $data['error']['message'] ) ) {
 			$error_msg = $data['error']['message'];
+		} elseif ( ! empty( $result['error'] ) ) {
+			$error_msg = $result['error'];
 		}
 
 		return new \WP_Error( 'api_error', $error_msg, array( 'status' => 500 ) );
@@ -259,9 +257,10 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 	private static function create_media_container( string $access_token, string $user_id, string $image_url ) {
 		$url = "https://graph.threads.net/v1.0/{$user_id}/media";
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Threads Media Container',
 				'body'    => array(
 					'media_type'   => 'IMAGE',
 					'image_url'    => $image_url,
@@ -271,21 +270,15 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
+		$data = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( ! empty( $result['success'] ) && isset( $data['id'] ) ) {
 			return $data['id'];
 		}
 
 		return new \WP_Error(
 			'threads_media_failed',
-			$data['error']['message'] ?? 'Failed to create media container'
+			$data['error']['message'] ?? ( $result['error'] ?? 'Failed to create media container' )
 		);
 	}
 
@@ -300,14 +293,19 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 		$url = "https://graph.threads.net/v1.0/{$media_id}?access_token={$access_token}";
 
 		for ( $i = 0; $i < 10; $i++ ) {
-			$response = wp_remote_get( $url, array( 'timeout' => 10 ) );
+			$result = HttpClient::get(
+				$url,
+				array(
+					'context' => 'Threads Media Status',
+					'timeout' => 10,
+				)
+			);
 
-			if ( is_wp_error( $response ) ) {
+			if ( empty( $result['success'] ) ) {
 				return false;
 			}
 
-			$body = wp_remote_retrieve_body( $response );
-			$data = json_decode( $body, true );
+			$data = json_decode( $result['data'], true );
 
 			if ( isset( $data['status'] ) && 'FINISHED' === $data['status'] ) {
 				return true;
@@ -333,9 +331,10 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 	private static function publish_thread( string $access_token, string $creation_id ) {
 		$url = 'https://graph.threads.net/v1.0/me/threads_publish';
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Threads Publish Thread',
 				'body'    => array(
 					'creation_id'  => $creation_id,
 					'access_token' => $access_token,
@@ -344,21 +343,15 @@ class ThreadsPublishAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
+		$data = ! empty( $result['success'] ) ? json_decode( $result['data'], true ) : null;
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-		$data        = json_decode( $body, true );
-
-		if ( $status_code >= 200 && $status_code < 300 && isset( $data['id'] ) ) {
+		if ( ! empty( $result['success'] ) && isset( $data['id'] ) ) {
 			return $data['id'];
 		}
 
 		return new \WP_Error(
 			'threads_publish_failed',
-			$data['error']['message'] ?? 'Failed to publish thread'
+			$data['error']['message'] ?? ( $result['error'] ?? 'Failed to publish thread' )
 		);
 	}
 }

--- a/inc/Abilities/Threads/ThreadsUpdateAbility.php
+++ b/inc/Abilities/Threads/ThreadsUpdateAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachineSocials\Abilities\Threads;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
 use DataMachineSocials\Abilities\AbstractSocialAbility;
 use DataMachineSocials\Handlers\Threads\ThreadsAuth;
 
@@ -117,9 +118,10 @@ class ThreadsUpdateAbility extends AbstractSocialAbility {
 	private function deleteThread( string $access_token, string $thread_id ): array|\WP_Error {
 		$url = self::GRAPH_API_URL . '/' . rawurlencode( $thread_id );
 
-		$response = wp_remote_post(
+		$result = HttpClient::post(
 			$url,
 			array(
+				'context' => 'Threads Delete',
 				'timeout' => 30,
 				'body'    => array(
 					'access_token' => $access_token,
@@ -127,15 +129,7 @@ class ThreadsUpdateAbility extends AbstractSocialAbility {
 			)
 		);
 
-		$normalized = $this->normalizeJsonResponse( $response );
-		if ( is_wp_error( $normalized ) ) {
-			return $normalized;
-		}
-
-		$status_code = $normalized['status_code'];
-		$body        = $normalized['data'];
-
-		if ( 200 === $status_code || 204 === $status_code ) {
+		if ( ! empty( $result['success'] ) ) {
 			return array(
 				'success' => true,
 				'data'    => array(
@@ -145,6 +139,6 @@ class ThreadsUpdateAbility extends AbstractSocialAbility {
 			);
 		}
 
-		return $this->apiError( $body['error']['message'] ?? 'Failed to delete thread' );
+		return $this->apiError( $result['error'] ?? 'Failed to delete thread' );
 	}
 }


### PR DESCRIPTION
## Summary

Implements #177. Routes every **write-path** ability (publish/update/delete) through the shared `DataMachine\Core\HttpClient` that the read/auth abilities already use (44 proven call sites), deleting the hand-rolled `wp_remote_* -> is_wp_error -> wp_remote_retrieve_response_code -> json_decode` boilerplate (~93 inlined sites). Net **-109 lines**.

This is a **transport-only swap** — same URLs, headers, bodies, timeouts, and the exact return shapes each ability hands back to its callers. The success path is byte-identical; HttpClient now owns the `is_wp_error` + status-code check internally, so the write abilities stop re-doing it.

## Before / after (the common pattern)

```php
// before
$response = wp_remote_post( $url, array( 'headers' => [...], 'body' => $payload, 'timeout' => 30 ) );
if ( is_wp_error( $response ) ) { return new \WP_Error( 'api_error', $response->get_error_message(), ... ); }
$status_code = wp_remote_retrieve_response_code( $response );
if ( $status_code < 200 || $status_code >= 300 ) { ... }
$data = json_decode( wp_remote_retrieve_body( $response ), true );

// after
$result = HttpClient::post( $url, array( 'context' => '...', 'headers' => [...], 'body' => $payload, 'timeout' => 30 ) );
if ( empty( $result['success'] ) ) { return new \WP_Error( 'api_error', $result['error'] ?? '...', ... ); }
$data = json_decode( $result['data'], true );
```

This mirrors the established read-path convention in this plugin (e.g. `BlueskyReadAbility`, `*Auth.php`, and the already-HttpClient `LinkedInPublishAbility` / `PinterestPublishAbility`).

## Platforms / methods converted

- **Reddit** — Vote, Submit, Reply (POST). Reddit's `json.errors`-in-200-body logical-error handling preserved (decode `data` on success, then check `json.errors`).
- **Bluesky** — Publish (createRecord POST + binary blob upload + OG-tag fetch), Update (delete DELETE, like POST), Delete (deleteRecord POST).
- **Pinterest** — Update/Delete (DELETE).
- **Threads** — Publish (media container POST, status-poll GET, publish POST), Update (delete POST), Delete (POST).
- **Facebook** — Publish (feed POST, photo-upload POST, comment POST), Update (edit/hide/delete POST), Delete (POST).
- **Instagram** — Publish (image/carousel/reel/story container POSTs, status-poll GETs, media_publish POST, permalink GET), Update (edit/delete/archive POST), Delete (DELETE), CommentReply (POST).
- **AbstractSocialAbility** — removed the now-dead `normalizeJsonResponse()` and `isSuccessStatus()` helpers (no remaining callers; HttpClient centralizes response handling) and updated the class docblock.

## Behavior preserved + the one nuance

- **Success paths are identical** — same parsing of `id` / `uri` / `permalink` / `json.data`, same returned arrays.
- **Error messages:** for platforms whose old error text came from a **nested** body field (Threads/Facebook/Instagram use `error.message`; Reddit/Pinterest used top-level `message`), the converted code keeps the nested-field extraction wherever the body is available on success-shaped responses. On a true transport/HTTP **failure**, HttpClient does not surface the raw body, so those failure messages now come from HttpClient's formatted error string (which already extracts top-level `message`/`error`/`error_description`/`detail`). The user-facing fallback strings (e.g. "Failed to delete pin", "Reel video processing failed…") are unchanged. This is a strictly more-consistent error surface, not a behavior regression on the publish path.
- Multipart/binary uploads (Bluesky blob, LinkedIn image — already converted) go through HttpClient cleanly via `body`/`headers`; no upload was left broken.

## Intentional hold-out

- `inc/Abilities/Reddit/FetchRedditAbility.php` — a **read** ability with a self-contained `httpGet()` helper that already returns the HttpClient-shaped `success`/`status_code`/`data` array. It is out of scope for #177 (write-path only) and was left as-is to keep this PR a clean write-path swap. Worth a follow-up for full read-path consistency.

## Verification

- `php -l` clean on all 19 touched files.
- `grep` for remaining write-path `wp_remote_` calls → **zero** (only the documented read-path `FetchRedditAbility` hold-out remains).
- `homeboy lint data-machine-socials`: **phpstan level 7 passed, 0 findings**. The eslint failures are pre-existing findings in untouched `src/components/*.tsx` files — unrelated to this PHP-only change.

Closes Extra-Chill/data-machine-socials#177