### PR TITLE
Refactor Socials agent guidance to concise routing

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -190,13 +190,9 @@ add_action( 'plugins_loaded', 'datamachine_socials_bootstrap', 20 );
 
 /**
  * Register the Data Machine Socials CLI section in the composable AGENTS.md
- * file so external agent runtimes discover the social CLI surface
- * automatically.
- *
+ * file so external agent runtimes discover intent-based social CLI routing.
  * Runs outside the WP_CLI guard because compose/auto-regeneration may fire in
- * non-CLI WordPress contexts (web/cron). The section generator reflects over
- * the command class files directly (resolved from disk via CommandRegistry),
- * so it never depends on the live WP-CLI runner being loaded.
+ * non-CLI WordPress contexts (web/cron).
  */
 function datamachine_socials_register_agents_md_section() {
 	if ( ! class_exists( '\DataMachine\Engine\AI\SectionRegistry' ) ) {
@@ -275,9 +271,7 @@ add_action( 'admin_enqueue_scripts', 'datamachine_socials_enqueue_assets' );
  * Register WP-CLI commands.
  */
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	// Single source of truth: CommandRegistry maps every command string to its
-	// class. The AGENTS.md section generator reads the same map, so the
-	// documented CLI surface can never drift from what is registered here.
+	// CommandRegistry is the single source of truth for runtime registration.
 	foreach ( \DataMachineSocials\Cli\CommandRegistry::map() as $command => $class ) {
 		require_once \DataMachineSocials\Cli\CommandRegistry::file_for_class( $class );
 		WP_CLI::add_command( $command, $class );

--- a/inc/Cli/AgentsMdSection.php
+++ b/inc/Cli/AgentsMdSection.php
@@ -2,365 +2,42 @@
 /**
  * AGENTS.md Section Generator
  *
- * Generates the "Data Machine Socials CLI" section of the composed AGENTS.md
- * file by introspecting the real registered command tree instead of
- * hand-maintaining a heredoc. Walks every command registered in
- * CommandRegistry, reflects over each command class's subcommand methods, and
- * emits each namespace with its real subcommands and their PHPDoc short
- * descriptions.
- *
- * Context-safe: the section callback runs on `datamachine_sections` /
- * `plugins_loaded` in web/cron compose contexts where the WP_CLI-guarded
- * command `require_once` block (and the live WP-CLI runner) is NOT loaded. This
- * generator resolves command class files directly from disk via CommandRegistry
- * and reflects over them, never relying on the live WP-CLI runner.
- *
- * Reflection is delegated to the shared
- * `\DataMachine\Engine\AI\CliCommandIntrospector` when present (the canonical
- * home for this logic, Extra-Chill/data-machine#2613), with a self-contained
- * local fallback so this plugin never hard-depends on an unreleased core class.
- * The local fallback additionally handles `__invoke` leaf commands regardless
- * of whether the shared helper's `__invoke` support (data-machine#2639) has
- * landed.
- *
  * @package DataMachineSocials\Cli
  */
 
 namespace DataMachineSocials\Cli;
-
-use ReflectionClass;
-use ReflectionMethod;
 
 defined( 'ABSPATH' ) || exit;
 
 class AgentsMdSection {
 
 	/**
-	 * Build the Markdown body for the Data Machine Socials CLI AGENTS.md section.
+	 * Build concise intent routing for the Data Machine Socials CLI.
 	 *
 	 * @param string $wp The `wp --allow-root --path=...` invocation prefix.
 	 * @return string
 	 */
 	public static function render( $wp ) {
-		$lines   = array();
-		$lines[] = '### Data Machine Socials CLI';
-		$lines[] = '';
-		$lines[] = 'Cross-platform social media commands — read, publish, and engage across Instagram, Twitter/X, Facebook, Bluesky, Threads, Pinterest, LinkedIn, Tumblr, and Reddit, plus unified comments and per-item share tracking.';
-		$lines[] = "Discover everything: `{$wp} datamachine-socials --help`";
-		$lines[] = '';
-
-		foreach ( self::collect_commands() as $command => $subcommands ) {
-			$summary = self::summarize_subcommands( $subcommands );
-
-			if ( '' !== $summary ) {
-				$lines[] = "- `{$wp} {$command}` — {$summary}";
-			} else {
-				$lines[] = "- `{$wp} {$command}`";
-			}
-
-			foreach ( $subcommands as $sub ) {
-				if ( '__default' === $sub['name'] ) {
-					continue;
-				}
-				$desc = $sub['description'];
-				if ( '' !== $desc ) {
-					$lines[] = "  - `{$sub['name']}` — {$desc}";
-				} else {
-					$lines[] = "  - `{$sub['name']}`";
-				}
-			}
-		}
-
-		$lines[] = '';
-		$lines[] = 'All commands support `--help` for full options and subcommand discovery.';
+		$lines = array(
+			'### Data Machine Socials CLI',
+			'',
+			'Data Machine Socials owns cross-platform social media authentication, reading, publishing, engagement, and per-item share tracking.',
+			'',
+			'**Default routing**',
+			"- Check authentication or account status: `{$wp} datamachine-socials instagram status`",
+			"- Read recent platform content: `{$wp} datamachine-socials instagram posts`",
+			"- Discover public content: `{$wp} datamachine-socials reddit search \"live music\"`",
+			"- Publish through a platform command: `{$wp} datamachine-socials instagram publish --help`",
+			"- Read or reply to comments across supported platforms: `{$wp} datamachine-socials comments --help`",
+			"- Inspect share tracking for a WordPress post: `{$wp} datamachine-socials shares list <post-id>`",
+			'',
+			'**Safety**',
+			'Publishing, replies, deletes, and other mutations affect live social accounts. Confirm the target account, content, and requested action before running them.',
+			'',
+			'**Discovery**',
+			"Use `{$wp} datamachine-socials --help` for the current platform list and `{$wp} datamachine-socials <platform> --help` for that platform's live actions and options. Live `--help` output is authoritative.",
+		);
 
 		return implode( "\n", $lines );
-	}
-
-	/**
-	 * Walk the CommandRegistry and reflect each class into its subcommands.
-	 *
-	 * @return array<string, array<int, array{name:string, description:string}>>
-	 *               command string => ordered list of subcommands.
-	 */
-	private static function collect_commands() {
-		$out = array();
-
-		foreach ( CommandRegistry::map() as $command => $class ) {
-			self::ensure_class_loaded( $class );
-			$out[ $command ] = self::reflect_subcommands( $class );
-		}
-
-		return $out;
-	}
-
-	/**
-	 * Ensure a command class is loaded for reflection.
-	 *
-	 * Triggers the composer autoloader first (the plugin requires
-	 * vendor/autoload.php unconditionally); falls back to requiring the class
-	 * file directly from disk via CommandRegistry when the autoloader is not
-	 * available (e.g. a minimal compose context). The class files guard only on
-	 * ABSPATH, never on WP_CLI, so loading them outside WP-CLI is safe.
-	 *
-	 * @param class-string $class Command class.
-	 * @return void
-	 */
-	private static function ensure_class_loaded( $class ) {
-		if ( class_exists( $class ) ) {
-			return;
-		}
-
-		$file = CommandRegistry::file_for_class( $class );
-		if ( is_readable( $file ) ) {
-			require_once $file;
-		}
-	}
-
-	/**
-	 * Reflect a command class into its list of subcommands.
-	 *
-	 * Prefers the shared core introspector when available; otherwise uses the
-	 * self-contained local reflection fallback. Subcommand names are normalized
-	 * to WP-CLI's runtime convention (trailing underscore stripped, remaining
-	 * underscores converted to hyphens) so the documented names match what an
-	 * operator actually types.
-	 *
-	 * @param class-string $class Command class.
-	 * @return array<int, array{name:string, description:string}>
-	 */
-	private static function reflect_subcommands( $class ) {
-		if ( ! class_exists( $class ) ) {
-			return array();
-		}
-
-		$shared = self::reflect_via_shared_helper( $class );
-		$subs   = null !== $shared ? $shared : self::reflect_locally( $class );
-
-		foreach ( $subs as &$sub ) {
-			if ( '__default' !== $sub['name'] ) {
-				$sub['name'] = self::normalize_subcommand_name( $sub['name'] );
-			}
-		}
-		unset( $sub );
-
-		return $subs;
-	}
-
-	/**
-	 * Reflect subcommands via the shared core CliCommandIntrospector.
-	 *
-	 * @param class-string $class Command class.
-	 * @return array<int, array{name:string, description:string}>|null Subcommands,
-	 *         or null when the shared helper is unavailable.
-	 */
-	private static function reflect_via_shared_helper( $class ) {
-		$helper = '\DataMachine\Engine\AI\CliCommandIntrospector';
-
-		if ( ! class_exists( $helper ) || ! method_exists( $helper, 'describe_class' ) ) {
-			return null;
-		}
-
-		$subs = $helper::describe_class( $class );
-
-		if ( ! is_array( $subs ) ) {
-			return null;
-		}
-
-		// The shared helper (pre data-machine#2639) does not enumerate
-		// __invoke leaf commands. Detect that case and append it locally so the
-		// surface is complete regardless of which core version is installed.
-		if ( self::class_has_invoke_subcommand( $class ) && ! self::list_has_default( $subs ) ) {
-			$subs[] = array(
-				'name'        => '__default',
-				'description' => '',
-			);
-		}
-
-		return $subs;
-	}
-
-	/**
-	 * Self-contained reflection fallback over a command class.
-	 *
-	 * Public, non-static, non-magic methods are WP-CLI subcommands. The
-	 * subcommand name is taken from `@subcommand <name>` when present, otherwise
-	 * the method name. `__invoke` (or `@subcommand __default`) represents the
-	 * directly-invokable namespace itself.
-	 *
-	 * @param class-string $class Command class.
-	 * @return array<int, array{name:string, description:string}>
-	 */
-	private static function reflect_locally( $class ) {
-		try {
-			$reflection = new ReflectionClass( $class );
-		} catch ( \Throwable $e ) {
-			return array();
-		}
-
-		$subcommands = array();
-
-		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
-			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
-				continue;
-			}
-
-			if ( $method->isStatic() || $method->isConstructor() || $method->isDestructor() ) {
-				continue;
-			}
-
-			$method_name = $method->getName();
-			$doc         = $method->getDocComment() ?: '';
-			$annotated   = self::parse_subcommand_annotation( $doc );
-
-			if ( '__invoke' === $method_name && '' === $annotated ) {
-				$annotated = '__default';
-			}
-
-			if ( '' !== $annotated ) {
-				$name = $annotated;
-			} else {
-				if ( 0 === strpos( $method_name, '__' ) ) {
-					continue;
-				}
-				$name = $method_name;
-			}
-
-			$subcommands[] = array(
-				'name'        => $name,
-				'description' => self::parse_short_description( $doc ),
-			);
-		}
-
-		return $subcommands;
-	}
-
-	/**
-	 * Whether a class exposes an `__invoke` (or `@subcommand __default`) command.
-	 *
-	 * @param class-string $class Command class.
-	 * @return bool
-	 */
-	private static function class_has_invoke_subcommand( $class ) {
-		try {
-			$reflection = new ReflectionClass( $class );
-		} catch ( \Throwable $e ) {
-			return false;
-		}
-
-		if ( $reflection->hasMethod( '__invoke' ) ) {
-			return true;
-		}
-
-		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
-			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
-				continue;
-			}
-			if ( '__default' === self::parse_subcommand_annotation( $method->getDocComment() ?: '' ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Whether a subcommand list already contains the namespace default.
-	 *
-	 * @param array<int, array{name:string, description:string}> $subs Subcommands.
-	 * @return bool
-	 */
-	private static function list_has_default( array $subs ) {
-		foreach ( $subs as $sub ) {
-			if ( isset( $sub['name'] ) && '__default' === $sub['name'] ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Normalize a raw method/subcommand name to WP-CLI's runtime convention.
-	 *
-	 * WP-CLI strips a single trailing underscore (so `list_` is invoked as
-	 * `list`) and converts remaining underscores to hyphens (so `list_boards`
-	 * is invoked as `list-boards`).
-	 *
-	 * @param string $name Raw name.
-	 * @return string
-	 */
-	private static function normalize_subcommand_name( $name ) {
-		if ( '' !== $name && '_' === substr( $name, -1 ) ) {
-			$name = substr( $name, 0, -1 );
-		}
-
-		return str_replace( '_', '-', $name );
-	}
-
-	/**
-	 * Build a comma-separated summary of subcommand names for the headline.
-	 *
-	 * @param array<int, array{name:string, description:string}> $subcommands Subcommands.
-	 * @return string
-	 */
-	private static function summarize_subcommands( $subcommands ) {
-		$names = array();
-		foreach ( $subcommands as $sub ) {
-			if ( '__default' === $sub['name'] ) {
-				continue;
-			}
-			$names[] = $sub['name'];
-		}
-
-		return implode( ', ', $names );
-	}
-
-	/**
-	 * Parse the `@subcommand <name>` annotation from a docblock.
-	 *
-	 * @param string $doc Raw docblock.
-	 * @return string Subcommand name, or '' when not annotated.
-	 */
-	private static function parse_subcommand_annotation( $doc ) {
-		if ( preg_match( '/@subcommand\s+(\S+)/', $doc, $m ) ) {
-			return $m[1];
-		}
-		return '';
-	}
-
-	/**
-	 * Parse the short description (first prose line) from a docblock.
-	 *
-	 * Mirrors how WP-CLI derives a command's summary for `--help`: the first
-	 * non-empty content line of the docblock, before any `## SECTION` heading or
-	 * `@tag` annotation.
-	 *
-	 * @param string $doc Raw docblock.
-	 * @return string
-	 */
-	private static function parse_short_description( $doc ) {
-		if ( '' === $doc ) {
-			return '';
-		}
-
-		$doc   = preg_replace( '#^/\*\*|\*/$#', '', $doc );
-		$lines = preg_split( '/\r\n|\r|\n/', $doc );
-
-		foreach ( $lines as $line ) {
-			$line = preg_replace( '/^\s*\*\s?/', '', $line );
-			$line = trim( $line );
-
-			if ( '' === $line ) {
-				continue;
-			}
-
-			if ( 0 === strpos( $line, '##' ) || 0 === strpos( $line, '@' ) ) {
-				return '';
-			}
-
-			return rtrim( $line, '.' );
-		}
-
-		return '';
 	}
 }

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -3,11 +3,8 @@
  * WP-CLI Command Registry
  *
  * Single source of truth mapping `datamachine-socials ...` command strings to
- * their implementing command classes. Both the WP-CLI bootstrap (which calls
- * WP_CLI::add_command for each entry) and the AGENTS.md section generator
- * (which reflects over each class to enumerate real subcommands) read from this
- * map, so the documented CLI surface can never drift from what is actually
- * registered.
+ * their implementing command classes. The WP-CLI bootstrap registers every
+ * entry in this map.
  *
  * @package DataMachineSocials\Cli
  */
@@ -22,8 +19,8 @@ class CommandRegistry {
 	 * Map of command string => fully-qualified command class.
 	 *
 	 * Keys are the exact strings passed to WP_CLI::add_command (the command
-	 * namespace, e.g. "datamachine-socials reddit"). Order here determines both
-	 * registration order and documentation order.
+	 * namespace, e.g. "datamachine-socials reddit"). Order here determines
+	 * registration order.
 	 *
 	 * @return array<string, class-string>
 	 */
@@ -51,10 +48,7 @@ class CommandRegistry {
 	 *
 	 * The command classes live under the plugin's PSR-4 root
 	 * (`DataMachineSocials\Cli\Commands\FooCommand` => `inc/Cli/Commands/FooCommand.php`).
-	 * The section generator uses this to require the class file directly from
-	 * disk in web/cron compose contexts where the WP_CLI-guarded `require_once`
-	 * block has not run. The class files guard only on ABSPATH, never on WP_CLI,
-	 * so loading them outside WP-CLI is safe.
+	 * The WP-CLI bootstrap uses this to load each registered command class.
 	 *
 	 * @param class-string $class Fully-qualified command class.
 	 * @return string Absolute file path (may not exist).

--- a/tests/agents-md-routing-smoke.php
+++ b/tests/agents-md-routing-smoke.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Smoke tests for concise Data Machine Socials AGENTS.md routing.
+ *
+ * Run with: php tests/agents-md-routing-smoke.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+require_once dirname( __DIR__ ) . '/inc/Cli/AgentsMdSection.php';
+
+use DataMachineSocials\Cli\AgentsMdSection;
+
+$failures = array();
+$passes   = 0;
+$assert   = static function ( bool $condition, string $message ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+	$failures[] = $message;
+};
+
+$wp       = 'wp --allow-root --path=/srv/example/';
+$rendered = AgentsMdSection::render( $wp );
+
+$assert( str_starts_with( $rendered, '### Data Machine Socials CLI' ), 'section keeps the Socials heading' );
+$assert( str_contains( $rendered, 'Data Machine Socials owns cross-platform social media' ), 'section states owner and scope' );
+$assert( str_contains( $rendered, '**Default routing**' ), 'default routing is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials instagram status`" ), 'authentication and status route uses the resolved prefix' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials instagram posts`" ), 'read route is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials reddit search \"live music\"`" ), 'discovery route is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials instagram publish --help`" ), 'publish route is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials comments --help`" ), 'engagement route is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials shares list <post-id>`" ), 'share tracking route is present' );
+$assert( str_contains( $rendered, '**Safety**' ), 'live mutation safety is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials --help`" ), 'root discovery route is present' );
+$assert( str_contains( $rendered, "`{$wp} datamachine-socials <platform> --help`" ), 'platform discovery route is present' );
+$assert( str_contains( $rendered, 'Live `--help` output is authoritative.' ), 'live help is declared authoritative' );
+$assert( substr_count( $rendered, "\n" ) + 1 <= 20, 'section remains bounded to 20 lines' );
+
+foreach ( array( 'instagram archive', 'pinterest board-pins', 'mastodon register-app', 'shares clear' ) as $exhaustive_command ) {
+	$assert( ! str_contains( $rendered, "datamachine-socials {$exhaustive_command}" ), "exhaustive command {$exhaustive_command} is not injected" );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, "AGENTS.md Socials routing smoke failed:\n- " . implode( "\n- ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "AGENTS.md Socials routing smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary

- Replace exhaustive platform-by-platform AGENTS.md CLI reflection with concise intent-based routing owned by Data Machine Socials.
- Keep representative routes for authentication/status, reading/discovery, publishing, engagement, and share tracking while preserving the resolved WP-CLI prefix and context-safe section registration.
- Remove AGENTS-only reflection and fallback machinery; actual Socials command registration and behavior remain unchanged.

## Why

Injecting every platform action duplicates mutable WP-CLI help, adds prompt cost, and makes stable operational guidance churn whenever the command surface changes. This follows the coordinated concise-guidance refactor established in Data Machine Code #950, Intelligence #898, and wp-coding-agents #299: AGENTS.md carries stable ownership, routing, safety, and discovery, while live CLI help carries exhaustive mutable detail.

Live `wp ... datamachine-socials --help` and platform-specific `wp ... datamachine-socials <platform> --help` output is authoritative for current actions and options.

## Default routes retained

- Authentication/status: `wp ... datamachine-socials instagram status`
- Read: `wp ... datamachine-socials instagram posts`
- Discovery: `wp ... datamachine-socials reddit search \"live music\"`
- Publish: `wp ... datamachine-socials instagram publish --help`
- Engagement: `wp ... datamachine-socials comments --help`
- Share tracking: `wp ... datamachine-socials shares list <post-id>`
- Root discovery: `wp ... datamachine-socials --help`
- Platform discovery: `wp ... datamachine-socials <platform> --help`

## Rendered size

- Before: 118 lines / 7,170 bytes
- After: 17 lines / 1,440 bytes
- Reduction: 101 lines / 5,730 bytes

## Verification

- `php -l inc/Cli/AgentsMdSection.php` passed
- `php -l inc/Cli/CommandRegistry.php` passed
- `php -l data-machine-socials.php` passed
- `php -l tests/agents-md-routing-smoke.php` passed
- `php tests/agents-md-routing-smoke.php` passed: 18 assertions
- `git diff --check origin/main...HEAD` passed
- `homeboy --placement local review lint --changed-only --summary` passed PHPCS and PHPStan; one existing non-blocking reserved-parameter warning remains in `CommandRegistry::file_for_class()`
- `homeboy --placement local review test --changed-since origin/main` ran 165 tests but the repository-wide sandbox gate failed 126 because the test environment does not provide upstream `DataMachine\\Core\\OAuth\\BaseOAuth2Provider`; 39 tests passed, including the new routing smoke

Closes #208