### PR TITLE
fix: scrub Extra Chill knowledge from QuoteCard template (layer purity)

### DIFF
--- a/inc/ImageGeneration/Templates/QuoteCard.php
+++ b/inc/ImageGeneration/Templates/QuoteCard.php
@@ -41,16 +41,88 @@ class QuoteCard implements TemplateInterface {
 	);
 
 	/**
-	 * Color palette — Extra Chill brand.
+	 * Neutral default color palette.
+	 *
+	 * Generic, brand-agnostic dark theme. Deploying sites override the palette
+	 * (including their own brand accent) via the `dm_socials_quote_card_palette`
+	 * filter — see get_palette().
 	 */
-	private const COLORS = array(
+	private const DEFAULT_COLORS = array(
 		'background'  => array( 26, 26, 26 ),      // #1a1a1a — dark.
 		'quote_text'  => array( 245, 245, 245 ),    // #f5f5f5 — near-white.
 		'attribution' => array( 176, 176, 176 ),    // #b0b0b0 — muted.
-		'accent'      => array( 83, 148, 11 ),      // #53940b — EC green.
-		'quote_mark'  => array( 83, 148, 11 ),      // #53940b — EC green.
+		'accent'      => array( 160, 160, 160 ),    // #a0a0a0 — neutral grey.
+		'quote_mark'  => array( 160, 160, 160 ),    // #a0a0a0 — neutral grey.
 		'branding'    => array( 120, 120, 120 ),    // #787878 — subtle.
 	);
+
+	/**
+	 * Neutral default header font filename.
+	 *
+	 * Resolved by GDRenderer against the active theme's assets/fonts/ directory
+	 * (with a system fallback). Sites that want a distinct brand display font
+	 * override this via the `dm_socials_quote_card_header_font` filter.
+	 */
+	private const DEFAULT_HEADER_FONT = 'helvetica.ttf';
+
+	/**
+	 * Resolve the color palette.
+	 *
+	 * Generic substrate ships a neutral dark palette. Deploying sites register
+	 * their own brand palette (accent color, etc.) by filtering the default.
+	 * Returned array is merged over the default so partial overrides are safe.
+	 *
+	 * @return array Palette keyed by region => array( r, g, b ).
+	 */
+	private function get_palette(): array {
+		/**
+		 * Filters the quote-card color palette.
+		 *
+		 * @param array $palette Palette keyed by region => array( r, g, b ).
+		 */
+		$palette = apply_filters( 'dm_socials_quote_card_palette', self::DEFAULT_COLORS );
+
+		return array_merge( self::DEFAULT_COLORS, is_array( $palette ) ? $palette : array() );
+	}
+
+	/**
+	 * Resolve the header (display) font filename.
+	 *
+	 * @return string Font filename resolved by GDRenderer against the theme.
+	 */
+	private function get_header_font(): string {
+		/**
+		 * Filters the quote-card header font filename.
+		 *
+		 * @param string $font Font filename (resolved against the theme fonts dir).
+		 */
+		$font = apply_filters( 'dm_socials_quote_card_header_font', self::DEFAULT_HEADER_FONT );
+
+		return is_string( $font ) && '' !== $font ? $font : self::DEFAULT_HEADER_FONT;
+	}
+
+	/**
+	 * Resolve the default branding text.
+	 *
+	 * Generic substrate derives branding from the running site, never a
+	 * hardcoded host. Deploying sites can override via the
+	 * `dm_socials_quote_card_branding` filter.
+	 *
+	 * @return string Branding text stamped onto the card.
+	 */
+	private function get_default_branding(): string {
+		$host    = wp_parse_url( home_url(), PHP_URL_HOST );
+		$default = is_string( $host ) && '' !== $host ? $host : (string) get_bloginfo( 'name' );
+
+		/**
+		 * Filters the default quote-card branding text.
+		 *
+		 * @param string $default Site-derived branding text.
+		 */
+		$branding = apply_filters( 'dm_socials_quote_card_branding', $default );
+
+		return is_string( $branding ) ? $branding : $default;
+	}
 
 	public function get_id(): string {
 		return 'quote_card';
@@ -61,7 +133,7 @@ class QuoteCard implements TemplateInterface {
 	}
 
 	public function get_description(): string {
-		return 'Instagram-friendly quote graphic from interview content. Renders quote text with attribution and Extra Chill branding.';
+		return 'Instagram-friendly quote graphic from interview content. Renders quote text with attribution and site branding.';
 	}
 
 	public function get_fields(): array {
@@ -118,7 +190,7 @@ class QuoteCard implements TemplateInterface {
 			);
 		}
 
-		$branding = $data['branding'] ?? 'extrachill.com';
+		$branding = $data['branding'] ?? $this->get_default_branding();
 		$preset   = $options['preset'] ?? $this->get_default_preset();
 		$format   = $options['format'] ?? 'png';
 		$context  = $options['context'] ?? array();
@@ -161,7 +233,7 @@ class QuoteCard implements TemplateInterface {
 	 * @param string     $quote_text   The quote.
 	 * @param string     $attribution  Who said it.
 	 * @param string     $source_title Interview/article title.
-	 * @param string     $branding     Branding text (e.g. extrachill.com).
+	 * @param string     $branding     Branding text (e.g. the site host).
 	 * @param string     $preset       Platform preset name.
 	 * @param string     $format       Output format (png/jpeg).
 	 * @param array      $context      Storage context for repository.
@@ -187,16 +259,19 @@ class QuoteCard implements TemplateInterface {
 		}
 
 		// Register fonts.
-		$renderer->register_font( 'header', 'WilcoLoftSans-Treble.ttf' );
+		$renderer->register_font( 'header', $this->get_header_font() );
 		$renderer->register_font( 'body', 'helvetica.ttf' );
 
+		// Resolve palette (neutral default, brand override via filter).
+		$colors = $this->get_palette();
+
 		// Allocate colors.
-		$bg_color          = $renderer->color_rgb( 'background', self::COLORS['background'] );
-		$quote_text_color  = $renderer->color_rgb( 'quote_text', self::COLORS['quote_text'] );
-		$attribution_color = $renderer->color_rgb( 'attribution', self::COLORS['attribution'] );
-		$accent_color      = $renderer->color_rgb( 'accent', self::COLORS['accent'] );
-		$quote_mark_color  = $renderer->color_rgb( 'quote_mark', self::COLORS['quote_mark'] );
-		$branding_color    = $renderer->color_rgb( 'branding', self::COLORS['branding'] );
+		$bg_color          = $renderer->color_rgb( 'background', $colors['background'] );
+		$quote_text_color  = $renderer->color_rgb( 'quote_text', $colors['quote_text'] );
+		$attribution_color = $renderer->color_rgb( 'attribution', $colors['attribution'] );
+		$accent_color      = $renderer->color_rgb( 'accent', $colors['accent'] );
+		$quote_mark_color  = $renderer->color_rgb( 'quote_mark', $colors['quote_mark'] );
+		$branding_color    = $renderer->color_rgb( 'branding', $colors['branding'] );
 
 		// Fill background.
 		$renderer->fill( $bg_color );


### PR DESCRIPTION
## Summary

Generic Data Machine substrate must not know it runs on Extra Chill. The `QuoteCard` image template (`inc/ImageGeneration/Templates/QuoteCard.php`) baked Extra Chill's brand identity directly into substrate code. This routes every site-specific value through a filterable seam with a **neutral, brand-agnostic default**, mirroring the `data-machine-business#54 / PR #55` precedent (`apply_filters` over a hardcoded literal).

Scope is limited to issue #179 bucket-A violations (plus the in-file `@param` example that the acceptance grep targets). Bucket-B prose/EXAMPLES docblocks and legit external refs are untouched.

## Violations fixed

| # | Was | Now |
|---|-----|-----|
| 1 | `COLORS` const = EC palette only (accent/quote_mark = `#53940b` EC green) | `DEFAULT_COLORS` = neutral dark palette, accent/quote_mark = neutral grey `#a0a0a0`; resolved via `get_palette()` |
| 2 | `get_description()` returned `"...Extra Chill branding."` (ships into MCP/REST template schema via `TemplateRegistry::get_template_definitions()`) | `"...site branding."` — no EC literal in the schema surface |
| 3 | `$branding = $data['branding'] ?? 'extrachill.com'` | defaults to the running site host (`wp_parse_url( home_url(), PHP_URL_HOST )`, falling back to `get_bloginfo('name')`), filterable |
| 4 (related, folded in) | header font hardcoded to EC-specific `WilcoLoftSans-Treble.ttf` | `DEFAULT_HEADER_FONT = 'helvetica.ttf'` (the generic body font), filterable so the EC display font is consumer-opted |

Also neutralized the `@param $branding` docblock example (`e.g. extrachill.com` → `e.g. the site host`) so the acceptance grep is clean.

## Filters added (what a consumer registers)

- **`dm_socials_quote_card_palette`** — array of `region => array(r,g,b)`. Override returned values are `array_merge`d over the neutral default, so partial overrides are safe. An EC consumer plugin registers the EC palette (incl. `#53940b` green accent) here.
- **`dm_socials_quote_card_header_font`** — font filename, resolved by `GDRenderer` against the active theme's `assets/fonts/`. An EC consumer registers `WilcoLoftSans-Treble.ttf` here.
- **`dm_socials_quote_card_branding`** — default branding text. An EC consumer can hardcode `extrachill.com` here if desired (otherwise the site host is used automatically).

## Neutral default chosen

A plain dark theme (`#1a1a1a` background, near-white quote text, **neutral grey** `#a0a0a0` accent/quote-mark — explicitly **not** EC green), the generic `helvetica.ttf` display font, and a site-derived branding string. With **no filter registered**, the default render path produces a coherent neutral card (behavior parity for the default path). Restoring the Extra Chill look is a **consumer-side filter registration**, which is **out of scope here** and noted as follow-up.

## Verification

- `php -l inc/ImageGeneration/Templates/QuoteCard.php` → no syntax errors.
- `phpcs --standard=WordPress inc/ImageGeneration/Templates/QuoteCard.php` → **exit 0** (clean, incl. the equals-alignment sniff).
- `homeboy lint data-machine-socials` → PHPStan passed; the touched file is **not** in any PHPCS/ESLint violation report (all reported findings are pre-existing repo-wide debt, out of scope for this layer-purity fix). Autofixer's unrelated edit to `LinkedInPublishAbility.php` was reverted to keep this PR scoped.
- Acceptance grep from the issue returns empty:
  ```
  grep -rinE "extrachill\.com|extra chill brand|extra chill branding" inc/ \
    | grep -vE "vendor/|node_modules/" | grep -vE "## EXAMPLES|@param|wp datamachine-socials"
  ```
- `grep -inE "extrachill|extra chill|53940b|WilcoLoftSans" QuoteCard.php` → **no matches** (all EC values reachable only via filters).

## Follow-up (out of scope)

- Register the EC palette / header font / branding via the three new filters from an Extra Chill consumer plugin to restore the EC-branded look in production.
- Bucket-B prose/`## EXAMPLES` `extrachill.com` references across CLI commands + `RestApi.php` remain (cosmetic, lower priority per the issue).

Closes Extra-Chill/data-machine-socials#179