### PR TITLE
fix: preserve Reddit queries across search sorts

### DIFF
--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -56,9 +56,9 @@ class FetchRedditAbility extends AbstractSocialAbility {
 							),
 							'sort_by'           => array(
 								'type'        => 'string',
-								'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' ),
+								'enum'        => array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance', 'comments' ),
 								'default'     => 'hot',
-								'description' => __( 'Sort order for posts. Use "relevance" for global search.', 'data-machine-socials' ),
+								'description' => __( 'Sort order for posts. Search supports relevance, hot, top, new, and comments.', 'data-machine-socials' ),
 							),
 							'timeframe_limit'   => array(
 								'type'        => 'string',
@@ -197,7 +197,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		$download_images       = $config['download_images'];
 
 		// Determine mode: global search vs subreddit fetch.
-		$is_global_search = ! empty( $query ) && empty( $subreddit );
+		$is_global_search    = ! empty( $query ) && empty( $subreddit );
 		$is_subreddit_search = ! empty( $query ) && ! empty( $subreddit );
 
 		// Validate: must have either subreddit or query.
@@ -232,7 +232,9 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			);
 		}
 
-		$valid_sorts = array( 'hot', 'new', 'top', 'rising', 'controversial', 'relevance' );
+		$valid_sorts = ! empty( $query )
+			? array( 'relevance', 'hot', 'top', 'new', 'comments' )
+			: array( 'hot', 'new', 'top', 'rising', 'controversial' );
 		if ( ! in_array( $sort, $valid_sorts, true ) ) {
 			$logs[] = array(
 				'level'   => 'error',
@@ -257,8 +259,8 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			'level'   => 'info',
 			'message' => sprintf( 'Reddit: Starting fetch (%s, sort: %s).', $mode_label, $sort ),
 			'data'    => array(
-				'subreddit'       => $subreddit,
-				'query'           => $query,
+				'subreddit'        => $subreddit,
+				'query'            => $query,
 				'is_global_search' => $is_global_search,
 			),
 		);
@@ -278,8 +280,6 @@ class FetchRedditAbility extends AbstractSocialAbility {
 				$timeframe_limit,
 				$fetch_batch_size,
 				$after_param,
-				$is_global_search,
-				$is_subreddit_search,
 				$logs
 			);
 
@@ -642,8 +642,6 @@ class FetchRedditAbility extends AbstractSocialAbility {
 	 * @param string      $timeframe_limit     Timeframe filter.
 	 * @param int         $fetch_batch_size    Number of posts per page.
 	 * @param string|null $after_param         Pagination cursor.
-	 * @param bool        $is_global_search    Whether this is a global search.
-	 * @param bool        $is_subreddit_search Whether this is a search within a subreddit.
 	 * @param array       &$logs               Log entries array (passed by reference).
 	 * @return string The full Reddit API URL.
 	 */
@@ -654,8 +652,6 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		string $timeframe_limit,
 		int $fetch_batch_size,
 		?string $after_param,
-		bool $is_global_search,
-		bool $is_subreddit_search,
 		array &$logs
 	): string {
 		$base = 'https://oauth.reddit.com';
@@ -671,7 +667,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			'1_year'   => 'year',
 		);
 
-		if ( $is_global_search || $is_subreddit_search ) {
+		if ( ! empty( $query ) ) {
 			// Search endpoint: /search.json or /r/{subreddit}/search.json
 			$params = array(
 				'q'     => $query,
@@ -693,7 +689,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 				);
 			}
 
-			if ( $is_subreddit_search ) {
+			if ( ! empty( $subreddit ) ) {
 				$params['restrict_sr'] = 'on';
 				$endpoint              = "/r/{$subreddit}/search.json";
 			} else {

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -475,6 +475,7 @@ class RedditCommand {
 	 *   - rising
 	 *   - controversial
 	 *   - relevance
+	 *   - comments
 	 * ---
 	 *
 	 * [--timeframe=<timeframe>]

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -92,6 +92,75 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider searchSortProvider
+	 */
+	public function test_global_query_uses_search_endpoint_for_supported_sort( string $sort ): void {
+		$request_url = '';
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$request_url ) {
+				$request_url = $url;
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'data' => array(
+								'after'    => null,
+								'children' => array(),
+							),
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$result = ( new FetchRedditAbility() )->execute(
+			array(
+				'query'           => 'Charleston live music',
+				'access_token'    => 'reddit-token',
+				'sort_by'         => $sort,
+				'timeframe_limit' => '90_days',
+				'download_images' => false,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( '/search.json', wp_parse_url( $request_url, PHP_URL_PATH ) );
+
+		parse_str( (string) wp_parse_url( $request_url, PHP_URL_QUERY ), $request_params );
+		$this->assertSame( 'Charleston live music', $request_params['q'] );
+		$this->assertSame( $sort, $request_params['sort'] );
+		$this->assertSame( 'year', $request_params['t'] );
+	}
+
+	public function searchSortProvider(): array {
+		return array(
+			'relevance' => array( 'relevance' ),
+			'hot'       => array( 'hot' ),
+			'top'       => array( 'top' ),
+			'new'       => array( 'new' ),
+			'comments'  => array( 'comments' ),
+		);
+	}
+
+	public function test_global_query_rejects_browse_only_sort(): void {
+		$result = ( new FetchRedditAbility() )->execute(
+			array(
+				'query'        => 'Charleston live music',
+				'access_token' => 'reddit-token',
+				'sort_by'      => 'rising',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'Invalid sort parameter', $result->get_error_message() );
+	}
+
+	/**
 	 * @param array<int,array{after:?string,posts:array<int,array<string,mixed>>}> $pages
 	 */
 	private function mockRedditPages( array $pages, ?int &$request_count = null ): void {


### PR DESCRIPTION
## Summary
- make a non-empty Reddit `query` the authoritative signal for `/search.json` or subreddit search routing, independent of sort
- validate search and browse sorts against their endpoint-specific capabilities, including Reddit's `comments` search sort and explicit rejection of browse-only search combinations
- cover global query request construction across every supported search sort, including `new`

## Root cause
The request builder received both the query and separately derived search-mode booleans, so endpoint selection was not directly bound to the presence of `query`. The ability also validated one union of browse and search sorts, allowing unsupported endpoint combinations without an explicit error. The affected route is the OAuth Reddit global search endpoint, `GET /search.json`.

Current `main` already had a search branch for correctly derived mode flags, so the reported production response could not be reproduced as a deterministic `/new` construction from the checked-out source. This change removes that duplicated routing state and adds request-level regression coverage so query-preserving behavior is enforced rather than incidental.

## Request semantics
Before:
- route selection depended on booleans computed separately from the query and passed into the URL builder
- all browse/search sort names shared one validation list
- global query + `new` had no request-construction regression coverage

After:
- any non-empty query always selects `/search.json` (or `/r/{subreddit}/search.json`) and remains attached as `q`
- `sort=new` remains the search endpoint's `sort` parameter
- search accepts Reddit's supported `relevance`, `hot`, `top`, `new`, and `comments` sorts
- browse-only `rising` and `controversial` sorts return `Invalid sort parameter` when combined with a query

## Verification
- `php -l inc/Abilities/Reddit/FetchRedditAbility.php && php -l inc/Cli/Commands/RedditCommand.php && php -l tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php` - passed
- `homeboy review test --placement local --skip-lint -- --filter test_global_query` - passed, 6 tests / 27 assertions
- `homeboy review lint --placement local --changed-only --summary` - passed; PHPStan passed; one pre-existing `urlencode()` warning remains outside the changed lines
- `homeboy review audit --placement local --profile pr --changed-since origin/main` - passed with no introduced findings
- `git diff --check` - passed

The broader `FetchRedditAbilityTest` class run executed all 8 tests: the 6 new query cases passed, while 2 pre-existing collector tests errored because the Codebox PHPUnit recipe does not load `DataMachine\\Core\\Steps\\Fetch\\FreshCandidateCollector`. No product-code failure was reported by those tests.

## Reddit API limitations
Reddit search supports `relevance`, `hot`, `top`, `new`, and `comments`. `rising` and `controversial` are listing sorts, not supported search sorts. Reddit may still return broad matches according to its own query-matching behavior; this change guarantees endpoint and parameter semantics, not result relevance.

## Residual risk
This uses mocked HTTP request inspection rather than a live Reddit assertion, avoiding dependence on credentials, rate limits, and changing search results. A live API behavior change could still affect result quality while preserving the verified request contract.

Fixes #191