### PR TITLE
feat: add bounded delegated cross-posting

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -172,6 +172,8 @@ function datamachine_socials_bootstrap() {
 		return $tasks;
 	} );
 
+	\DataMachineSocials\Operations\DelegatedCrossPostAction::register();
+
 	// Register image generation templates
 	add_filter( 'datamachine/image_generation/templates', function ( array $templates ): array {
 		$templates['quote_card'] = \DataMachineSocials\ImageGeneration\Templates\QuoteCard::class;

--- a/inc/Abilities/Twitter/TwitterPublishAbility.php
+++ b/inc/Abilities/Twitter/TwitterPublishAbility.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * Self-contained ability class for Twitter publishing.
  */
 class TwitterPublishAbility extends AbstractSocialAbility {
+	private const MAX_REMOTE_MEDIA_BYTES = 15 * MB_IN_BYTES;
 
 	/**
 	 * Whether the ability has been registered.
@@ -58,6 +59,15 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 							'image_path'    => array(
 								'type'        => 'string',
 								'description' => 'Path to image file for upload',
+							),
+							'image_urls'    => array(
+								'type'        => 'array',
+								'description' => 'Public image URLs to download and upload (maximum 4)',
+								'items'       => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+								'maxItems'    => 4,
 							),
 							'source_url'    => array(
 								'type'        => 'string',
@@ -132,6 +142,8 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 	public static function execute_publish( array $input ): array|\WP_Error {
 		$content       = $input['content'] ?? '';
 		$media_path    = $input['media_path'] ?? $input['image_path'] ?? '';
+		$image_limit   = empty( $media_path ) ? 4 : 3;
+		$image_urls    = is_array( $input['image_urls'] ?? null ) ? array_slice( $input['image_urls'], 0, $image_limit ) : array();
 		$source_url    = $input['source_url'] ?? '';
 		$link_handling = $input['link_handling'] ?? 'append';
 
@@ -157,27 +169,42 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 		try {
 			$connection->setApiVersion( '2' );
 
-			$v2_payload = array( 'text' => $tweet_text );
-			$media_id   = null;
+			$v2_payload  = array( 'text' => $tweet_text );
+			$media_paths = array();
+			$temporary   = array();
+			$media_ids   = array();
 
 			// Handle media upload if provided — supports images and video via core validation.
 			if ( ! empty( $media_path ) && file_exists( $media_path ) ) {
-				$media_id = self::upload_media( $connection, $media_path );
+				$media_paths[] = $media_path;
+			}
+			foreach ( $image_urls as $image_url ) {
+				$downloaded = self::download_media( (string) $image_url );
+				if ( is_wp_error( $downloaded ) ) {
+					return $downloaded;
+				}
+				$media_paths[] = $downloaded;
+				$temporary[]   = $downloaded;
+			}
+
+			foreach ( $media_paths as $path ) {
+				$media_id = self::upload_media( $connection, $path );
 				if ( ! $media_id ) {
 					return new \WP_Error( 'api_error', 'Failed to upload media', array( 'status' => 500 ) );
 				}
+				$media_ids[] = $media_id;
 			}
 
-			if ( $media_id ) {
-				$v2_payload['media'] = array( 'media_ids' => array( $media_id ) );
+			if ( ! empty( $media_ids ) ) {
+				$v2_payload['media'] = array( 'media_ids' => $media_ids );
 			}
 
 			$response  = $connection->post( 'tweets', $v2_payload, array( 'json' => true ) );
 			$http_code = $connection->getLastHttpCode();
 
 			if ( 201 === $http_code && isset( $response->data->id ) ) {
-				$tweet_id = $response->data->id;
-				$username = $provider->get_username() ?? 'twitter';
+				$tweet_id  = $response->data->id;
+				$username  = $provider->get_username() ?? 'twitter';
 				$tweet_url = "https://twitter.com/{$username}/status/{$tweet_id}";
 
 				$result = array(
@@ -206,7 +233,46 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 			return new \WP_Error( 'api_error', $error_msg, array( 'status' => 500 ) );
 		} catch ( \Exception $e ) {
 			return new \WP_Error( 'api_error', $e->getMessage(), array( 'status' => 500 ) );
+		} finally {
+			foreach ( $temporary ?? array() as $temporary_path ) {
+				wp_delete_file( $temporary_path );
+			}
 		}
+	}
+
+	/**
+	 * Download one public media URL to a temporary local file.
+	 *
+	 * @param string $url Public media URL.
+	 * @return string|\WP_Error Temporary path or download failure.
+	 */
+	private static function download_media( string $url ): string|\WP_Error {
+		if ( ! wp_http_validate_url( $url ) ) {
+			return new \WP_Error( 'invalid_media_url', 'Media URL must be a public HTTP URL', array( 'status' => 400 ) );
+		}
+		if ( ! function_exists( 'wp_tempnam' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		$temporary_path = wp_tempnam( $url );
+		if ( ! is_string( $temporary_path ) || '' === $temporary_path ) {
+			return new \WP_Error( 'media_download_failed', 'Could not allocate temporary media storage', array( 'status' => 500 ) );
+		}
+
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'             => 30,
+				'stream'              => true,
+				'filename'            => $temporary_path,
+				'limit_response_size' => self::MAX_REMOTE_MEDIA_BYTES + 1,
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) || filesize( $temporary_path ) > self::MAX_REMOTE_MEDIA_BYTES ) {
+			wp_delete_file( $temporary_path );
+			return new \WP_Error( 'media_download_failed', 'Twitter media download failed or exceeded the 15 MB limit', array( 'status' => 400 ) );
+		}
+
+		return $temporary_path;
 	}
 
 	/**
@@ -313,11 +379,13 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 		$media_id = $init_response->media_id_string;
 
 		// APPEND
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Twitter's chunked upload requires a streaming file handle.
 		$handle        = fopen( $media_path, 'rb' );
 		$segment_index = 0;
 		$chunk_size    = 1048576; // 1MB
 
 		while ( ! feof( $handle ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Read bounded chunks from the validated local file.
 			$chunk = fread( $handle, $chunk_size );
 			$connection->post(
 				'media/upload',
@@ -331,6 +399,7 @@ class TwitterPublishAbility extends AbstractSocialAbility {
 			);
 			++$segment_index;
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Close the streaming upload handle opened above.
 		fclose( $handle );
 
 		// FINALIZE

--- a/inc/Operations/DelegatedCrossPostAction.php
+++ b/inc/Operations/DelegatedCrossPostAction.php
@@ -1,0 +1,442 @@
+<?php
+/**
+ * Bounded delegated cross-post operation.
+ *
+ * @package DataMachineSocials\Operations
+ */
+
+namespace DataMachineSocials\Operations;
+
+defined( 'ABSPATH' ) || exit;
+
+final class DelegatedCrossPostAction {
+
+	public const ACTION_ID = 'datamachine-socials/cross-post';
+
+	private const VERSION = '1';
+
+	private const CHANNELS = array(
+		'bluesky',
+		'facebook',
+		'instagram',
+		'pinterest',
+		'threads',
+		'twitter',
+	);
+
+	private const MEDIA_KINDS = array( 'image', 'carousel', 'reel', 'story' );
+
+	private const INPUT_KEYS = array(
+		'post_id',
+		'source_url',
+		'caption',
+		'content_hash',
+		'channels',
+		'media_kind',
+		'asset_refs',
+	);
+
+	private const RESULT_SOURCE = 'datamachine_socials_cross_post';
+
+	/** Register the owner action through Data Machine's public filter. */
+	public static function register(): void {
+		add_filter( 'datamachine_delegated_operation_actions', array( self::class, 'register_action' ) );
+	}
+
+	/**
+	 * @param array $actions Registered delegated actions.
+	 * @return array
+	 */
+	public static function register_action( array $actions ): array {
+		$actions[ self::ACTION_ID ] = array(
+			'version'         => self::VERSION,
+			'normalize_input' => array( self::class, 'normalize_input' ),
+			'authorize'       => array( self::class, 'authorize' ),
+			'prepare'         => array( self::class, 'prepare' ),
+			'project'         => array( self::class, 'project' ),
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Normalize and validate owner-controlled operation input before enqueue.
+	 *
+	 * @param array $input   Raw operation input.
+	 * @param array $context Data Machine operation context.
+	 * @return array|\WP_Error
+	 */
+	public static function normalize_input( array $input, array $context = array() ) {
+		unset( $context );
+
+		$unknown_keys = array_diff( array_keys( $input ), self::INPUT_KEYS );
+		if ( ! empty( $unknown_keys ) ) {
+			return self::error( 'social_cross_post_invalid_input', 'Unknown input fields are not allowed.' );
+		}
+
+		$post_id = self::strict_positive_int( $input['post_id'] ?? null );
+		if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
+			return self::error( 'social_cross_post_invalid_post', 'A published canonical post is required.' );
+		}
+
+		$canonical_url = get_permalink( $post_id );
+		$source_url    = $input['source_url'] ?? null;
+		if ( ! is_string( $source_url ) || ! self::is_public_url( $source_url ) || ! is_string( $canonical_url ) || ! hash_equals( $canonical_url, $source_url ) ) {
+			return self::error( 'social_cross_post_invalid_source_url', 'The source URL must match the canonical post URL.' );
+		}
+
+		$channels = self::normalize_channels( $input['channels'] ?? null );
+		if ( is_wp_error( $channels ) ) {
+			return $channels;
+		}
+
+		$caption = $input['caption'] ?? null;
+		if ( ! is_string( $caption ) || sanitize_textarea_field( $caption ) !== $caption || '' === trim( $caption ) || mb_strlen( $caption ) > self::caption_limit( $channels, $source_url ) ) {
+			return self::error( 'social_cross_post_invalid_caption', 'The approved caption must be canonical text within every selected channel limit.' );
+		}
+
+		$content_hash = $input['content_hash'] ?? null;
+		if ( ! is_string( $content_hash ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $content_hash ) || ! hash_equals( hash( 'sha256', $caption ), $content_hash ) ) {
+			return self::error( 'social_cross_post_content_hash_mismatch', 'The approved content hash does not match the caption.' );
+		}
+
+		$media_kind = $input['media_kind'] ?? null;
+		if ( ! is_string( $media_kind ) || ! in_array( $media_kind, self::MEDIA_KINDS, true ) ) {
+			return self::error( 'social_cross_post_unsupported_media_kind', 'The requested media kind is not supported.' );
+		}
+
+		if ( in_array( $media_kind, array( 'reel', 'story' ), true ) && array_diff( $channels, array( 'instagram' ) ) ) {
+			return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support the requested media kind.' );
+		}
+		if ( 'carousel' === $media_kind && array_diff( $channels, array( 'instagram', 'twitter' ) ) ) {
+			return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support carousel publishing.' );
+		}
+
+		$assets = self::normalize_asset_refs( $input['asset_refs'] ?? null, $media_kind );
+		if ( is_wp_error( $assets ) ) {
+			return $assets;
+		}
+		if ( 'carousel' === $media_kind && in_array( 'twitter', $channels, true ) && count( $assets['images'] ) > 4 ) {
+			return self::error( 'social_cross_post_unsupported_channel_media', 'Twitter carousels support at most four image assets.' );
+		}
+
+		return array(
+			'post_id'       => $post_id,
+			'source_url'    => $source_url,
+			'caption'       => $caption,
+			'content_hash'  => $content_hash,
+			'channels'      => $channels,
+			'media_kind'    => $media_kind,
+			'asset_refs'    => $assets['refs'],
+			'images'        => $assets['images'],
+			'video_url'     => $assets['video_url'],
+			'cover_url'     => $assets['cover_url'],
+			'share_to_feed' => true,
+		);
+	}
+
+	/**
+	 * Require an explicit bounded authorization decision for every phase.
+	 *
+	 * @param array $context Data Machine operation context.
+	 * @return true|\WP_Error
+	 */
+	public static function authorize( array $context ) {
+		/**
+		 * Filter delegated cross-post authorization.
+		 *
+		 * This action is denied by default. A domain owner may authorize its exact
+		 * resource using the normalized input and actor supplied in the context.
+		 *
+		 * @param bool  $authorized Whether the operation is authorized.
+		 * @param array $context    Delegated operation context.
+		 */
+		$authorized = apply_filters( 'datamachine_socials_delegated_cross_post_authorized', false, $context );
+
+		return true === $authorized
+			? true
+			: self::error( 'social_cross_post_forbidden', 'The actor is not authorized for this cross-post operation.' );
+	}
+
+	/**
+	 * Compose the private workflow and stable Data Machine execution owner.
+	 *
+	 * @param array $input   Normalized owner input.
+	 * @param array $context Data Machine operation context.
+	 * @return array|\WP_Error
+	 */
+	public static function prepare( array $input, array $context ) {
+		$owner = function_exists( 'datamachine_resolve_system_agent_context' )
+			? datamachine_resolve_system_agent_context()
+			: array();
+
+		/**
+		 * Filter the trusted, stable execution owner registered for this action.
+		 *
+		 * @param array $owner   Data Machine user and agent identity.
+		 * @param array $input   Normalized owner input.
+		 * @param array $context Delegated operation context.
+		 */
+		$owner = apply_filters( 'datamachine_socials_delegated_cross_post_execution_owner', $owner, $input, $context );
+
+		if ( ! is_array( $owner ) || empty( $owner['user_id'] ) || empty( $owner['agent_id'] ) ) {
+			return self::error( 'social_cross_post_owner_unavailable', 'The stable Socials execution owner is unavailable.' );
+		}
+
+		$params = array(
+			'post_id'                 => $input['post_id'],
+			'platforms'               => $input['channels'],
+			'caption'                 => $input['caption'],
+			'images'                  => $input['images'],
+			'media_kind'              => $input['media_kind'],
+			'video_url'               => $input['video_url'],
+			'cover_url'               => $input['cover_url'],
+			'share_to_feed'           => true,
+			'source_url'              => $input['source_url'],
+			'delegated_operation_ref' => (string) ( $context['operation_ref'] ?? '' ),
+		);
+
+		return array(
+			'owner_user_id' => (int) $owner['user_id'],
+			'agent_id'      => (int) $owner['agent_id'],
+			'label'         => 'Delegated social cross-post',
+			'workflow'      => array(
+				'steps' => array(
+					array(
+						'step_type'          => 'system_task',
+						'flow_step_settings' => array(
+							'task_type' => 'social_cross_post',
+							'params'    => $params,
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Project canonical packet references onto the bounded public result.
+	 *
+	 * @param array $run_result Canonical datamachine.run_result.v1 envelope.
+	 * @param array $context    Data Machine operation context.
+	 * @return array
+	 */
+	public static function project( array $run_result, array $context = array() ): array {
+		unset( $context );
+
+		if ( empty( $run_result ) ) {
+			return array();
+		}
+		if ( in_array( $run_result['status'] ?? '', array( 'submitted', 'executing', 'retrying' ), true ) ) {
+			return array();
+		}
+
+		$share_refs  = array();
+		$error_codes = array();
+		foreach ( self::packet_refs( $run_result ) as $ref ) {
+			if ( self::RESULT_SOURCE !== ( $ref['source_type'] ?? '' ) ) {
+				continue;
+			}
+
+			$channel = self::bounded_channel( $ref['source_id'] ?? '' );
+			if ( '' === $channel ) {
+				continue;
+			}
+
+			if ( 'social_share_ref' === ( $ref['type'] ?? '' ) ) {
+				$share_refs[] = array(
+					'channel'          => $channel,
+					'platform_post_id' => sanitize_text_field( (string) ( $ref['source_item_id'] ?? '' ) ),
+				);
+			} elseif ( 'social_share_error' === ( $ref['type'] ?? '' ) ) {
+				$code = (string) ( $ref['source_item_id'] ?? '' );
+				if ( in_array( $code, array( 'channel_unavailable', 'publish_failed' ), true ) ) {
+					$error_codes[] = array(
+						'channel' => $channel,
+						'code'    => $code,
+					);
+				}
+			}
+		}
+
+		$effect_count   = count( $share_refs );
+		$classification = 'no_op';
+		if ( $effect_count > 0 && ! empty( $error_codes ) ) {
+			$classification = 'partial';
+		} elseif ( $effect_count > 0 ) {
+			$classification = 'success';
+		} elseif ( ! empty( $error_codes ) || self::run_failed( $run_result ) ) {
+			$classification = 'failure';
+		}
+
+		return array(
+			'effect_count'   => $effect_count,
+			'classification' => $classification,
+			'share_refs'     => $share_refs,
+			'error_codes'    => $error_codes,
+		);
+	}
+
+	/** Map private provider failures to bounded public codes. */
+	public static function classify_error( $error ): string {
+		return is_string( $error ) && str_contains( $error, 'not registered' ) ? 'channel_unavailable' : 'publish_failed';
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function packet_refs( array $run_result ): array {
+		if ( is_array( $run_result['packet_refs'] ?? null ) ) {
+			return array_values( array_filter( $run_result['packet_refs'], 'is_array' ) );
+		}
+
+		$refs = array();
+		foreach ( array( 'steps', 'step_results' ) as $steps_key ) {
+			foreach ( is_array( $run_result[ $steps_key ] ?? null ) ? $run_result[ $steps_key ] : array() as $step ) {
+				if ( is_array( $step['packet_refs'] ?? null ) ) {
+					$refs = array_merge( $refs, $step['packet_refs'] );
+				}
+			}
+		}
+
+		return array_values( array_filter( $refs, 'is_array' ) );
+	}
+
+	private static function run_failed( array $run_result ): bool {
+		$status = strtolower( (string) ( $run_result['status'] ?? '' ) );
+		return 'failed' === $status || str_starts_with( $status, 'failed' );
+	}
+
+	/**
+	 * @param mixed $channels Raw channels.
+	 * @return array|\WP_Error
+	 */
+	private static function normalize_channels( $channels ) {
+		if ( ! is_array( $channels ) || ! array_is_list( $channels ) || count( $channels ) > count( self::CHANNELS ) ) {
+			return self::error( 'social_cross_post_invalid_channels', 'Channels must be a bounded list.' );
+		}
+
+		$normalized = array();
+		foreach ( $channels as $channel ) {
+			if ( ! is_string( $channel ) || ! in_array( $channel, self::CHANNELS, true ) ) {
+				return self::error( 'social_cross_post_unsupported_channel', 'A requested channel is not supported.' );
+			}
+			if ( in_array( $channel, $normalized, true ) ) {
+				return self::error( 'social_cross_post_invalid_channels', 'Duplicate channels are not allowed.' );
+			}
+			$normalized[] = $channel;
+		}
+
+		sort( $normalized );
+		return $normalized;
+	}
+
+	/**
+	 * @param string[] $channels Normalized channels.
+	 */
+	private static function caption_limit( array $channels, string $source_url ): int {
+		$limits = array(
+			'bluesky'   => 300,
+			'facebook'  => 63206,
+			'instagram' => 2200,
+			'pinterest' => 500,
+			'threads'   => max( 1, 498 - mb_strlen( $source_url ) ),
+			'twitter'   => 256,
+		);
+
+		return empty( $channels ) ? 2200 : min( array_intersect_key( $limits, array_flip( $channels ) ) );
+	}
+
+	/**
+	 * @param mixed  $asset_refs Raw attachment references.
+	 * @param string $media_kind Requested media kind.
+	 * @return array|\WP_Error
+	 */
+	private static function normalize_asset_refs( $asset_refs, string $media_kind ) {
+		if ( ! is_array( $asset_refs ) || ! array_is_list( $asset_refs ) || count( $asset_refs ) > 11 ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Asset references must be a bounded list.' );
+		}
+
+		$refs        = array();
+		$images      = array();
+		$video_url   = '';
+		$cover_url   = '';
+		$seen_ids    = array();
+		$valid_roles = array( 'image', 'video', 'cover' );
+
+		foreach ( $asset_refs as $ref ) {
+			if ( ! is_array( $ref ) || array_diff( array_keys( $ref ), array( 'attachment_id', 'role' ) ) || ! isset( $ref['attachment_id'], $ref['role'] ) ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'Each asset reference requires only an attachment ID and role.' );
+			}
+
+			$attachment_id = self::strict_positive_int( $ref['attachment_id'] );
+			$role          = $ref['role'];
+			if ( ! $attachment_id || ! is_string( $role ) || ! in_array( $role, $valid_roles, true ) || in_array( $attachment_id, $seen_ids, true ) || 'attachment' !== get_post_type( $attachment_id ) ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'An asset reference is malformed or duplicated.' );
+			}
+
+			$url  = wp_get_attachment_url( $attachment_id );
+			$mime = (string) get_post_mime_type( $attachment_id );
+			if ( ! is_string( $url ) || ! self::is_public_url( $url ) ) {
+				return self::error( 'social_cross_post_asset_not_public', 'Every asset must resolve to a public URL.' );
+			}
+			if ( ( 'video' === $role && ! str_starts_with( $mime, 'video/' ) ) || ( 'video' !== $role && ! str_starts_with( $mime, 'image/' ) ) ) {
+				return self::error( 'social_cross_post_invalid_asset_kind', 'An asset MIME type does not match its role.' );
+			}
+
+			if ( 'video' === $role ) {
+				if ( '' !== $video_url ) {
+					return self::error( 'social_cross_post_invalid_asset_refs', 'Only one video asset is supported.' );
+				}
+				$video_url = $url;
+			} elseif ( 'cover' === $role ) {
+				if ( '' !== $cover_url ) {
+					return self::error( 'social_cross_post_invalid_asset_refs', 'Only one cover asset is supported.' );
+				}
+				$cover_url = $url;
+			} else {
+				$images[] = array( 'url' => $url );
+			}
+
+			$refs[]     = array(
+				'attachment_id' => $attachment_id,
+				'role'          => $role,
+			);
+			$seen_ids[] = $attachment_id;
+		}
+
+		$image_count = count( $images );
+		if ( 'image' === $media_kind && 1 !== $image_count ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Image publishing requires exactly one image asset.' );
+		}
+		if ( 'carousel' === $media_kind && ( $image_count < 2 || $image_count > 10 ) ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Carousel publishing requires between two and ten image assets.' );
+		}
+		if ( 'reel' === $media_kind && '' === $video_url ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Reel publishing requires one video asset.' );
+		}
+		if ( 'story' === $media_kind && '' === $video_url && 1 !== $image_count ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Story publishing requires one image or video asset.' );
+		}
+		if ( ! in_array( $media_kind, array( 'reel', 'story' ), true ) && ( '' !== $video_url || '' !== $cover_url ) ) {
+			return self::error( 'social_cross_post_invalid_asset_refs', 'Video and cover assets are not valid for this media kind.' );
+		}
+
+		return compact( 'refs', 'images', 'video_url', 'cover_url' );
+	}
+
+	private static function bounded_channel( $channel ): string {
+		return is_string( $channel ) && in_array( $channel, self::CHANNELS, true ) ? $channel : '';
+	}
+
+	private static function strict_positive_int( $value ): int {
+		return is_int( $value ) && $value > 0 ? $value : 0;
+	}
+
+	private static function is_public_url( string $url ): bool {
+		$parts = wp_parse_url( $url );
+		return is_array( $parts ) && in_array( $parts['scheme'] ?? '', array( 'http', 'https' ), true ) && ! empty( $parts['host'] ) && empty( $parts['user'] ) && empty( $parts['pass'] );
+	}
+
+	private static function error( string $code, string $message ): \WP_Error {
+		return new \WP_Error( $code, $message );
+	}
+}

--- a/inc/Operations/DelegatedCrossPostAction.php
+++ b/inc/Operations/DelegatedCrossPostAction.php
@@ -250,7 +250,7 @@ final class DelegatedCrossPostAction {
 				);
 			} elseif ( 'social_share_error' === ( $ref['type'] ?? '' ) ) {
 				$code = (string) ( $ref['source_item_id'] ?? '' );
-				if ( in_array( $code, array( 'channel_unavailable', 'publish_failed' ), true ) ) {
+				if ( in_array( $code, array( 'channel_unavailable', 'publish_failed', 'delivery_receipt_failed' ), true ) ) {
 					$error_codes[] = array(
 						'channel' => $channel,
 						'code'    => $code,
@@ -279,6 +279,10 @@ final class DelegatedCrossPostAction {
 
 	/** Map private provider failures to bounded public codes. */
 	public static function classify_error( $error ): string {
+		if ( 'delivery_receipt_failed' === $error ) {
+			return 'delivery_receipt_failed';
+		}
+
 		return is_string( $error ) && str_contains( $error, 'not registered' ) ? 'channel_unavailable' : 'publish_failed';
 	}
 

--- a/inc/Publisher.php
+++ b/inc/Publisher.php
@@ -114,15 +114,9 @@ class Publisher {
 					'replayed'         => true,
 				)
 				: self::post_to_platform( $platform, $images, $caption, $source_url, $extra );
-			$results[]      = $result;
-
-			if ( ! $result['success'] ) {
-				$errors[] = $platform . ': ' . $result['error'];
-			}
-
 			// Track successful shares via SocialShareTracker when post_id is available.
 			if ( $post_id && ! $existing_share && ! empty( $result['success'] ) ) {
-				SocialShareTracker::record_from_result(
+				$recorded = SocialShareTracker::record_from_result(
 					$post_id,
 					$platform,
 					$result,
@@ -131,6 +125,18 @@ class Publisher {
 						'operation_ref' => $operation_ref,
 					)
 				);
+				if ( '' !== $operation_ref && ! $recorded ) {
+					$result = array(
+						'platform' => $platform,
+						'success'  => false,
+						'error'    => 'delivery_receipt_failed',
+					);
+				}
+			}
+
+			$results[] = $result;
+			if ( ! $result['success'] ) {
+				$errors[] = $platform . ': ' . $result['error'];
 			}
 		}
 

--- a/inc/Publisher.php
+++ b/inc/Publisher.php
@@ -51,6 +51,7 @@ class Publisher {
 		$video_url     = sanitize_url( $params['video_url'] ?? '' );
 		$cover_url     = sanitize_url( $params['cover_url'] ?? '' );
 		$share_to_feed = $params['share_to_feed'] ?? true;
+		$operation_ref = sanitize_text_field( $params['delegated_operation_ref'] ?? '' );
 
 		if ( empty( $platforms ) || ! is_array( $platforms ) ) {
 			return array(
@@ -84,7 +85,10 @@ class Publisher {
 			);
 		}
 
-		$source_url = $post_id ? get_permalink( $post_id ) : '';
+		$source_url = sanitize_url( $params['source_url'] ?? '' );
+		if ( '' === $source_url && $post_id ) {
+			$source_url = get_permalink( $post_id );
+		}
 
 		$extra = array(
 			'media_kind'    => $media_kind,
@@ -97,20 +101,35 @@ class Publisher {
 		$errors  = array();
 
 		foreach ( $platforms as $platform ) {
-			$result    = self::post_to_platform( $platform, $images, $caption, $source_url, $extra );
-			$results[] = $result;
+			$existing_share = $post_id && '' !== $operation_ref
+				? SocialShareTracker::get_operation_share( $post_id, $platform, $operation_ref )
+				: null;
+			$result         = $existing_share
+				? array(
+					'platform'         => $platform,
+					'success'          => true,
+					'platform_post_id' => (string) ( $existing_share['platform_post_id'] ?? '' ),
+					'platform_url'     => (string) ( $existing_share['platform_url'] ?? '' ),
+					'media_kind'       => (string) ( $existing_share['media_kind'] ?? '' ),
+					'replayed'         => true,
+				)
+				: self::post_to_platform( $platform, $images, $caption, $source_url, $extra );
+			$results[]      = $result;
 
 			if ( ! $result['success'] ) {
 				$errors[] = $platform . ': ' . $result['error'];
 			}
 
 			// Track successful shares via SocialShareTracker when post_id is available.
-			if ( $post_id && ! empty( $result['success'] ) ) {
+			if ( $post_id && ! $existing_share && ! empty( $result['success'] ) ) {
 				SocialShareTracker::record_from_result(
 					$post_id,
 					$platform,
 					$result,
-					array( 'media_kind' => $media_kind )
+					array(
+						'media_kind'    => $media_kind,
+						'operation_ref' => $operation_ref,
+					)
 				);
 			}
 		}
@@ -118,7 +137,7 @@ class Publisher {
 		return array(
 			'success' => empty( $errors ),
 			'results' => $results,
-			'errors'  => $errors ?: null,
+			'errors'  => $errors ? $errors : null,
 		);
 	}
 
@@ -154,9 +173,20 @@ class Publisher {
 
 		$input = array(
 			'content'    => $caption,
-			'image_urls' => $image_urls,
 			'source_url' => $source_url,
 		);
+		if ( in_array( $platform, array( 'instagram', 'twitter' ), true ) ) {
+			$input['image_urls'] = $image_urls;
+		} elseif ( in_array( $platform, array( 'bluesky', 'facebook', 'threads' ), true ) ) {
+			$input['image_url'] = $image_urls[0] ?? '';
+		} elseif ( 'pinterest' === $platform ) {
+			$input = array(
+				'title'       => mb_substr( wp_strip_all_tags( $caption ), 0, 100 ),
+				'description' => $caption,
+				'image_url'   => $image_urls[0] ?? '',
+				'link'        => $source_url,
+			);
+		}
 
 		$media_kind = $extra['media_kind'] ?? 'image';
 		if ( 'reel' === $media_kind ) {

--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -104,16 +104,19 @@ class SocialCrossPostTask extends SystemTask {
 		);
 
 		if ( '' !== $operation_ref ) {
-			$completion_data['output_data_packets']    = self::delegated_result_packets( $results, ! empty( $successes ) );
+			$completion_data['output_data_packets']    = self::delegated_result_packets( $results );
 			$completion_data['suppress_result_packet'] = true;
 		}
 
+		if ( '' !== $operation_ref && ! empty( $errors ) ) {
+			$completion_data['job_status'] = empty( $successes )
+				? 'failed - delegated_cross_post_failed'
+				: 'failed - delegated_cross_post_partial';
+			$this->completeJob( $jobId, $completion_data );
+			return;
+		}
+
 		if ( empty( $successes ) ) {
-			if ( '' !== $operation_ref ) {
-				$completion_data['job_status'] = 'failed - delegated_cross_post_failed';
-				$this->completeJob( $jobId, $completion_data );
-				return;
-			}
 			$this->failJob( $jobId, 'All platforms failed: ' . implode( '; ', $errors ) );
 			return;
 		}
@@ -124,11 +127,10 @@ class SocialCrossPostTask extends SystemTask {
 	/**
 	 * Build safe canonical packet references for delegated projection.
 	 *
-	 * @param array $results       Publisher results.
-	 * @param bool  $has_successes Whether at least one platform published.
+	 * @param array $results Publisher results.
 	 * @return array
 	 */
-	private static function delegated_result_packets( array $results, bool $has_successes ): array {
+	private static function delegated_result_packets( array $results ): array {
 		$packets = array();
 		foreach ( $results as $result ) {
 			$platform = sanitize_key( (string) ( $result['platform'] ?? '' ) );
@@ -149,7 +151,7 @@ class SocialCrossPostTask extends SystemTask {
 					'source_type'    => 'datamachine_socials_cross_post',
 					'source_id'      => $platform,
 					'source_item_id' => $item_ref,
-					'success'        => $success || $has_successes,
+					'success'        => $success,
 				),
 			);
 		}

--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -14,6 +14,7 @@
 namespace DataMachineSocials\Tasks;
 
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachineSocials\Operations\DelegatedCrossPostAction;
 use DataMachineSocials\Publisher;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,16 +28,28 @@ class SocialCrossPostTask extends SystemTask {
 	 * @param array $params Task parameters from engine_data.
 	 */
 	public function executeTask( int $jobId, array $params ): void {
-		$post_id      = absint( $params['post_id'] ?? 0 );
-		$platforms    = $params['platforms'] ?? array();
-		$caption      = $params['caption'] ?? '';
-		$images       = $params['images'] ?? array();
-		$media_kind   = $params['media_kind'] ?? 'image';
-		$aspect_ratio = $params['aspect_ratio'] ?? '4:5';
-		$video_url    = $params['video_url'] ?? '';
-		$cover_url    = $params['cover_url'] ?? '';
+		$post_id       = absint( $params['post_id'] ?? 0 );
+		$platforms     = $params['platforms'] ?? array();
+		$caption       = $params['caption'] ?? '';
+		$images        = $params['images'] ?? array();
+		$media_kind    = $params['media_kind'] ?? 'image';
+		$aspect_ratio  = $params['aspect_ratio'] ?? '4:5';
+		$video_url     = $params['video_url'] ?? '';
+		$cover_url     = $params['cover_url'] ?? '';
+		$operation_ref = $params['delegated_operation_ref'] ?? '';
 
 		if ( empty( $platforms ) || ! is_array( $platforms ) ) {
+			if ( '' !== $operation_ref ) {
+				$this->completeJob(
+					$jobId,
+					array(
+						'job_status'             => 'completed_no_items',
+						'skipped'                => true,
+						'suppress_result_packet' => true,
+					)
+				);
+				return;
+			}
 			$this->failJob( $jobId, 'No platforms specified' );
 			return;
 		}
@@ -55,8 +68,8 @@ class SocialCrossPostTask extends SystemTask {
 			return;
 		}
 
-		$results  = $publish_result['results'] ?? array();
-		$errors   = $publish_result['errors'] ?? array();
+		$results   = $publish_result['results'] ?? array();
+		$errors    = $publish_result['errors'] ?? array();
 		$successes = array_filter( $results, fn( $r ) => ! empty( $r['success'] ) );
 
 		// Build normalized log entries.
@@ -74,14 +87,15 @@ class SocialCrossPostTask extends SystemTask {
 
 		// Store results in post meta when post_id is available.
 		if ( $post_id ) {
-			$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true ) ?: array();
+			$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true );
+			$existing_log = $existing_log ? $existing_log : array();
 			$merged_log   = array_merge( $existing_log, $log );
 			update_post_meta( $post_id, '_studio_social_publish_log', $merged_log );
 		}
 
 		// Write full results to job engine_data.
 		$completion_data = array(
-			'post_id'       => $post_id ?: null,
+			'post_id'       => $post_id ? $post_id : null,
 			'platforms'     => $platforms,
 			'results'       => $results,
 			'log'           => $log,
@@ -89,12 +103,58 @@ class SocialCrossPostTask extends SystemTask {
 			'failure_count' => count( $errors ),
 		);
 
+		if ( '' !== $operation_ref ) {
+			$completion_data['output_data_packets']    = self::delegated_result_packets( $results, ! empty( $successes ) );
+			$completion_data['suppress_result_packet'] = true;
+		}
+
 		if ( empty( $successes ) ) {
+			if ( '' !== $operation_ref ) {
+				$completion_data['job_status'] = 'failed - delegated_cross_post_failed';
+				$this->completeJob( $jobId, $completion_data );
+				return;
+			}
 			$this->failJob( $jobId, 'All platforms failed: ' . implode( '; ', $errors ) );
 			return;
 		}
 
 		$this->completeJob( $jobId, $completion_data );
+	}
+
+	/**
+	 * Build safe canonical packet references for delegated projection.
+	 *
+	 * @param array $results       Publisher results.
+	 * @param bool  $has_successes Whether at least one platform published.
+	 * @return array
+	 */
+	private static function delegated_result_packets( array $results, bool $has_successes ): array {
+		$packets = array();
+		foreach ( $results as $result ) {
+			$platform = sanitize_key( (string) ( $result['platform'] ?? '' ) );
+			if ( '' === $platform ) {
+				continue;
+			}
+
+			$success = ! empty( $result['success'] );
+
+			$item_ref = $success
+				? sanitize_text_field( (string) ( $result['platform_post_id'] ?? '' ) )
+				: DelegatedCrossPostAction::classify_error( $result['error'] ?? '' );
+
+			$packets[] = array(
+				'type'     => $success ? 'social_share_ref' : 'social_share_error',
+				'data'     => array(),
+				'metadata' => array(
+					'source_type'    => 'datamachine_socials_cross_post',
+					'source_id'      => $platform,
+					'source_item_id' => $item_ref,
+					'success'        => $success || $has_successes,
+				),
+			);
+		}
+
+		return $packets;
 	}
 
 	/**

--- a/inc/Tracking/SocialShareTracker.php
+++ b/inc/Tracking/SocialShareTracker.php
@@ -51,15 +51,18 @@ class SocialShareTracker {
 			'platform'         => sanitize_key( $platform ),
 			'platform_post_id' => sanitize_text_field( $platform_post_id ),
 			'platform_url'     => esc_url_raw( $platform_url ),
+			'operation_hash'   => ! empty( $extra['operation_ref'] ) ? hash( 'sha256', (string) $extra['operation_ref'] ) : '',
 			'shared_at'        => time(),
 			'shared_by'        => $extra['shared_by'] ?? get_current_user_id(),
 			'media_kind'       => sanitize_key( $extra['media_kind'] ?? '' ),
-			'job_id'           => intval( $extra['job_id'] ?? 0 ) ?: null,
+			'job_id'           => ! empty( $extra['job_id'] ) ? intval( $extra['job_id'] ) : null,
 		);
 
 		$shares[] = $record;
 
-		update_post_meta( $post_id, self::SHARES_META_KEY, $shares );
+		if ( false === update_post_meta( $post_id, self::SHARES_META_KEY, $shares ) ) {
+			return false;
+		}
 		self::update_platforms_index( $post_id, $shares );
 
 		return true;
@@ -156,6 +159,29 @@ class SocialShareTracker {
 		usort( $shares, fn( $a, $b ) => ( $b['shared_at'] ?? 0 ) <=> ( $a['shared_at'] ?? 0 ) );
 
 		return $shares[0];
+	}
+
+	/**
+	 * Get a share already recorded for one delegated operation and platform.
+	 *
+	 * @param int    $post_id      WordPress post ID.
+	 * @param string $platform     Platform slug.
+	 * @param string $operation_ref Opaque delegated operation reference.
+	 * @return array|null
+	 */
+	public static function get_operation_share( int $post_id, string $platform, string $operation_ref ): ?array {
+		if ( ! preg_match( '/^dop_[a-f0-9]{64}$/', $operation_ref ) ) {
+			return null;
+		}
+		$operation_hash = hash( 'sha256', $operation_ref );
+
+		foreach ( array_reverse( self::get_shares( $post_id, $platform ) ) as $share ) {
+			if ( 'deleted' !== ( $share['status'] ?? 'published' ) && hash_equals( $operation_hash, (string) ( $share['operation_hash'] ?? '' ) ) ) {
+				return $share;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -286,8 +312,8 @@ class SocialShareTracker {
 			return false;
 		}
 
-		$platform_post_id = self::extract_platform_post_id( $platform, $result );
-		$platform_url     = self::extract_platform_url( $platform, $result );
+		$platform_post_id = (string) ( $result['platform_post_id'] ?? self::extract_platform_post_id( $platform, $result ) );
+		$platform_url     = (string) ( $result['platform_url'] ?? self::extract_platform_url( $platform, $result ) );
 
 		// Merge media_kind from result if present.
 		if ( ! empty( $result['media_kind'] ) && empty( $extra['media_kind'] ) ) {

--- a/tests/Unit/PublisherTest.php
+++ b/tests/Unit/PublisherTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Publisher replay tests.
+ *
+ * @package DataMachineSocials\Tests\Unit
+ */
+
+use DataMachineSocials\Publisher;
+use DataMachineSocials\Tracking\SocialShareTracker;
+
+final class PublisherTest extends WP_UnitTestCase {
+
+	public function test_delegated_operation_reuses_authoritative_share_receipt(): void {
+		$post_id       = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$operation_ref = 'dop_' . str_repeat( 'b', 64 );
+		SocialShareTracker::record(
+			$post_id,
+			'instagram',
+			'ig-existing',
+			'https://instagram.test/ig-existing',
+			array(
+				'media_kind'    => 'image',
+				'operation_ref' => $operation_ref,
+			)
+		);
+
+		$result = Publisher::cross_post(
+			array(
+				'post_id'                 => $post_id,
+				'platforms'               => array( 'instagram' ),
+				'caption'                 => 'Approved caption.',
+				'images'                  => array( array( 'url' => 'https://example.test/image.jpg' ) ),
+				'delegated_operation_ref' => $operation_ref,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['results'][0]['replayed'] );
+		$this->assertSame( 'ig-existing', $result['results'][0]['platform_post_id'] );
+		$this->assertSame( 1, SocialShareTracker::count_shares( $post_id, 'instagram' ) );
+	}
+}

--- a/tests/Unit/Tracking/SocialShareTrackerTest.php
+++ b/tests/Unit/Tracking/SocialShareTrackerTest.php
@@ -212,6 +212,30 @@ class SocialShareTrackerTest extends WP_UnitTestCase {
 		$this->assertFalse( SocialShareTracker::record( $this->post_id, '', 'id1' ) );
 	}
 
+	public function test_get_operation_share_returns_only_matching_durable_receipt(): void {
+		$operation_ref = 'dop_' . str_repeat( 'a', 64 );
+		SocialShareTracker::record_from_result(
+			$this->post_id,
+			'instagram',
+			array(
+				'success'          => true,
+				'platform_post_id' => 'ig1',
+				'platform_url'     => 'https://instagram.test/ig1',
+			),
+			array( 'operation_ref' => $operation_ref )
+		);
+		SocialShareTracker::record( $this->post_id, 'instagram', 'ig2', 'https://instagram.test/ig2' );
+
+		$share = SocialShareTracker::get_operation_share( $this->post_id, 'instagram', $operation_ref );
+
+		$this->assertIsArray( $share );
+		$this->assertSame( 'ig1', $share['platform_post_id'] );
+		$this->assertArrayNotHasKey( 'operation_ref', $share );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $share['operation_hash'] );
+		$this->assertNull( SocialShareTracker::get_operation_share( $this->post_id, 'instagram', 'invalid' ) );
+		$this->assertNull( SocialShareTracker::get_operation_share( $this->post_id, 'twitter', $operation_ref ) );
+	}
+
 	public function test_multiple_platforms_same_post(): void {
 		SocialShareTracker::record( $this->post_id, 'instagram', 'ig1', 'https://ig.com/1' );
 		SocialShareTracker::record( $this->post_id, 'twitter', 'tw1', 'https://x.com/1' );

--- a/tests/delegated-cross-post-action-smoke.php
+++ b/tests/delegated-cross-post-action-smoke.php
@@ -170,7 +170,7 @@ namespace {
 	DelegatedCrossPostAction::register();
 	$actions = apply_filters( 'datamachine_delegated_operation_actions', array() );
 	$action  = $actions[ DelegatedCrossPostAction::ACTION_ID ] ?? array();
-	$assert( array( 'version', 'normalize_input', 'authorize', 'prepare', 'project' ) === array_keys( $action ), 'registers the exact Data Machine owner callback contract without retry' );
+	$assert( array( 'version', 'normalize_input', 'authorize', 'prepare', 'project' ) === array_keys( $action ), 'registers the exact Data Machine owner callback contract without unsafe retry' );
 	$assert( is_callable( $action['normalize_input'] ?? null ) && is_callable( $action['authorize'] ?? null ) && is_callable( $action['prepare'] ?? null ) && is_callable( $action['project'] ?? null ), 'all required owner callbacks are callable' );
 
 	$normalized = $action['normalize_input']( $input, array( 'phase' => 'submit' ) );
@@ -225,8 +225,8 @@ namespace {
 		)
 	);
 	$packets = $GLOBALS['delegated_cross_post_jobs'][50]['output_data_packets'] ?? array();
-	$assert( 'completed' === ( $GLOBALS['delegated_cross_post_jobs'][50]['_status'] ?? null ) && 2 === count( $packets ), 'partial delivery completes with canonical result packets' );
-	$assert( true === $packets[1]['metadata']['success'], 'partial provider failure remains a successful owner step with bounded error projection' );
+	$assert( 'completed' === ( $GLOBALS['delegated_cross_post_jobs'][50]['_status'] ?? null ) && 2 === count( $packets ), 'partial delivery completes its child task with canonical result packets' );
+	$assert( 'failed - delegated_cross_post_partial' === ( $GLOBALS['delegated_cross_post_jobs'][50]['job_status'] ?? null ) && false === $packets[1]['metadata']['success'], 'partial provider failure terminates the delegated run for explicit retry' );
 
 	$packet_refs = array_map(
 		static fn( array $packet ): array => array(

--- a/tests/delegated-cross-post-action-smoke.php
+++ b/tests/delegated-cross-post-action-smoke.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Smoke tests for the bounded delegated cross-post owner contract.
+ *
+ * Run with: php tests/delegated-cross-post-action-smoke.php
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	$GLOBALS['delegated_cross_post_filters'] = array();
+	$GLOBALS['delegated_cross_post_jobs']    = array();
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function add_filter( string $hook, callable $callback ): void {
+		$GLOBALS['delegated_cross_post_filters'][ $hook ][] = $callback;
+	}
+
+	function apply_filters( string $hook, $value, ...$args ) {
+		foreach ( $GLOBALS['delegated_cross_post_filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+		return $value;
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function get_post_status( int $post_id ): string|false {
+		return 42 === $post_id ? 'publish' : false;
+	}
+
+	function get_permalink( int $post_id ): string|false {
+		return 42 === $post_id ? 'https://example.test/canonical-post/' : false;
+	}
+
+	function get_post_type( int $post_id ): string|false {
+		return isset( $GLOBALS['delegated_cross_post_assets'][ $post_id ] ) ? 'attachment' : false;
+	}
+
+	function get_post_mime_type( int $post_id ): string|false {
+		return $GLOBALS['delegated_cross_post_assets'][ $post_id ]['mime'] ?? false;
+	}
+
+	function wp_get_attachment_url( int $post_id ): string|false {
+		return $GLOBALS['delegated_cross_post_assets'][ $post_id ]['url'] ?? false;
+	}
+
+	function wp_parse_url( string $url ) {
+		return parse_url( $url );
+	}
+
+	function sanitize_text_field( string $value ): string {
+		return trim( strip_tags( $value ) );
+	}
+
+	function sanitize_textarea_field( string $value ): string {
+		return trim( strip_tags( $value ) );
+	}
+
+	function sanitize_key( string $value ): string {
+		return preg_replace( '/[^a-z0-9_-]/', '', strtolower( $value ) );
+	}
+
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function get_post_meta( int $post_id, string $key, bool $single = false ) {
+		unset( $post_id, $key, $single );
+		return array();
+	}
+
+	function update_post_meta( int $post_id, string $key, $value ): bool {
+		unset( $post_id, $key, $value );
+		return true;
+	}
+
+	function datamachine_resolve_system_agent_context(): array {
+		return array( 'user_id' => 7, 'agent_id' => 9, 'triggering_user_id' => 0 );
+	}
+
+	function datamachine_merge_engine_data( int $job_id, array $data ): void {
+		$GLOBALS['delegated_cross_post_jobs'][ $job_id ] = array_merge( $GLOBALS['delegated_cross_post_jobs'][ $job_id ] ?? array(), $data );
+	}
+
+	$GLOBALS['delegated_cross_post_assets'] = array(
+		101 => array( 'url' => 'https://example.test/uploads/image-one.jpg', 'mime' => 'image/jpeg' ),
+		102 => array( 'url' => 'https://example.test/uploads/image-two.jpg', 'mime' => 'image/jpeg' ),
+		103 => array( 'url' => 'https://example.test/uploads/video.mp4', 'mime' => 'video/mp4' ),
+	);
+}
+
+namespace DataMachine\Engine\AI\System\Tasks {
+	abstract class SystemTask {
+		abstract public function executeTask( int $jobId, array $params ): void;
+		abstract public function getTaskType(): string;
+
+		protected function completeJob( int $job_id, array $data ): void {
+			$GLOBALS['delegated_cross_post_jobs'][ $job_id ] = array_merge( $GLOBALS['delegated_cross_post_jobs'][ $job_id ] ?? array(), $data, array( '_status' => 'completed' ) );
+		}
+
+		protected function failJob( int $job_id, string $message ): void {
+			$GLOBALS['delegated_cross_post_jobs'][ $job_id ] = array_merge( $GLOBALS['delegated_cross_post_jobs'][ $job_id ] ?? array(), array( '_status' => 'failed', '_error' => $message ) );
+		}
+	}
+}
+
+namespace DataMachineSocials {
+	class Publisher {
+		public static function cross_post( array $params ): array {
+			$results = array();
+			foreach ( $params['platforms'] as $platform ) {
+				$success   = 'twitter' !== $platform;
+				$results[] = $success
+					? array( 'platform' => $platform, 'success' => true, 'platform_post_id' => $platform . '-123' )
+					: array( 'platform' => $platform, 'success' => false, 'error' => 'private provider token diagnostic' );
+			}
+
+			return array(
+				'success' => false,
+				'results' => $results,
+				'errors'  => array( 'private provider token diagnostic' ),
+			);
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Operations/DelegatedCrossPostAction.php';
+	require_once dirname( __DIR__ ) . '/inc/Tasks/SocialCrossPostTask.php';
+
+	use DataMachineSocials\Operations\DelegatedCrossPostAction;
+	use DataMachineSocials\Tasks\SocialCrossPostTask;
+
+	$failures = array();
+	$passes   = 0;
+	$assert   = static function ( bool $condition, string $message ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			return;
+		}
+		$failures[] = $message;
+	};
+
+	$input = array(
+		'post_id'      => 42,
+		'source_url'   => 'https://example.test/canonical-post/',
+		'caption'      => 'Approved canonical copy.',
+		'content_hash' => hash( 'sha256', 'Approved canonical copy.' ),
+		'channels'     => array( 'twitter', 'instagram' ),
+		'media_kind'   => 'image',
+		'asset_refs'   => array( array( 'attachment_id' => 101, 'role' => 'image' ) ),
+	);
+
+	echo "delegated-cross-post-action-smoke\n\n";
+
+	DelegatedCrossPostAction::register();
+	$actions = apply_filters( 'datamachine_delegated_operation_actions', array() );
+	$action  = $actions[ DelegatedCrossPostAction::ACTION_ID ] ?? array();
+	$assert( array( 'version', 'normalize_input', 'authorize', 'prepare', 'project' ) === array_keys( $action ), 'registers the exact Data Machine owner callback contract without retry' );
+	$assert( is_callable( $action['normalize_input'] ?? null ) && is_callable( $action['authorize'] ?? null ) && is_callable( $action['prepare'] ?? null ) && is_callable( $action['project'] ?? null ), 'all required owner callbacks are callable' );
+
+	$normalized = $action['normalize_input']( $input, array( 'phase' => 'submit' ) );
+	$assert( ! is_wp_error( $normalized ), 'valid canonical input normalizes' );
+	$assert( array( 'instagram', 'twitter' ) === ( $normalized['channels'] ?? null ), 'channels normalize deterministically' );
+	$assert( array( array( 'url' => 'https://example.test/uploads/image-one.jpg' ) ) === ( $normalized['images'] ?? null ), 'registered attachment resolves to public publisher input' );
+
+	$denied = $action['authorize']( array( 'phase' => 'submit', 'input' => $normalized, 'actor' => array( 'user_id' => 11 ) ) );
+	$assert( is_wp_error( $denied ) && 'social_cross_post_forbidden' === $denied->get_error_code(), 'owner action denies every actor by default' );
+	add_filter( 'datamachine_socials_delegated_cross_post_authorized', static fn( bool $allowed, array $context ): bool => in_array( (int) ( $context['actor']['user_id'] ?? 0 ), array( 11, 12 ), true ) );
+	$assert( true === $action['authorize']( array( 'phase' => 'reconcile', 'input' => $normalized, 'actor' => array( 'user_id' => 11 ) ) ), 'owner authorization applies to reconciliation phases' );
+	$assert( true === $action['authorize']( array( 'phase' => 'submit', 'input' => $normalized, 'actor' => array( 'user_id' => 12 ) ) ), 'a second authorized actor receives the same bounded action' );
+	$assert( is_wp_error( $action['authorize']( array( 'phase' => 'submit', 'input' => $normalized, 'actor' => array( 'user_id' => 13 ) ) ) ), 'authorization grants no unrelated actor authority' );
+	$second_normalized = $action['normalize_input']( $input, array( 'phase' => 'submit', 'actor' => array( 'user_id' => 12 ) ) );
+	$assert( $normalized === $second_normalized, 'normalized fingerprint input is actor-neutral' );
+
+	$prepared = $action['prepare']( $normalized, array( 'operation_ref' => 'dop_' . str_repeat( 'a', 64 ) ) );
+	$second_prepared = $action['prepare']( $second_normalized, array( 'operation_ref' => 'dop_' . str_repeat( 'a', 64 ), 'actor' => array( 'user_id' => 12 ) ) );
+	$settings = $prepared['workflow']['steps'][0]['flow_step_settings'] ?? array();
+	$assert( 7 === ( $prepared['owner_user_id'] ?? null ) && 9 === ( $prepared['agent_id'] ?? null ), 'prepare binds a stable owner and registered agent' );
+	$assert( 'system_task' === ( $prepared['workflow']['steps'][0]['step_type'] ?? null ) && 'social_cross_post' === ( $settings['task_type'] ?? null ), 'prepare composes the canonical system-task workflow' );
+	$assert( 'dop_' . str_repeat( 'a', 64 ) === ( $settings['params']['delegated_operation_ref'] ?? null ), 'opaque operation identity reaches the idempotent owner task' );
+	$assert( $prepared === $second_prepared, 'two authorized actors compose one frozen owner workflow' );
+	$encoded_prepare = json_encode( $prepared );
+	$assert( ! str_contains( $encoded_prepare, 'TaskScheduler' ) && ! str_contains( $encoded_prepare, 'execute-workflow' ), 'owner workflow exposes no scheduler or arbitrary ability launch' );
+
+	$bad_hash                 = $input;
+	$bad_hash['content_hash'] = str_repeat( '0', 64 );
+	$hash_error               = $action['normalize_input']( $bad_hash, array() );
+	$assert( is_wp_error( $hash_error ) && 'social_cross_post_content_hash_mismatch' === $hash_error->get_error_code(), 'caption approval hash is enforced before enqueue' );
+	$uncanonical_caption                 = $input;
+	$uncanonical_caption['caption']      = '<strong>Approved canonical copy.</strong>';
+	$uncanonical_caption['content_hash'] = hash( 'sha256', $uncanonical_caption['caption'] );
+	$assert( is_wp_error( $action['normalize_input']( $uncanonical_caption, array() ) ), 'caption must already match the exact canonical text Publisher will receive' );
+
+	$unsupported             = $input;
+	$unsupported['channels'] = array( 'unknown-network' );
+	$channel_error           = $action['normalize_input']( $unsupported, array() );
+	$assert( is_wp_error( $channel_error ) && 'social_cross_post_unsupported_channel' === $channel_error->get_error_code(), 'unsupported channels fail before enqueue' );
+
+	$raw_asset                         = $input;
+	$raw_asset['asset_refs'][0]['url'] = 'https://attacker.example/image.jpg';
+	$asset_error                       = $action['normalize_input']( $raw_asset, array() );
+	$assert( is_wp_error( $asset_error ) && 'social_cross_post_invalid_asset_ref' === $asset_error->get_error_code(), 'raw asset URLs cannot bypass registered attachment references' );
+
+	$task = new SocialCrossPostTask();
+	$task->executeTask(
+		50,
+		array_merge(
+			$settings['params'],
+			array( 'platforms' => array( 'instagram', 'twitter' ) )
+		)
+	);
+	$packets = $GLOBALS['delegated_cross_post_jobs'][50]['output_data_packets'] ?? array();
+	$assert( 'completed' === ( $GLOBALS['delegated_cross_post_jobs'][50]['_status'] ?? null ) && 2 === count( $packets ), 'partial delivery completes with canonical result packets' );
+	$assert( true === $packets[1]['metadata']['success'], 'partial provider failure remains a successful owner step with bounded error projection' );
+
+	$packet_refs = array_map(
+		static fn( array $packet ): array => array(
+			'type'           => $packet['type'],
+			'source_type'    => $packet['metadata']['source_type'],
+			'source_id'      => $packet['metadata']['source_id'],
+			'source_item_id' => $packet['metadata']['source_item_id'],
+		),
+		$packets
+	);
+	$projection = $action['project'](
+		array(
+			'schema_version' => 'datamachine.run_result.v1',
+			'status'         => 'completed',
+			'packet_refs'    => $packet_refs,
+			'steps'          => array( array( 'packet_refs' => $packet_refs ) ),
+			'diagnostics'    => array( 'token' => 'private provider token diagnostic' ),
+		),
+		array()
+	);
+	$assert( 'partial' === ( $projection['classification'] ?? null ) && 1 === ( $projection['effect_count'] ?? null ), 'partial result preserves successful effect count' );
+	$assert( array( array( 'channel' => 'instagram', 'platform_post_id' => 'instagram-123' ) ) === ( $projection['share_refs'] ?? null ), 'projection preserves only safe share references' );
+	$assert( array( array( 'channel' => 'twitter', 'code' => 'publish_failed' ) ) === ( $projection['error_codes'] ?? null ), 'provider failures collapse to bounded error codes' );
+	$encoded_projection = json_encode( $projection );
+	$assert( ! str_contains( $encoded_projection, 'private' ) && ! str_contains( $encoded_projection, 'token' ), 'projection redacts content, credentials, and provider diagnostics' );
+	$assert( array() === $action['project']( array( 'schema_version' => 'datamachine.run_result.v1', 'status' => 'executing' ), array() ), 'active operation envelopes expose no premature result projection' );
+	$task->executeTask( 52, array_merge( $settings['params'], array( 'platforms' => array( 'twitter' ) ) ) );
+	$failed_packets = $GLOBALS['delegated_cross_post_jobs'][52]['output_data_packets'] ?? array();
+	$failed_ref     = array(
+		'type'           => $failed_packets[0]['type'] ?? '',
+		'source_type'    => $failed_packets[0]['metadata']['source_type'] ?? '',
+		'source_id'      => $failed_packets[0]['metadata']['source_id'] ?? '',
+		'source_item_id' => $failed_packets[0]['metadata']['source_item_id'] ?? '',
+	);
+	$failed_projection = $action['project']( array( 'status' => 'failed', 'packet_refs' => array( $failed_ref ) ), array() );
+	$assert( 'failed - delegated_cross_post_failed' === ( $GLOBALS['delegated_cross_post_jobs'][52]['job_status'] ?? null ) && false === ( $failed_packets[0]['metadata']['success'] ?? null ), 'total delegated failure terminates without scheduling an unsafe owner retry' );
+	$assert( 'failure' === ( $failed_projection['classification'] ?? null ) && 0 === ( $failed_projection['effect_count'] ?? null ), 'total provider failure projects a bounded failure rather than success' );
+
+	$empty             = $normalized;
+	$empty['platforms'] = array();
+	$task->executeTask( 51, $empty + array( 'delegated_operation_ref' => 'dop_' . str_repeat( 'b', 64 ) ) );
+	$assert( 'completed_no_items' === ( $GLOBALS['delegated_cross_post_jobs'][51]['job_status'] ?? null ), 'empty channel work emits canonical no-op status' );
+
+	if ( $failures ) {
+		foreach ( $failures as $failure ) {
+			echo "FAIL: {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "All {$passes} delegated cross-post assertions passed.\n";
+}

--- a/tests/twitter-publisher-media-contract-smoke.php
+++ b/tests/twitter-publisher-media-contract-smoke.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Smoke coverage for Publisher's public URL contract with Twitter.
+ *
+ * Run with: php tests/twitter-publisher-media-contract-smoke.php
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'MB_IN_BYTES', 1048576 );
+	$GLOBALS['twitter_media_deleted'] = array();
+
+	class WP_Error {
+		public function __construct( public string $code, public string $message, public array $data = array() ) {}
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return is_object( $value ) && $value instanceof WP_Error;
+	}
+
+	function wp_http_validate_url( string $url ): string|false {
+		return str_starts_with( $url, 'https://' ) ? $url : false;
+	}
+
+	function wp_tempnam( string $url ): string {
+		unset( $url );
+		return __FILE__;
+	}
+
+	function wp_safe_remote_get( string $url, array $args ): array {
+		unset( $url, $args );
+		return array( 'response' => array( 'code' => 200 ) );
+	}
+
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+
+	function wp_delete_file( string $path ): void {
+		$GLOBALS['twitter_media_deleted'][] = $path;
+	}
+
+	function wp_get_ability( string $slug ): object {
+		unset( $slug );
+		return $GLOBALS['twitter_publish_ability'];
+	}
+}
+
+namespace DataMachineSocials\Abilities {
+	abstract class AbstractSocialAbility {}
+}
+
+namespace DataMachine\Abilities {
+	class AuthAbilities {
+		public function getProvider( string $platform ): object {
+			unset( $platform );
+			return $GLOBALS['twitter_media_provider'];
+		}
+	}
+
+	class PermissionHelper {
+		public static function can( string $capability ): bool {
+			unset( $capability );
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class EngineData {}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class VideoValidator {
+		public static function is_video_extension( string $path ): bool {
+			unset( $path );
+			return false;
+		}
+	}
+
+	class ImageValidator {
+		public function validate_repository_file( string $path ): array {
+			return array(
+				'valid'     => is_file( $path ),
+				'mime_type' => 'image/jpeg',
+				'size'      => filesize( $path ),
+			);
+		}
+	}
+}
+
+namespace DataMachineSocials\Tracking {
+	class SocialShareTracker {
+		public static function extract_platform_post_id( string $platform, array $result ): string {
+			unset( $platform );
+			return (string) ( $result['tweet_id'] ?? '' );
+		}
+
+		public static function extract_platform_url( string $platform, array $result ): string {
+			unset( $platform );
+			return (string) ( $result['tweet_url'] ?? '' );
+		}
+	}
+}
+
+namespace {
+	final class TwitterMediaConnection {
+		public int $http_code = 0;
+		public array $media_ids = array();
+		public array $tweet_payload = array();
+
+		public function setApiVersion( string $version ): void {
+			unset( $version );
+		}
+
+		public function post( string $endpoint, array $payload, array $options = array() ): object {
+			unset( $options );
+			if ( 'media/upload' === $endpoint && 'INIT' === ( $payload['command'] ?? '' ) ) {
+				$id                = 'media-' . ( count( $this->media_ids ) + 1 );
+				$this->media_ids[] = $id;
+				return (object) array( 'media_id_string' => $id );
+			}
+			if ( 'media/upload' === $endpoint && 'FINALIZE' === ( $payload['command'] ?? '' ) ) {
+				return (object) array( 'media_id_string' => $payload['media_id'] );
+			}
+			if ( 'tweets' === $endpoint ) {
+				$this->tweet_payload = $payload;
+				$this->http_code     = 201;
+				return (object) array( 'data' => (object) array( 'id' => 'tweet-1' ) );
+			}
+
+			return (object) array();
+		}
+
+		public function getLastHttpCode(): int {
+			return $this->http_code;
+		}
+	}
+
+	final class TwitterMediaProvider {
+		public function __construct( private TwitterMediaConnection $connection ) {}
+		public function is_authenticated(): bool {
+			return true;
+		}
+		public function get_connection(): TwitterMediaConnection {
+			return $this->connection;
+		}
+		public function get_username(): string {
+			return 'publisher-test';
+		}
+	}
+
+	final class TwitterPublisherAbility {
+		public function execute( array $input ): array|WP_Error {
+			return \DataMachineSocials\Abilities\Twitter\TwitterPublishAbility::execute_publish( $input );
+		}
+	}
+
+	$connection = new TwitterMediaConnection();
+	$GLOBALS['twitter_media_provider'] = new TwitterMediaProvider( $connection );
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Twitter/TwitterPublishAbility.php';
+	require_once dirname( __DIR__ ) . '/inc/Publisher.php';
+	$GLOBALS['twitter_publish_ability'] = new TwitterPublisherAbility();
+
+	$result = \DataMachineSocials\Publisher::post_to_platform(
+		'twitter',
+		array( array( 'url' => 'https://example.test/one.jpg' ), array( 'url' => 'https://example.test/two.jpg' ) ),
+		'Publisher media contract.',
+		'https://example.test/source'
+	);
+
+	$failures = array();
+	if ( empty( $result['success'] ) || 'tweet-1' !== ( $result['platform_post_id'] ?? '' ) ) {
+		$failures[] = 'Twitter publish succeeds with public image_urls.';
+	}
+	if ( array( 'media-1', 'media-2' ) !== ( $connection->tweet_payload['media']['media_ids'] ?? null ) ) {
+		$failures[] = 'Every downloaded Publisher image reaches the Twitter media payload.';
+	}
+	if ( 2 !== count( $GLOBALS['twitter_media_deleted'] ) ) {
+		$failures[] = 'Downloaded temporary media is always cleaned up.';
+	}
+
+	if ( $failures ) {
+		foreach ( $failures as $failure ) {
+			echo "FAIL: {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "All 3 Twitter Publisher media assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- register a bounded Socials-owned delegated cross-post action against the current Data Machine callback contract
- validate canonical posts, approved copy, channels, media compatibility, and attachment-backed assets before enqueue
- preserve durable per-operation share receipts, safe partial/failure projection, and fail-closed retry behavior
- adapt Publisher payloads per platform and fix Twitter public-URL media uploads at the Twitter owning layer

## Verification
- `php tests/delegated-cross-post-action-smoke.php` (29 assertions)
- `php tests/twitter-publisher-media-contract-smoke.php` (3 assertions)
- focused Publisher PHPUnit: 1 test, 4 assertions passed in the underlying WP Codebox runner
- focused tracker receipt PHPUnit: 1 test, 6 assertions passed in the underlying WP Codebox runner
- `homeboy review lint data-machine-socials --changed-only --placement local --summary` (PHPCS and PHPStan clean)
- `homeboy review audit data-machine-socials --changed-since origin/main --placement local --json-summary` (0 introduced findings)
- independent exact-diff review: no blocking findings

Homeboy currently misreads the successful focused WP Codebox PHPUnit artifacts as zero executed tests; the raw runner output records the passing test/assertion counts above. The broader existing suite also retains unrelated baseline failures tracked outside this PR.

Closes #203
Closes #204