### PR TITLE
fix: preserve Reddit fetch API errors

### DIFF
--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -307,21 +307,22 @@ class FetchRedditAbility extends AbstractSocialAbility {
 				)
 			);
 
-			if ( ! $result['success'] ) {
+			if ( is_wp_error( $result ) ) {
 				if ( 1 === $pages_fetched ) {
+					$error_message = $result->get_error_message();
+
 					$logs[] = array(
 						'level'   => 'error',
 						'message' => 'Reddit: API request failed.',
-						'data'    => array( 'error' => $result['error'] ),
+						'data'    => array( 'error' => $error_message ),
 					);
-					return new \WP_Error(
-						'api_error',
-						$result['error'],
-						array(
-							'status' => 500,
-							'logs'   => $logs,
-						)
-					);
+
+					$error_data         = $result->get_error_data();
+					$error_data         = is_array( $error_data ) ? $error_data : array();
+					$error_data['logs'] = $logs;
+					$result->add_data( $error_data );
+
+					return $result;
 				} else {
 					break;
 				}
@@ -747,14 +748,69 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		$response = wp_remote_get( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'api_error', $response->get_error_message(), array( 'status' => 500 ) );
+			return new \WP_Error(
+				'api_error',
+				sprintf( 'Reddit API request failed: %s', $response->get_error_message() ),
+				array(
+					'status'        => 500,
+					'upstream_code' => $response->get_error_code(),
+				)
+			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		$body        = wp_remote_retrieve_body( $response );
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			$response_data    = json_decode( $body, true );
+			$response_data    = is_array( $response_data ) ? $response_data : array();
+			$upstream_error   = $response_data['error'] ?? null;
+			$upstream_code    = is_array( $upstream_error ) ? ( $upstream_error['code'] ?? null ) : $upstream_error;
+			$upstream_message = is_array( $upstream_error ) ? ( $upstream_error['message'] ?? '' ) : '';
+			$upstream_message = $response_data['message'] ?? $response_data['error_description'] ?? $response_data['reason'] ?? $upstream_message;
+
+			if ( ! is_scalar( $upstream_message ) || '' === trim( (string) $upstream_message ) ) {
+				$upstream_message = wp_remote_retrieve_response_message( $response );
+			}
+			if ( '' === trim( (string) $upstream_message ) && is_scalar( $upstream_code ) ) {
+				$upstream_message = (string) $upstream_code;
+			}
+			if ( '' === trim( (string) $upstream_message ) ) {
+				$upstream_message = 'Reddit API request failed';
+			}
+
+			$error_context = sprintf( 'HTTP %d', $status_code );
+			if ( is_scalar( $upstream_code ) && '' !== trim( (string) $upstream_code ) && (string) $status_code !== (string) $upstream_code ) {
+				$error_context .= sprintf( ', code %s', (string) $upstream_code );
+			}
+
+			$error_data = array(
+				'status'           => $status_code > 0 ? $status_code : 500,
+				'upstream_message' => (string) $upstream_message,
+			);
+			if ( is_scalar( $upstream_code ) && '' !== trim( (string) $upstream_code ) ) {
+				$error_data['upstream_code'] = $upstream_code;
+			}
+
+			$rate_limit_headers = array(
+				'retry_after' => wp_remote_retrieve_header( $response, 'retry-after' ),
+				'remaining'   => wp_remote_retrieve_header( $response, 'x-ratelimit-remaining' ),
+				'used'        => wp_remote_retrieve_header( $response, 'x-ratelimit-used' ),
+				'reset'       => wp_remote_retrieve_header( $response, 'x-ratelimit-reset' ),
+			);
+			$rate_limit_headers = array_filter( $rate_limit_headers, static fn( $value ): bool => '' !== (string) $value );
+			if ( ! empty( $rate_limit_headers ) ) {
+				$error_data['rate_limit'] = $rate_limit_headers;
+			}
+
+			return new \WP_Error(
+				'api_error',
+				sprintf( 'Reddit API request failed (%s): %s', $error_context, (string) $upstream_message ),
+				$error_data
+			);
+		}
 
 		return array(
-			'success'     => $status_code >= 200 && $status_code < 300,
+			'success'     => true,
 			'status_code' => $status_code,
 			'data'        => $body,
 		);
@@ -774,7 +830,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			)
 		);
 
-		if ( $comments_result['success'] ) {
+		if ( ! is_wp_error( $comments_result ) && $comments_result['success'] ) {
 			$comments_data = json_decode( $comments_result['data'], true );
 			if ( json_last_error() === JSON_ERROR_NONE ) {
 				if ( is_array( $comments_data ) && isset( $comments_data[1]['data']['children'] ) ) {

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -91,6 +91,73 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $request_count );
 	}
 
+	public function test_rate_limit_error_preserves_upstream_details_for_cli(): void {
+		$this->mockRedditError(
+			429,
+			array(
+				'error'   => 429,
+				'message' => 'Too Many Requests',
+			),
+			array(
+				'retry-after'          => '60',
+				'x-ratelimit-remaining' => '0',
+				'x-ratelimit-reset'     => '60',
+			)
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'api_error', $result->get_error_code() );
+		$this->assertSame( 'Reddit API request failed (HTTP 429): Too Many Requests', $result->get_error_message() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+		$this->assertSame( 429, $result->get_error_data()['upstream_code'] );
+		$this->assertSame( 'Too Many Requests', $result->get_error_data()['upstream_message'] );
+		$this->assertSame( '60', $result->get_error_data()['rate_limit']['retry_after'] );
+		$this->assertSame( '0', $result->get_error_data()['rate_limit']['remaining'] );
+	}
+
+	public function test_nested_error_payload_is_normalized_to_non_empty_message(): void {
+		$this->mockRedditError(
+			401,
+			array(
+				'error' => array(
+					'code'    => 'invalid_token',
+					'message' => 'Token expired',
+				),
+			)
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'Reddit API request failed (HTTP 401, code invalid_token): Token expired', $result->get_error_message() );
+		$this->assertSame( 'invalid_token', $result->get_error_data()['upstream_code'] );
+	}
+
+	public function test_missing_error_payload_uses_http_response_message(): void {
+		$this->mockRedditError( 503, array(), array(), 'Service Unavailable' );
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'Reddit API request failed (HTTP 503): Service Unavailable', $result->get_error_message() );
+		$this->assertNotSame( '', $result->get_error_message() );
+	}
+
+	public function test_transport_error_is_normalized_for_cli(): void {
+		add_filter(
+			'pre_http_request',
+			static fn() => new \WP_Error( 'http_request_failed', 'Connection timed out' )
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'Reddit API request failed: Connection timed out', $result->get_error_message() );
+		$this->assertSame( 'http_request_failed', $result->get_error_data()['upstream_code'] );
+	}
+
 	/**
 	 * @param array<int,array{after:?string,posts:array<int,array<string,mixed>>}> $pages
 	 */
@@ -126,6 +193,24 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 							),
 						)
 					),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	private function mockRedditError( int $status_code, array $body, array $headers = array(), string $message = '' ): void {
+		add_filter(
+			'pre_http_request',
+			static function () use ( $status_code, $body, $headers, $message ): array {
+				return array(
+					'response' => array(
+						'code'    => $status_code,
+						'message' => $message,
+					),
+					'headers'  => $headers,
+					'body'     => wp_json_encode( $body ),
 				);
 			},
 			10,


### PR DESCRIPTION
## Summary
- normalize Reddit fetch transport and non-2xx failures to populated `WP_Error` objects at the ability HTTP boundary
- preserve HTTP status, upstream error code/message, and available rate-limit headers while keeping CLI output text-safe
- add regression coverage for rate limits, nested and missing error payloads, and transport failures

Fixes #190

## Root cause
`FetchRedditAbility::httpGet()` returned incompatible failure shapes: transport failures were `WP_Error`, while non-2xx responses were arrays containing `success`, `status_code`, and `data` but no `error`. The pagination loop assumed every failure was an array with an `error` key, producing undefined-key warnings and an empty error message that ultimately reached `WP_CLI::error()` as `null`.

## Error contract
Before: successful and non-2xx HTTP responses returned arrays, transport failures returned `WP_Error`, and callers did not safely distinguish them.

After: `httpGet()` returns a success array only for 2xx responses and a non-empty `WP_Error` for every transport or non-2xx failure. The first-page fetch returns that error with ability logs attached; later-page and comment failures stop or degrade cleanly without indexing an error object.

## Upstream details retained
Error data now includes the effective HTTP `status`, Reddit's `upstream_code` and `upstream_message` when present, and `retry_after`, remaining, used, and reset rate-limit values when supplied as response headers. The human-readable message includes HTTP status plus distinct upstream code/message, so the existing CLI path exits cleanly without exposing response HTML.

## Verification
- `php -l inc/Abilities/Reddit/FetchRedditAbility.php` - passed
- `php -l tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php` - passed
- `git diff --check` - passed
- `homeboy --placement local review lint --changed-only --errors-only --summary` - passed PHPCS and PHPStan with no errors
- `homeboy --placement local review test --skip-lint --json-summary -- --filter FetchRedditAbilityTest` - infrastructure timeout before PHPUnit produced results (exit 143), including a retry with a 300-second command timeout
- `homeboy --placement local review ci run --job wp-codebox-phpunit` - local WP Codebox job exited 1 without reporting PHPUnit results

## Residual limitation
The added WordPress unit tests could not execute locally because the Homeboy/WP Codebox test harness did not reach PHPUnit. Hosted PR checks remain the available execution surface. Comment-fetch failures continue to be intentionally non-fatal and return posts without comments, matching existing behavior.