### PR TITLE
feat: add explicit Reddit fetch result limit

### DIFF
--- a/docs/handlers/reddit.md
+++ b/docs/handlers/reddit.md
@@ -38,12 +38,13 @@ Fetches posts from Reddit subreddits via OAuth 2.0 with timeframe filtering, key
 | `min_upvotes` | int | No | Minimum upvote threshold (default: 0) |
 | `min_comment_count` | int | No | Minimum comment count threshold (default: 0) |
 | `search` | string | No | Keyword filter for post titles and content |
+| `max_items` | int | No | Direct ability result cap (1-500); pipeline fetches remain governed by their collector |
 
 ## Fetch Behavior
 
 1. Authenticates via `RedditAuth::get_valid_access_token()` (auto-refreshes expired tokens)
 2. Delegates to `FetchRedditAbility::execute()` with config parameters
-3. Fetches up to `fetch_batch_size` (100) posts across `max_pages` (5) pages
+3. Fetches up to `fetch_batch_size` (100) posts across `max_pages` (5) pages, stopping early when a direct `max_items` cap or pipeline collector target is met
 4. Filters by upvotes, comment count, and keywords
 5. Checks processed items for dedup
 6. Downloads images for eligible posts via `ExecutionContext::downloadFile()`
@@ -80,7 +81,8 @@ Each eligible item contains:
 ## CLI Commands
 
 `RedditCommand` provides WP-CLI access:
-- `wp datamachine reddit fetch` — fetch posts from a subreddit
+- `wp datamachine-socials reddit fetch <subreddit> --limit=25` — bounded subreddit fetch
+- `wp datamachine-socials reddit fetch --query="live music" --limit=10` — bounded global search
 
 ## Chat Tools
 

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -95,6 +95,12 @@ class FetchRedditAbility extends AbstractSocialAbility {
 								'default'     => 5,
 								'description' => __( 'Maximum number of pages to fetch', 'data-machine-socials' ),
 							),
+							'max_items'         => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => 500,
+								'description' => __( 'Maximum eligible posts to return for direct ability calls', 'data-machine-socials' ),
+							),
 							'download_images'   => array(
 								'type'        => 'boolean',
 								'default'     => true,
@@ -134,7 +140,8 @@ class FetchRedditAbility extends AbstractSocialAbility {
 	 * Used for direct ability invocations (REST, MCP, ad-hoc PHP calls) where
 	 * there is no Data Machine pipeline context to consult for processed/claim
 	 * state. Returns every Reddit-side eligible post the pagination loop
-	 * surfaces, capped only by `max_pages` and Reddit's natural pagination.
+	 * surfaces, optionally capped by `max_items`, plus `max_pages` and Reddit's
+	 * natural pagination.
 	 *
 	 * Pipeline-driven fetches go through `executeWithCollector()` so that the
 	 * Data Machine core `FreshCandidateCollector` owns processed/claimed/
@@ -194,7 +201,16 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		$search_term           = $config['search'];
 		$fetch_batch_size      = $config['fetch_batch_size'];
 		$max_pages             = $config['max_pages'];
+		$max_items             = null === $collector ? $config['max_items'] : null;
 		$download_images       = $config['download_images'];
+
+		if ( null !== $max_items && ( ! is_int( $max_items ) || $max_items < 1 || $max_items > 500 ) ) {
+			return new \WP_Error(
+				'invalid_param',
+				'max_items must be an integer between 1 and 500',
+				array( 'status' => 400 )
+			);
+		}
 
 		// Determine mode: global search vs subreddit fetch.
 		$is_global_search = ! empty( $query ) && empty( $subreddit );
@@ -524,8 +540,11 @@ class FetchRedditAbility extends AbstractSocialAbility {
 
 				if ( null === $collector ) {
 					// Direct REST/MCP/ad-hoc invocation — no DM core eligibility
-					// surface to consult; surface every Reddit-side eligible item.
+					// surface to consult; honor only the direct-call result cap.
 					$eligible_items[] = $candidate;
+					if ( null !== $max_items && count( $eligible_items ) >= $max_items ) {
+						break;
+					}
 					continue;
 				}
 
@@ -543,6 +562,15 @@ class FetchRedditAbility extends AbstractSocialAbility {
 				if ( $collector->isFull() ) {
 					break;
 				}
+			}
+
+			if ( null === $collector && null !== $max_items && count( $eligible_items ) >= $max_items ) {
+				$logs[] = array(
+					'level'   => 'debug',
+					'message' => 'Reddit: Direct result limit reached, ending pagination.',
+					'data'    => array( 'page' => $pages_fetched ),
+				);
+				break;
 			}
 
 			if ( null !== $collector && $collector->isFull() ) {
@@ -627,6 +655,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			'search'            => '',
 			'fetch_batch_size'  => 100,
 			'max_pages'         => 5,
+			'max_items'         => null,
 			'download_images'   => true,
 		);
 

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -213,7 +213,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		}
 
 		// Determine mode: global search vs subreddit fetch.
-		$is_global_search = ! empty( $query ) && empty( $subreddit );
+		$is_global_search    = ! empty( $query ) && empty( $subreddit );
 		$is_subreddit_search = ! empty( $query ) && ! empty( $subreddit );
 
 		// Validate: must have either subreddit or query.
@@ -273,8 +273,8 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			'level'   => 'info',
 			'message' => sprintf( 'Reddit: Starting fetch (%s, sort: %s).', $mode_label, $sort ),
 			'data'    => array(
-				'subreddit'       => $subreddit,
-				'query'           => $query,
+				'subreddit'        => $subreddit,
+				'query'            => $query,
 				'is_global_search' => $is_global_search,
 			),
 		);

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -513,6 +513,9 @@ class RedditCommand {
 	 * [--search=<search>]
 	 * : Comma-separated search terms to filter posts locally (client-side).
 	 *
+	 * [--limit=<count>]
+	 * : Maximum eligible posts to return. Must be between 1 and 500.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -527,11 +530,11 @@ class RedditCommand {
 	 *
 	 *     # Fetch from a subreddit
 	 *     wp datamachine-socials reddit fetch jambands
-	 *     wp datamachine-socials reddit fetch festivals --sort=top --min-upvotes=50
+	 *     wp datamachine-socials reddit fetch festivals --sort=top --min-upvotes=50 --limit=25
 	 *     wp datamachine-socials reddit fetch bonnaroo --timeframe=7_days --comments=5
 	 *
 	 *     # Global search across all of Reddit
-	 *     wp datamachine-socials reddit fetch --query="best live music calendar" --sort=relevance --timeframe=30_days
+	 *     wp datamachine-socials reddit fetch --query="best live music calendar" --sort=relevance --timeframe=30_days --limit=10
 	 *     wp datamachine-socials reddit fetch --query="concert events near me" --min-upvotes=5 --comments=3
 	 *
 	 *     # Search within a specific subreddit
@@ -565,6 +568,11 @@ class RedditCommand {
 			'max_pages'         => 5,
 			'download_images'   => false, // CLI doesn't download images by default.
 		);
+		try {
+			$input = $this->applyFetchLimit( $input, $assoc_args );
+		} catch ( \InvalidArgumentException $exception ) {
+			WP_CLI::error( $exception->getMessage() );
+		}
 
 		if ( ! empty( $subreddit ) && ! empty( $query ) ) {
 			WP_CLI::log( "Searching r/{$subreddit} for \"{$query}\" (sort: {$input['sort_by']})..." );
@@ -622,6 +630,23 @@ class RedditCommand {
 
 		WP_CLI::success( count( $rows ) . ' posts found' );
 		WP_CLI\Utils\format_items( 'table', $rows, array( 'score', 'comments', 'subreddit', 'author', 'title' ) );
+	}
+
+	/**
+	 * Validate and map the optional CLI limit to the direct ability contract.
+	 */
+	private function applyFetchLimit( array $input, array $assoc_args ): array {
+		if ( ! array_key_exists( 'limit', $assoc_args ) ) {
+			return $input;
+		}
+
+		$limit = $assoc_args['limit'];
+		if ( ! is_string( $limit ) || ! preg_match( '/^[1-9][0-9]*$/', $limit ) || (int) $limit > 500 ) {
+			throw new \InvalidArgumentException( '--limit must be a whole number between 1 and 500.' );
+		}
+
+		$input['max_items'] = (int) $limit;
+		return $input;
 	}
 
 	/**

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -541,14 +541,21 @@ class RedditCommand {
 	 *     wp datamachine-socials reddit fetch Austin --query="live music tonight"
 	 */
 	public function fetch( $args, $assoc_args ) {
-		$subreddit    = $args[0] ?? '';
-		$query        = $assoc_args['query'] ?? '';
-		$access_token = $this->get_access_token();
+		$subreddit = $args[0] ?? '';
+		$query     = $assoc_args['query'] ?? '';
 
 		// Validate: must have at least one of subreddit or query.
 		if ( empty( $subreddit ) && empty( $query ) ) {
 			WP_CLI::error( 'Provide a subreddit name or --query (or both).' );
 		}
+
+		try {
+			$limit_input = $this->applyFetchLimit( array(), $assoc_args );
+		} catch ( \InvalidArgumentException $exception ) {
+			WP_CLI::error( $exception->getMessage() );
+		}
+
+		$access_token = $this->get_access_token();
 
 		// Default sort to 'relevance' for search queries.
 		$default_sort = ! empty( $query ) ? 'relevance' : 'hot';
@@ -568,11 +575,7 @@ class RedditCommand {
 			'max_pages'         => 5,
 			'download_images'   => false, // CLI doesn't download images by default.
 		);
-		try {
-			$input = $this->applyFetchLimit( $input, $assoc_args );
-		} catch ( \InvalidArgumentException $exception ) {
-			WP_CLI::error( $exception->getMessage() );
-		}
+		$input = array_merge( $input, $limit_input );
 
 		if ( ! empty( $subreddit ) && ! empty( $query ) ) {
 			WP_CLI::log( "Searching r/{$subreddit} for \"{$query}\" (sort: {$input['sort_by']})..." );

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -91,6 +91,72 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $request_count );
 	}
 
+	public function test_direct_limit_caps_items_and_stops_pagination_early(): void {
+		$request_count = 0;
+		$this->mockRedditPages(
+			array(
+				array(
+					'after' => 'page-2',
+					'posts' => array(
+						$this->redditPost( 'first', 'First post' ),
+						$this->redditPost( 'second', 'Second post' ),
+						$this->redditPost( 'third', 'Third post' ),
+					),
+				),
+				array(
+					'after' => null,
+					'posts' => array( $this->redditPost( 'fourth', 'Fourth post' ) ),
+				),
+			),
+			$request_count
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput( array( 'max_items' => 2 ) ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'first', 'second' ), array_column( $result['items'], 'item_id' ) );
+		$this->assertSame( 1, $request_count );
+	}
+
+	public function test_direct_limit_returns_fewer_items_when_source_is_exhausted(): void {
+		$this->mockRedditPages(
+			array(
+				array(
+					'after' => null,
+					'posts' => array( $this->redditPost( 'only', 'Only post' ) ),
+				),
+			)
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput( array( 'max_items' => 3 ) ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'only' ), array_column( $result['items'], 'item_id' ) );
+	}
+
+	public function test_direct_limit_does_not_override_collector_authority(): void {
+		$this->mockRedditPages(
+			array(
+				array(
+					'after' => null,
+					'posts' => array(
+						$this->redditPost( 'first', 'First post' ),
+						$this->redditPost( 'second', 'Second post' ),
+					),
+				),
+			)
+		);
+
+		$collector = new FreshCandidateCollector( $this->buildContext(), 2 );
+		$result    = ( new FetchRedditAbility() )->executeWithCollector(
+			$this->fetchInput( array( 'max_items' => 1 ) ),
+			$collector
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'first', 'second' ), array_column( $result['items'], 'item_id' ) );
+	}
+
 	/**
 	 * @param array<int,array{after:?string,posts:array<int,array<string,mixed>>}> $pages
 	 */
@@ -154,13 +220,16 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 		return $context;
 	}
 
-	private function fetchInput(): array {
-		return array(
-			'subreddit'        => 'WordPress',
-			'access_token'     => 'reddit-token',
-			'fetch_batch_size' => 100,
-			'max_pages'        => 5,
-			'download_images'  => false,
+	private function fetchInput( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'subreddit'        => 'WordPress',
+				'access_token'     => 'reddit-token',
+				'fetch_batch_size' => 100,
+				'max_pages'        => 5,
+				'download_images'  => false,
+			),
+			$overrides
 		);
 	}
 

--- a/tests/Unit/Cli/Commands/RedditCommandTest.php
+++ b/tests/Unit/Cli/Commands/RedditCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * RedditCommand Tests
+ *
+ * @package DataMachineSocials\Tests\Unit\Cli\Commands
+ */
+
+namespace DataMachineSocials\Tests\Unit\Cli\Commands;
+
+use DataMachineSocials\Cli\Commands\RedditCommand;
+use WP_UnitTestCase;
+
+class RedditCommandTest extends WP_UnitTestCase {
+
+	public function test_fetch_limit_maps_to_ability_max_items(): void {
+		$input = $this->applyFetchLimit( array( 'limit' => '25' ) );
+
+		$this->assertSame( 25, $input['max_items'] );
+	}
+
+	public function test_omitted_fetch_limit_preserves_unbounded_ability_input(): void {
+		$input = $this->applyFetchLimit();
+
+		$this->assertArrayNotHasKey( 'max_items', $input );
+	}
+
+	/**
+	 * @dataProvider invalidFetchLimitProvider
+	 */
+	public function test_fetch_limit_rejects_invalid_values( mixed $limit ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( '--limit must be a whole number between 1 and 500.' );
+
+		$this->applyFetchLimit( array( 'limit' => $limit ) );
+	}
+
+	public function invalidFetchLimitProvider(): array {
+		return array(
+			'zero'         => array( '0' ),
+			'negative'     => array( '-1' ),
+			'decimal'      => array( '1.5' ),
+			'malformed'    => array( 'ten' ),
+			'unreasonable' => array( '501' ),
+		);
+	}
+
+	private function applyFetchLimit( array $assoc_args = array() ): array {
+		$method = new \ReflectionMethod( RedditCommand::class, 'applyFetchLimit' );
+
+		return $method->invoke( new RedditCommand(), array(), $assoc_args );
+	}
+}


### PR DESCRIPTION
## Summary
- add optional `--limit=<count>` to direct Reddit subreddit and global fetches
- map the bound to the Socials-owned `datamachine/fetch-reddit` `max_items` input and stop pagination as soon as enough eligible posts are collected
- preserve Core `FreshCandidateCollector` authority for pipeline executions and preserve existing unbounded direct behavior when the flag is omitted

Fixes #192

## Before / After
Before, `wp datamachine-socials reddit fetch` always scanned up to five pages of 100 posts and returned every Reddit-eligible result. After, callers can request an exact cap such as `--limit=25`; omitted limits retain the prior behavior.

## Ownership
The change remains in Data Machine Socials because it bounds the Reddit-specific direct ability and CLI adapter. It does not add or alter a generic Core substrate. Pipeline execution still passes candidates to Core's `FreshCandidateCollector`, whose configured `max_items`, processed/claimed filtering, and final pipeline cap remain authoritative.

## Pagination Semantics
Direct calls append eligible posts in Reddit order and break the current page loop exactly when `max_items` is reached, so later posts on that page are not expanded and later pages are not requested. If Reddit exhausts first, all available eligible posts are returned normally. Collector-backed calls ignore the direct input and continue according to collector fullness or source exhaustion.

## Validation
`--limit` must be an unsigned whole-number string from 1 through 500. Zero, negatives, decimals, malformed values, non-string programmatic CLI values, and values above the existing 5 x 100 page budget are rejected with `--limit must be a whole number between 1 and 500.` Validation runs before Reddit authentication. The ability schema and direct PHP execution enforce the same 1-500 range.

## Tests
- `php -l inc/Abilities/Reddit/FetchRedditAbility.php && php -l inc/Cli/Commands/RedditCommand.php && php -l tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php && php -l tests/Unit/Cli/Commands/RedditCommandTest.php` - passed
- `git diff --check origin/main...HEAD` - passed
- `homeboy --placement local review lint data-machine-socials --changed-since origin/main` - passed; PHPCS and PHPStan passed, with one pre-existing `urlencode()` warning in `FetchRedditAbility.php`
- `homeboy --placement local review --changed-since origin/main --summary` - audit passed and lint passed; test runner selected both focused Reddit test files but executed zero tests because the Codebox runtime could not load `DataMachine\\Core\\OAuth\\BaseOAuth2Provider`

Focused coverage added for exact caps, early pagination stop, source exhaustion below the cap, collector authority, omitted CLI limits, CLI mapping, and invalid CLI values.

## Residual Risks
The new PHPUnit cases could not execute in the current Codebox review environment because its Data Machine Core overlay failed during suite bootstrap. Runtime behavior is covered by focused tests in the repository, syntax checks, PHPCS, PHPStan, and direct boundary checks, but CI must confirm the PHPUnit cases once the dependency overlay is available.