### PR TITLE
feat: add Reddit domain mentions report

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -132,6 +132,7 @@ function datamachine_socials_bootstrap() {
 
 	// Reddit
 	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
+	new \DataMachineSocials\Abilities\Reddit\RedditDomainMentionsAbility();
 	new \DataMachineSocials\Abilities\Reddit\ReplyRedditAbility();
 	new \DataMachineSocials\Abilities\Reddit\SubmitRedditAbility();
 	new \DataMachineSocials\Abilities\Reddit\VoteRedditAbility();

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -110,11 +110,62 @@ class FetchRedditAbility extends AbstractSocialAbility {
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
+						'required'   => array( 'success', 'pagination', 'logs' ),
 						'properties' => array(
-							'success' => array( 'type' => 'boolean' ),
-							'data'    => array( 'type' => 'object' ),
-							'error'   => array( 'type' => 'string' ),
-							'logs'    => array( 'type' => 'array' ),
+							'success'    => array( 'type' => 'boolean' ),
+							'data'       => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+							'items'      => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'required'   => array( 'data', 'source_url', 'item_id' ),
+									'properties' => array(
+										'data'       => array(
+											'type'       => 'object',
+											'required'   => array( 'title', 'content', 'metadata' ),
+											'properties' => array(
+												'title'    => array( 'type' => 'string' ),
+												'content'  => array( 'type' => 'string' ),
+												'metadata' => array(
+													'type' => 'object',
+													'required' => array( 'source_type', 'item_identifier_to_log', 'original_id', 'original_title', 'original_date_gmt', 'subreddit', 'upvotes', 'comment_count', 'author', 'is_self_post', 'target_url' ),
+													'properties' => array(
+														'source_type'            => array( 'type' => 'string' ),
+														'item_identifier_to_log' => array( 'type' => 'string' ),
+														'original_id'            => array( 'type' => 'string' ),
+														'original_title'         => array( 'type' => 'string' ),
+														'original_date_gmt'      => array( 'type' => 'string' ),
+														'subreddit'              => array( 'type' => 'string' ),
+														'upvotes'                => array( 'type' => 'integer' ),
+														'comment_count'          => array( 'type' => 'integer' ),
+														'author'                 => array( 'type' => 'string' ),
+														'is_self_post'           => array( 'type' => 'boolean' ),
+														'target_url'             => array( 'type' => 'string' ),
+													),
+												),
+											),
+										),
+										'source_url' => array( 'type' => 'string' ),
+										'item_id'    => array( 'type' => 'string' ),
+									),
+								),
+							),
+							'pagination' => array(
+								'type'       => 'object',
+								'required'   => array( 'pages_fetched', 'truncated' ),
+								'properties' => array(
+									'pages_fetched' => array( 'type' => 'integer' ),
+									'truncated'     => array( 'type' => 'boolean' ),
+								),
+							),
+							'error'      => array( 'type' => 'string' ),
+							'logs'       => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -378,6 +429,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 						)
 					);
 				} else {
+					$truncated = true;
 					break;
 				}
 			}

--- a/inc/Abilities/Reddit/FetchRedditAbility.php
+++ b/inc/Abilities/Reddit/FetchRedditAbility.php
@@ -285,6 +285,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		$total_checked  = 0;
 		$pages_fetched  = 0;
 		$eligible_items = array();
+		$truncated      = false;
 
 		while ( $pages_fetched < $max_pages ) {
 			++$pages_fetched;
@@ -340,6 +341,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 
 					return $result;
 				} else {
+					$truncated = true;
 					break;
 				}
 			}
@@ -389,7 +391,8 @@ class FetchRedditAbility extends AbstractSocialAbility {
 				break;
 			}
 
-			foreach ( $response_data['data']['children'] as $post_wrapper ) {
+			$post_wrappers = $response_data['data']['children'];
+			foreach ( $post_wrappers as $post_index => $post_wrapper ) {
 				++$total_checked;
 				if ( empty( $post_wrapper['data'] ) || empty( $post_wrapper['data']['id'] ) || empty( $post_wrapper['kind'] ) ) {
 					$logs[] = array(
@@ -491,6 +494,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 					'comment_count'          => $item_data['num_comments'] ?? 0,
 					'author'                 => $item_data['author'] ?? '[deleted]',
 					'is_self_post'           => $item_data['is_self'] ?? false,
+					'target_url'             => $item_data['url'] ?? '',
 				);
 
 				if ( ! empty( $comments_array ) ) {
@@ -544,6 +548,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 					// surface to consult; honor only the direct-call result cap.
 					$eligible_items[] = $candidate;
 					if ( null !== $max_items && count( $eligible_items ) >= $max_items ) {
+						$truncated = $post_index < count( $post_wrappers ) - 1 || ! empty( $response_data['data']['after'] );
 						break;
 					}
 					continue;
@@ -600,6 +605,7 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		// either filling the collector or running out of Reddit `after`
 		// cursors, that is "scan budget exhausted", not source exhaustion —
 		// leave `source_exhausted=false` so callers can distinguish the two.
+		$truncated = $truncated || ( $pages_fetched >= $max_pages && ! empty( $after_param ) );
 
 		// Pipeline path: emit collector accepted set as the result so handler
 		// post-processing iterates only the items the core primitive blessed.
@@ -618,9 +624,13 @@ class FetchRedditAbility extends AbstractSocialAbility {
 			);
 
 			return array(
-				'success' => true,
-				'data'    => array(),
-				'logs'    => $logs,
+				'success'    => true,
+				'data'       => array(),
+				'pagination' => array(
+					'pages_fetched' => $pages_fetched,
+					'truncated'     => $truncated,
+				),
+				'logs'       => $logs,
 			);
 		}
 
@@ -634,9 +644,13 @@ class FetchRedditAbility extends AbstractSocialAbility {
 		);
 
 		return array(
-			'success' => true,
-			'items'   => $eligible_items,
-			'logs'    => $logs,
+			'success'    => true,
+			'items'      => $eligible_items,
+			'pagination' => array(
+				'pages_fetched' => $pages_fetched,
+				'truncated'     => $truncated,
+			),
+			'logs'       => $logs,
 		);
 	}
 

--- a/inc/Abilities/Reddit/RedditDomainMentionsAbility.php
+++ b/inc/Abilities/Reddit/RedditDomainMentionsAbility.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Reddit Domain Mentions Ability
+ *
+ * @package    DataMachineSocials
+ * @subpackage Abilities\Reddit
+ */
+
+namespace DataMachineSocials\Abilities\Reddit;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Build a read-only report of Reddit posts that mention a domain.
+ */
+class RedditDomainMentionsAbility extends AbstractSocialAbility {
+
+	protected static bool $registered = false;
+
+	public function __construct() {
+		$this->registerAbility( $this->registerCallback(), true );
+	}
+
+	private function registerCallback(): callable {
+		return function () {
+			wp_register_ability(
+				'datamachine/reddit-domain-mentions',
+				array(
+					'label'               => __( 'Report Reddit Domain Mentions', 'data-machine-socials' ),
+					'description'         => __( 'Report Reddit posts that directly link to or mention a domain in self-post text.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'domain', 'access_token' ),
+						'properties' => array(
+							'domain'          => array(
+								'type'        => 'string',
+								'description' => __( 'Domain or root URL to report.', 'data-machine-socials' ),
+							),
+							'access_token'    => array(
+								'type'        => 'string',
+								'description' => __( 'Reddit OAuth access token.', 'data-machine-socials' ),
+							),
+							'owners'          => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'default'     => array(),
+								'description' => __( 'Reddit usernames whose posts count as owned.', 'data-machine-socials' ),
+							),
+							'timeframe_limit' => array(
+								'type'        => 'string',
+								'default'     => 'all_time',
+								'description' => __( 'Fetch ability timeframe filter.', 'data-machine-socials' ),
+							),
+							'limit'           => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => 500,
+								'default'     => 100,
+								'description' => __( 'Maximum deduplicated report rows.', 'data-machine-socials' ),
+							),
+							'max_pages'       => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => 10,
+								'default'     => 5,
+								'description' => __( 'Maximum Reddit pages fetched per query variant.', 'data-machine-socials' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'report'  => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can( 'use_tools' );
+	}
+
+	/**
+	 * Execute the report by composing the existing Reddit fetch ability.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute( array $input ): array|\WP_Error {
+		$domain = self::normalizeDomain( (string) ( $input['domain'] ?? '' ) );
+		if ( is_wp_error( $domain ) ) {
+			return $domain;
+		}
+
+		$access_token = trim( (string) ( $input['access_token'] ?? '' ) );
+		if ( '' === $access_token ) {
+			return new \WP_Error( 'missing_param', 'A Reddit access token is required', array( 'status' => 400 ) );
+		}
+
+		$owners = self::normalizeOwners( $input['owners'] ?? array() );
+		if ( is_wp_error( $owners ) ) {
+			return $owners;
+		}
+
+		$limit     = (int) ( $input['limit'] ?? 100 );
+		$max_pages = (int) ( $input['max_pages'] ?? 5 );
+		$timeframe = (string) ( $input['timeframe_limit'] ?? 'all_time' );
+		if ( $limit < 1 || $limit > 500 ) {
+			return new \WP_Error( 'invalid_param', 'limit must be between 1 and 500', array( 'status' => 400 ) );
+		}
+		if ( $max_pages < 1 || $max_pages > 10 ) {
+			return new \WP_Error( 'invalid_param', 'max_pages must be between 1 and 10', array( 'status' => 400 ) );
+		}
+		if ( ! in_array( $timeframe, array( 'all_time', '24_hours', '72_hours', '7_days', '30_days', '90_days', '6_months', '1_year' ), true ) ) {
+			return new \WP_Error( 'invalid_param', 'Unsupported timeframe_limit', array( 'status' => 400 ) );
+		}
+
+		$fetch = wp_get_ability( 'datamachine/fetch-reddit' );
+		if ( ! $fetch ) {
+			return new \WP_Error( 'missing_ability', 'datamachine/fetch-reddit ability not registered', array( 'status' => 500 ) );
+		}
+
+		$items     = array();
+		$truncated = false;
+		$queries   = array( 'url:' . $domain, $domain );
+		foreach ( $queries as $query ) {
+			$result = $fetch->execute(
+				array(
+					'query'            => $query,
+					'access_token'     => $access_token,
+					'sort_by'          => 'relevance',
+					'timeframe_limit'  => $timeframe,
+					'fetch_batch_size' => 100,
+					'max_pages'        => $max_pages,
+					'max_items'        => $limit,
+					'download_images'  => false,
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			if ( empty( $result['success'] ) ) {
+				return new \WP_Error( 'api_error', (string) ( $result['error'] ?? 'Reddit domain search failed' ), array( 'status' => 500 ) );
+			}
+
+			$query_items = $result['items'] ?? array();
+			$truncated   = $truncated || ! empty( $result['pagination']['truncated'] );
+			foreach ( $query_items as $item ) {
+				$row = self::itemToRow( $item, $domain, $owners );
+				if ( null === $row ) {
+					continue;
+				}
+
+				$id = $row['item_id'];
+				if ( ! isset( $items[ $id ] ) || 'direct_link' === $row['match_type'] ) {
+					$items[ $id ] = $row;
+				}
+			}
+		}
+
+		$rows = array_values( $items );
+		usort( $rows, static fn( array $a, array $b ): int => strcmp( $b['timestamp'], $a['timestamp'] ) );
+		if ( count( $rows ) > $limit ) {
+			$truncated = true;
+			$rows      = array_slice( $rows, 0, $limit );
+		}
+
+		return array(
+			'success' => true,
+			'report'  => self::buildReport( $domain, $owners, $rows, $truncated, $limit, $max_pages ),
+		);
+	}
+
+	/**
+	 * Normalize a bare domain or root URL and reject ambiguous URL components.
+	 *
+	 * @return string|\WP_Error
+	 */
+	private static function normalizeDomain( string $input ): string|\WP_Error {
+		$input = trim( strtolower( $input ) );
+		if ( '' === $input || preg_match( '/\s/', $input ) ) {
+			return new \WP_Error( 'invalid_domain', 'Provide a valid domain or root URL', array( 'status' => 400 ) );
+		}
+
+		$has_scheme = str_contains( $input, '://' );
+		$url        = $has_scheme ? $input : 'https://' . $input;
+		$parts      = wp_parse_url( $url );
+		if (
+			! is_array( $parts ) ||
+			empty( $parts['host'] ) ||
+			isset( $parts['user'] ) ||
+			isset( $parts['pass'] ) ||
+			isset( $parts['port'] ) ||
+			! empty( $parts['query'] ) ||
+			! empty( $parts['fragment'] ) ||
+			( isset( $parts['path'] ) && ! in_array( $parts['path'], array( '', '/' ), true ) ) ||
+			( $has_scheme && ! in_array( $parts['scheme'] ?? '', array( 'http', 'https' ), true ) )
+		) {
+			return new \WP_Error( 'invalid_domain', 'Domain must not include credentials, a port, path, query, or fragment', array( 'status' => 400 ) );
+		}
+
+		$domain = rtrim( strtolower( (string) $parts['host'] ), '.' );
+		if ( function_exists( 'idn_to_ascii' ) ) {
+			$ascii = idn_to_ascii( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+			if ( false !== $ascii ) {
+				$domain = strtolower( $ascii );
+			}
+		}
+
+		if (
+			strlen( $domain ) > 253 ||
+			! str_contains( $domain, '.' ) ||
+			filter_var( $domain, FILTER_VALIDATE_IP ) ||
+			! preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/', $domain )
+		) {
+			return new \WP_Error( 'invalid_domain', 'Provide a valid public domain name', array( 'status' => 400 ) );
+		}
+
+		return $domain;
+	}
+
+	/**
+	 * @return array|\WP_Error
+	 */
+	private static function normalizeOwners( mixed $input ): array|\WP_Error {
+		$values = is_array( $input ) ? $input : array( $input );
+		$owners = array();
+		foreach ( $values as $value ) {
+			foreach ( explode( ',', (string) $value ) as $owner ) {
+				$owner = strtolower( preg_replace( '#^(?:u/|/u/)#i', '', trim( $owner ) ) );
+				if ( '' === $owner ) {
+					continue;
+				}
+				if ( ! preg_match( '/^[a-z0-9_-]{3,20}$/', $owner ) ) {
+					return new \WP_Error( 'invalid_owner', 'Owner usernames must be valid Reddit usernames', array( 'status' => 400 ) );
+				}
+				$owners[] = $owner;
+			}
+		}
+
+		return array_values( array_unique( $owners ) );
+	}
+
+	private static function itemToRow( array $item, string $domain, array $owners ): ?array {
+		$data        = $item['data'] ?? array();
+		$metadata    = $data['metadata'] ?? array();
+		$item_id     = (string) ( $item['item_id'] ?? $metadata['original_id'] ?? '' );
+		$target_url  = html_entity_decode( (string) ( $metadata['target_url'] ?? '' ) );
+		$target_host = self::matchingHost( $target_url, $domain );
+
+		$match_type   = 'direct_link';
+		$matched_url  = $target_host ? $target_url : '';
+		$matched_host = $target_host;
+		if ( ! $target_host ) {
+			if ( empty( $metadata['is_self_post'] ) ) {
+				return null;
+			}
+			$match_type = 'self_text';
+			$match      = self::findTextMatch( (string) ( $data['content'] ?? '' ), $domain );
+			if ( null === $match ) {
+				return null;
+			}
+			$matched_url  = $match['url'];
+			$matched_host = $match['host'];
+		}
+
+		if ( '' === $item_id ) {
+			return null;
+		}
+
+		$timestamp = (string) ( $metadata['original_date_gmt'] ?? '' );
+		$author    = (string) ( $metadata['author'] ?? '[deleted]' );
+
+		return array(
+			'item_id'            => $item_id,
+			'title'              => (string) ( $data['title'] ?? '' ),
+			'reddit_permalink'   => (string) ( $item['source_url'] ?? '' ),
+			'matched_target_url' => $matched_url,
+			'matched_host'       => $matched_host,
+			'author'             => $author,
+			'subreddit'          => (string) ( $metadata['subreddit'] ?? '' ),
+			'timestamp'          => $timestamp,
+			'score'              => (int) ( $metadata['upvotes'] ?? 0 ),
+			'comment_count'      => (int) ( $metadata['comment_count'] ?? 0 ),
+			'match_type'         => $match_type,
+			'ownership'          => in_array( strtolower( $author ), $owners, true ) ? 'owned' : 'organic',
+		);
+	}
+
+	private static function matchingHost( string $url, string $domain ): string {
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		return self::hostMatches( $host, $domain ) ? $host : '';
+	}
+
+	private static function hostMatches( string $host, string $domain ): bool {
+		return $host === $domain || str_ends_with( $host, '.' . $domain );
+	}
+
+	/**
+	 * @return array{url:string,host:string}|null
+	 */
+	private static function findTextMatch( string $text, string $domain ): ?array {
+		$text = html_entity_decode( $text );
+		if ( preg_match_all( '#https?://[^\s<>\]\[()"\']+#i', $text, $matches ) ) {
+			foreach ( $matches[0] as $url ) {
+				$url  = rtrim( $url, '.,;:!?' );
+				$host = self::matchingHost( $url, $domain );
+				if ( $host ) {
+					return array(
+						'url'  => $url,
+						'host' => $host,
+					);
+				}
+			}
+		}
+
+		$quoted_domain = preg_quote( $domain, '/' );
+		if ( preg_match( '/(?<![a-z0-9.-])((?:[a-z0-9-]+\.)*' . $quoted_domain . ')(?![a-z0-9.-])/i', $text, $match ) ) {
+			return array(
+				'url'  => '',
+				'host' => strtolower( $match[1] ),
+			);
+		}
+
+		return null;
+	}
+
+	private static function buildReport( string $domain, array $owners, array $rows, bool $truncated, int $limit, int $max_pages ): array {
+		$owned = count( array_filter( $rows, static fn( array $row ): bool => 'owned' === $row['ownership'] ) );
+
+		return array(
+			'domain'     => $domain,
+			'owners'     => $owners,
+			'totals'     => array(
+				'total'   => count( $rows ),
+				'owned'   => $owned,
+				'organic' => count( $rows ) - $owned,
+			),
+			'breakdowns' => array(
+				'author'       => self::breakdown( $rows, 'author' ),
+				'subreddit'    => self::breakdown( $rows, 'subreddit' ),
+				'matched_host' => self::breakdown( $rows, 'matched_host' ),
+				'date'         => self::dateBreakdown( $rows, 'Y-m-d' ),
+				'year'         => self::dateBreakdown( $rows, 'Y' ),
+			),
+			'rows'       => $rows,
+			'truncated'  => $truncated,
+			'limits'     => array(
+				'rows'            => $limit,
+				'pages_per_query' => $max_pages,
+				'query_variants'  => 2,
+			),
+			'coverage'   => 'Reddit post search results only; comments are not searched.',
+		);
+	}
+
+	private static function breakdown( array $rows, string $key ): array {
+		$counts = array_count_values( array_map( static fn( array $row ): string => (string) $row[ $key ], $rows ) );
+		arsort( $counts );
+		return $counts;
+	}
+
+	private static function dateBreakdown( array $rows, string $format ): array {
+		$values = array();
+		foreach ( $rows as $row ) {
+			$timestamp = strtotime( $row['timestamp'] );
+			if ( false !== $timestamp ) {
+				$values[] = gmdate( $format, $timestamp );
+			}
+		}
+		$counts = array_count_values( $values );
+		krsort( $counts );
+		return $counts;
+	}
+}

--- a/inc/Abilities/Reddit/RedditDomainMentionsAbility.php
+++ b/inc/Abilities/Reddit/RedditDomainMentionsAbility.php
@@ -34,15 +34,11 @@ class RedditDomainMentionsAbility extends AbstractSocialAbility {
 					'category'            => 'datamachine-socials',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'domain', 'access_token' ),
+						'required'   => array( 'domain' ),
 						'properties' => array(
 							'domain'          => array(
 								'type'        => 'string',
 								'description' => __( 'Domain or root URL to report.', 'data-machine-socials' ),
-							),
-							'access_token'    => array(
-								'type'        => 'string',
-								'description' => __( 'Reddit OAuth access token.', 'data-machine-socials' ),
 							),
 							'owners'          => array(
 								'type'        => 'array',
@@ -73,9 +69,10 @@ class RedditDomainMentionsAbility extends AbstractSocialAbility {
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
+						'required'   => array( 'success', 'report' ),
 						'properties' => array(
 							'success' => array( 'type' => 'boolean' ),
-							'report'  => array( 'type' => 'object' ),
+							'report'  => self::reportSchema(),
 							'error'   => array( 'type' => 'string' ),
 						),
 					),
@@ -91,6 +88,83 @@ class RedditDomainMentionsAbility extends AbstractSocialAbility {
 		return PermissionHelper::can( 'use_tools' );
 	}
 
+	private static function reportSchema(): array {
+		$count_map = array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'integer' ),
+		);
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'domain', 'owners', 'totals', 'breakdowns', 'rows', 'truncated', 'limits', 'coverage' ),
+			'properties' => array(
+				'domain'     => array( 'type' => 'string' ),
+				'owners'     => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'totals'     => array(
+					'type'       => 'object',
+					'required'   => array( 'total', 'owned', 'organic' ),
+					'properties' => array(
+						'total'   => array( 'type' => 'integer' ),
+						'owned'   => array( 'type' => 'integer' ),
+						'organic' => array( 'type' => 'integer' ),
+					),
+				),
+				'breakdowns' => array(
+					'type'       => 'object',
+					'required'   => array( 'author', 'subreddit', 'matched_host', 'date', 'year' ),
+					'properties' => array(
+						'author'       => $count_map,
+						'subreddit'    => $count_map,
+						'matched_host' => $count_map,
+						'date'         => $count_map,
+						'year'         => $count_map,
+					),
+				),
+				'rows'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'required'   => array( 'item_id', 'title', 'reddit_permalink', 'matched_target_url', 'matched_host', 'author', 'subreddit', 'timestamp', 'score', 'comment_count', 'match_type', 'ownership' ),
+						'properties' => array(
+							'item_id'            => array( 'type' => 'string' ),
+							'title'              => array( 'type' => 'string' ),
+							'reddit_permalink'   => array( 'type' => 'string' ),
+							'matched_target_url' => array( 'type' => 'string' ),
+							'matched_host'       => array( 'type' => 'string' ),
+							'author'             => array( 'type' => 'string' ),
+							'subreddit'          => array( 'type' => 'string' ),
+							'timestamp'          => array( 'type' => 'string' ),
+							'score'              => array( 'type' => 'integer' ),
+							'comment_count'      => array( 'type' => 'integer' ),
+							'match_type'         => array(
+								'type' => 'string',
+								'enum' => array( 'direct_link', 'self_text' ),
+							),
+							'ownership'          => array(
+								'type' => 'string',
+								'enum' => array( 'owned', 'organic' ),
+							),
+						),
+					),
+				),
+				'truncated'  => array( 'type' => 'boolean' ),
+				'limits'     => array(
+					'type'       => 'object',
+					'required'   => array( 'rows', 'pages_per_query', 'query_variants' ),
+					'properties' => array(
+						'rows'            => array( 'type' => 'integer' ),
+						'pages_per_query' => array( 'type' => 'integer' ),
+						'query_variants'  => array( 'type' => 'integer' ),
+					),
+				),
+				'coverage'   => array( 'type' => 'string' ),
+			),
+		);
+	}
+
 	/**
 	 * Execute the report by composing the existing Reddit fetch ability.
 	 *
@@ -103,10 +177,16 @@ class RedditDomainMentionsAbility extends AbstractSocialAbility {
 			return $domain;
 		}
 
-		$access_token = trim( (string) ( $input['access_token'] ?? '' ) );
-		if ( '' === $access_token ) {
-			return new \WP_Error( 'missing_param', 'A Reddit access token is required', array( 'status' => 400 ) );
+		$provider = $this->resolveProvider( 'reddit', 'Reddit' );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
 		}
+
+		$access_token = $provider->get_valid_access_token();
+		if ( ! is_string( $access_token ) || '' === trim( $access_token ) ) {
+			return new \WP_Error( 'missing_auth', 'Reddit access token expired and refresh failed', array( 'status' => 401 ) );
+		}
+		$access_token = trim( $access_token );
 
 		$owners = self::normalizeOwners( $input['owners'] ?? array() );
 		if ( is_wp_error( $owners ) ) {

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -651,7 +651,7 @@ class RedditCommand {
 	 * : Domain or root URL to report.
 	 *
 	 * [--owner=<username>]
-	 * : Known owner username. Repeat the option or use comma-separated values.
+	 * : Known owner usernames as a comma-separated list.
 	 *
 	 * [--timeframe=<timeframe>]
 	 * : Fetch timeframe (all_time, 24_hours, 72_hours, 7_days, 30_days, 90_days, 6_months, 1_year).
@@ -702,7 +702,6 @@ class RedditCommand {
 		$result = $ability->execute(
 			array(
 				'domain'          => $domain,
-				'access_token'    => $this->get_access_token(),
 				'owners'          => $owners,
 				'timeframe_limit' => $assoc_args['timeframe'] ?? 'all_time',
 				'limit'           => $limit,

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -53,6 +53,9 @@ defined( 'ABSPATH' ) || exit;
  *
  *     # Upvote a post
  *     wp datamachine-socials reddit vote t3_abc123 --up
+ *
+ *     # Report posts that mention a domain
+ *     wp datamachine-socials reddit mentions example.com --owner=example_user
  */
 class RedditCommand {
 
@@ -634,6 +637,139 @@ class RedditCommand {
 
 		WP_CLI::success( count( $rows ) . ' posts found' );
 		WP_CLI\Utils\format_items( 'table', $rows, array( 'score', 'comments', 'subreddit', 'author', 'title' ) );
+	}
+
+	/**
+	 * Report Reddit posts that link to or mention a domain.
+	 *
+	 * The report uses Reddit post search and does not claim comment coverage.
+	 * Owner usernames classify rows as owned; every other author is organic.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <domain>
+	 * : Domain or root URL to report.
+	 *
+	 * [--owner=<username>]
+	 * : Known owner username. Repeat the option or use comma-separated values.
+	 *
+	 * [--timeframe=<timeframe>]
+	 * : Fetch timeframe (all_time, 24_hours, 72_hours, 7_days, 30_days, 90_days, 6_months, 1_year).
+	 * ---
+	 * default: all_time
+	 * ---
+	 *
+	 * [--limit=<count>]
+	 * : Maximum deduplicated rows (1-500).
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * [--max-pages=<count>]
+	 * : Maximum Reddit pages fetched per query variant (1-10).
+	 * ---
+	 * default: 5
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit mentions example.com
+	 *     wp datamachine-socials reddit mentions https://example.com/ --owner=account_one,account_two --format=json
+	 *
+	 * @subcommand mentions
+	 */
+	public function mentions( $args, $assoc_args ) {
+		$domain    = $args[0] ?? '';
+		$format    = $assoc_args['format'] ?? 'table';
+		$limit     = $this->parseBoundedInteger( $assoc_args['limit'] ?? '100', '--limit', 1, 500 );
+		$max_pages = $this->parseBoundedInteger( $assoc_args['max-pages'] ?? '5', '--max-pages', 1, 10 );
+		$owners    = $this->parseOwners( $assoc_args['owner'] ?? array() );
+
+		$ability = wp_get_ability( 'datamachine/reddit-domain-mentions' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/reddit-domain-mentions ability not registered.' );
+		}
+
+		$result = $ability->execute(
+			array(
+				'domain'          => $domain,
+				'access_token'    => $this->get_access_token(),
+				'owners'          => $owners,
+				'timeframe_limit' => $assoc_args['timeframe'] ?? 'all_time',
+				'limit'           => $limit,
+				'max_pages'       => $max_pages,
+			)
+		);
+
+		if ( is_wp_error( $result ) || empty( $result['success'] ) ) {
+			WP_CLI::error( is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? 'Reddit domain mentions report failed.' ) );
+		}
+
+		$report = $result['report'];
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Domain: %s', $report['domain'] ) );
+		WP_CLI::log( sprintf( 'Total: %d | Owned: %d | Organic: %d', $report['totals']['total'], $report['totals']['owned'], $report['totals']['organic'] ) );
+		WP_CLI::log( 'Truncated: ' . ( $report['truncated'] ? 'yes' : 'no' ) );
+		WP_CLI::log( $report['coverage'] );
+
+		$rows = array_map(
+			static function ( array $row ): array {
+				return array(
+					'date'       => substr( $row['timestamp'], 0, 10 ),
+					'ownership'  => $row['ownership'],
+					'type'       => $row['match_type'],
+					'author'     => $row['author'],
+					'subreddit'  => 'r/' . $row['subreddit'],
+					'host'       => $row['matched_host'],
+					'score'      => $row['score'],
+					'comments'   => $row['comment_count'],
+					'title'      => mb_substr( $row['title'], 0, 55 ),
+					'target_url' => $row['matched_target_url'],
+					'permalink'  => $row['reddit_permalink'],
+				);
+			},
+			$report['rows']
+		);
+
+		if ( empty( $rows ) ) {
+			WP_CLI::warning( 'No matching Reddit posts found.' );
+			return;
+		}
+
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'date', 'ownership', 'type', 'author', 'subreddit', 'host', 'score', 'comments', 'title', 'target_url', 'permalink' ) );
+	}
+
+	private function parseOwners( mixed $input ): array {
+		$values = is_array( $input ) ? $input : array( $input );
+		$owners = array();
+		foreach ( $values as $value ) {
+			$owners = array_merge( $owners, array_map( 'trim', explode( ',', (string) $value ) ) );
+		}
+		return array_values( array_filter( $owners, static fn( string $owner ): bool => '' !== $owner ) );
+	}
+
+	private function parseBoundedInteger( mixed $input, string $option, int $minimum, int $maximum ): int {
+		if ( ! is_scalar( $input ) || ! preg_match( '/^[1-9][0-9]*$/', (string) $input ) ) {
+			WP_CLI::error( sprintf( '%s must be a whole number between %d and %d.', $option, $minimum, $maximum ) );
+		}
+		$value = (int) $input;
+		if ( $value < $minimum || $value > $maximum ) {
+			WP_CLI::error( sprintf( '%s must be a whole number between %d and %d.', $option, $minimum, $maximum ) );
+		}
+		return $value;
 	}
 
 	/**

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -357,25 +357,7 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 					'posts' => array(),
 				);
 
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
-						array(
-							'data' => array(
-								'after'    => $page['after'],
-								'children' => array_map(
-									static function ( array $post ): array {
-										return array(
-											'kind' => 't3',
-											'data' => $post,
-										);
-									},
-									$page['posts']
-								),
-							),
-						)
-					),
-				);
+				return self::redditListingResponse( $page['after'], $page['posts'] );
 			},
 			10,
 			3

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -116,6 +116,7 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( array( 'first', 'second' ), array_column( $result['items'], 'item_id' ) );
 		$this->assertSame( 1, $request_count );
+		$this->assertTrue( $result['pagination']['truncated'] );
 	}
 
 	public function test_direct_limit_returns_fewer_items_when_source_is_exhausted(): void {
@@ -132,6 +133,7 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( array( 'only' ), array_column( $result['items'], 'item_id' ) );
+		$this->assertFalse( $result['pagination']['truncated'] );
 	}
 
 	public function test_direct_limit_does_not_override_collector_authority(): void {

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -245,32 +245,22 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 			static function () use ( &$request_count ): array {
 				++$request_count;
 				if ( 1 === $request_count ) {
-					return array(
-						'response' => array( 'code' => 200 ),
-						'body'     => wp_json_encode(
+					return self::redditListingResponse(
+						'page-2',
+						array(
 							array(
-								'data' => array(
-									'after'    => 'page-2',
-									'children' => array(
-										array(
-											'kind' => 't3',
-											'data' => array(
-												'id'           => 'first',
-												'title'        => 'First post',
-												'selftext'     => '',
-												'created_utc'  => time(),
-												'score'        => 1,
-												'num_comments' => 0,
-												'permalink'    => '/r/WordPress/comments/first/',
-												'subreddit'    => 'WordPress',
-												'author'       => 'reddit_user',
-												'is_self'      => true,
-											),
-										),
-									),
-								),
-							)
-						),
+								'id'           => 'first',
+								'title'        => 'First post',
+								'selftext'     => '',
+								'created_utc'  => time(),
+								'score'        => 1,
+								'num_comments' => 0,
+								'permalink'    => '/r/WordPress/comments/first/',
+								'subreddit'    => 'WordPress',
+								'author'       => 'reddit_user',
+								'is_self'      => true,
+							),
+						)
 					);
 				}
 
@@ -302,17 +292,7 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 			static function ( $preempt, $args, $url ) use ( &$request_url ) {
 				$request_url = $url;
 
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
-						array(
-							'data' => array(
-								'after'    => null,
-								'children' => array(),
-							),
-						)
-					),
-				);
+				return self::redditListingResponse( null, array() );
 			},
 			10,
 			3
@@ -417,6 +397,29 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 			},
 			10,
 			3
+		);
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $posts
+	 */
+	private static function redditListingResponse( ?string $after, array $posts ): array {
+		return array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode(
+				array(
+					'data' => array(
+						'after'    => $after,
+						'children' => array_map(
+							static fn( array $post ): array => array(
+								'kind' => 't3',
+								'data' => $post,
+							),
+							$posts
+						),
+					),
+				)
+			),
 		);
 	}
 

--- a/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/FetchRedditAbilityTest.php
@@ -17,6 +17,18 @@ use WP_UnitTestCase;
 
 class FetchRedditAbilityTest extends WP_UnitTestCase {
 
+	public function test_registered_output_schema_describes_items_pagination_and_target_url(): void {
+		new FetchRedditAbility();
+		$ability = wp_get_ability( 'datamachine/fetch-reddit' );
+
+		$this->assertNotNull( $ability );
+		$schema = $ability->get_output_schema();
+		$this->assertContains( 'pagination', $schema['required'] );
+		$this->assertArrayHasKey( 'items', $schema['properties'] );
+		$this->assertArrayHasKey( 'pagination', $schema['properties'] );
+		$this->assertContains( 'target_url', $schema['properties']['items']['items']['properties']['data']['properties']['metadata']['required'] );
+	}
+
 	public function tear_down(): void {
 		remove_all_filters( 'pre_http_request' );
 		parent::tear_down();
@@ -224,6 +236,59 @@ class FetchRedditAbilityTest extends WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertSame( 'Reddit API request failed: Connection timed out', $result->get_error_message() );
 		$this->assertSame( 'http_request_failed', $result->get_error_data()['upstream_code'] );
+	}
+
+	public function test_invalid_json_after_a_successful_page_marks_results_truncated(): void {
+		$request_count = 0;
+		add_filter(
+			'pre_http_request',
+			static function () use ( &$request_count ): array {
+				++$request_count;
+				if ( 1 === $request_count ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode(
+							array(
+								'data' => array(
+									'after'    => 'page-2',
+									'children' => array(
+										array(
+											'kind' => 't3',
+											'data' => array(
+												'id'           => 'first',
+												'title'        => 'First post',
+												'selftext'     => '',
+												'created_utc'  => time(),
+												'score'        => 1,
+												'num_comments' => 0,
+												'permalink'    => '/r/WordPress/comments/first/',
+												'subreddit'    => 'WordPress',
+												'author'       => 'reddit_user',
+												'is_self'      => true,
+											),
+										),
+									),
+								),
+							)
+						),
+					);
+				}
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{invalid-json',
+				);
+			},
+			10,
+			3
+		);
+
+		$result = ( new FetchRedditAbility() )->execute( $this->fetchInput() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'first' ), array_column( $result['items'], 'item_id' ) );
+		$this->assertSame( 2, $result['pagination']['pages_fetched'] );
+		$this->assertTrue( $result['pagination']['truncated'] );
 	}
 
 	/**

--- a/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
@@ -17,6 +17,22 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	public function test_registered_contract_keeps_oauth_server_side_and_describes_report_rows(): void {
+		new RedditDomainMentionsAbility();
+		$ability = wp_get_ability( 'datamachine/reddit-domain-mentions' );
+
+		$this->assertNotNull( $ability );
+		$input_schema = $ability->get_input_schema();
+		$this->assertSame( array( 'domain' ), $input_schema['required'] );
+		$this->assertArrayNotHasKey( 'access_token', $input_schema['properties'] );
+
+		$output_schema = $ability->get_output_schema();
+		$this->assertSame( array( 'success', 'report' ), $output_schema['required'] );
+		$row_schema = $output_schema['properties']['report']['properties']['rows']['items'];
+		$this->assertContains( 'matched_target_url', $row_schema['required'] );
+		$this->assertContains( 'ownership', $row_schema['required'] );
+	}
+
 	public function test_reports_direct_and_self_text_mentions_with_dedupe_owners_and_subdomains(): void {
 		$this->mockSearches(
 			array(
@@ -54,12 +70,11 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = ( new RedditDomainMentionsAbility() )->execute(
+		$result = $this->ability()->execute(
 			array(
-				'domain'       => 'https://Example.org/',
-				'access_token' => 'reddit-token',
-				'owners'       => array( 'u/own_user' ),
-				'limit'        => 10,
+				'domain' => 'https://Example.org/',
+				'owners' => array( 'u/own_user' ),
+				'limit'  => 10,
 			)
 		);
 
@@ -85,7 +100,7 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input() );
+		$result = $this->ability()->execute( $this->input() );
 
 		$this->assertSame( 1, $result['report']['totals']['total'] );
 		$this->assertSame( 'guides.example.org', $result['report']['rows'][0]['matched_host'] );
@@ -100,7 +115,7 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input() );
+		$result = $this->ability()->execute( $this->input() );
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( array( 'total' => 0, 'owned' => 0, 'organic' => 0 ), $result['report']['totals'] );
@@ -112,10 +127,9 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 	 * @dataProvider malformedDomainProvider
 	 */
 	public function test_rejects_malformed_domains( string $domain ): void {
-		$result = ( new RedditDomainMentionsAbility() )->execute(
+		$result = $this->ability()->execute(
 			array(
-				'domain'       => $domain,
-				'access_token' => 'reddit-token',
+				'domain' => $domain,
 			)
 		);
 
@@ -151,7 +165,7 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input( array( 'limit' => 1 ) ) );
+		$result = $this->ability()->execute( $this->input( array( 'limit' => 1 ) ) );
 
 		$this->assertSame( 1, $result['report']['totals']['total'] );
 		$this->assertTrue( $result['report']['truncated'] );
@@ -193,12 +207,32 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 	private function input( array $overrides = array() ): array {
 		return array_merge(
 			array(
-				'domain'       => 'example.org',
-				'access_token' => 'reddit-token',
-				'limit'        => 10,
+				'domain' => 'example.org',
+				'limit'  => 10,
 			),
 			$overrides
 		);
+	}
+
+	private function ability(): RedditDomainMentionsAbility {
+		$provider = new class() {
+			public function get_valid_access_token(): string {
+				return 'reddit-token';
+			}
+		};
+
+		return new class( $provider ) extends RedditDomainMentionsAbility {
+			private object $provider;
+
+			public function __construct( object $provider ) {
+				$this->provider = $provider;
+				parent::__construct();
+			}
+
+			protected function resolveProvider( string $platform, string $label, bool $require_authenticated = true ) {
+				return $this->provider;
+			}
+		};
 	}
 
 	private function redditPost( string $id, array $overrides = array() ): array {

--- a/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
@@ -34,27 +34,20 @@ class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
 	}
 
 	public function test_reports_direct_and_self_text_mentions_with_dedupe_owners_and_subdomains(): void {
+		$direct_post = $this->redditPost(
+			'direct-1',
+			array(
+				'author'  => 'Own_User',
+				'is_self' => false,
+				'url'     => 'https://news.example.org/story',
+			)
+		);
+
 		$this->mockSearches(
 			array(
-				'url:example.org' => array(
-					$this->redditPost(
-						'direct-1',
-						array(
-							'author'  => 'Own_User',
-							'is_self' => false,
-							'url'     => 'https://news.example.org/story',
-						)
-					),
-				),
+				'url:example.org' => array( $direct_post ),
 				'example.org'     => array(
-					$this->redditPost(
-						'direct-1',
-						array(
-							'author'  => 'Own_User',
-							'is_self' => false,
-							'url'     => 'https://news.example.org/story',
-						)
-					),
+					$direct_post,
 					$this->redditPost(
 						'text-1',
 						array(

--- a/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/RedditDomainMentionsAbilityTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * RedditDomainMentionsAbility tests.
+ *
+ * @package DataMachineSocials\Tests\Unit\Abilities\Reddit
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities\Reddit;
+
+use DataMachineSocials\Abilities\Reddit\RedditDomainMentionsAbility;
+use WP_UnitTestCase;
+
+class RedditDomainMentionsAbilityTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	public function test_reports_direct_and_self_text_mentions_with_dedupe_owners_and_subdomains(): void {
+		$this->mockSearches(
+			array(
+				'url:example.org' => array(
+					$this->redditPost(
+						'direct-1',
+						array(
+							'author'  => 'Own_User',
+							'is_self' => false,
+							'url'     => 'https://news.example.org/story',
+						)
+					),
+				),
+				'example.org'     => array(
+					$this->redditPost(
+						'direct-1',
+						array(
+							'author'  => 'Own_User',
+							'is_self' => false,
+							'url'     => 'https://news.example.org/story',
+						)
+					),
+					$this->redditPost(
+						'text-1',
+						array(
+							'author'   => 'community_member',
+							'selftext' => 'Calendar: https://events.example.org/upcoming',
+						)
+					),
+					$this->redditPost(
+						'lookalike',
+						array( 'selftext' => 'Not a match: https://example.org.evil.test/page' )
+					),
+				),
+			)
+		);
+
+		$result = ( new RedditDomainMentionsAbility() )->execute(
+			array(
+				'domain'       => 'https://Example.org/',
+				'access_token' => 'reddit-token',
+				'owners'       => array( 'u/own_user' ),
+				'limit'        => 10,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$report = $result['report'];
+		$this->assertSame( 'example.org', $report['domain'] );
+		$this->assertSame( array( 'total' => 2, 'owned' => 1, 'organic' => 1 ), $report['totals'] );
+		$this->assertSame( array( 'news.example.org' => 1, 'events.example.org' => 1 ), $report['breakdowns']['matched_host'] );
+		$this->assertSame( array( 'direct-1', 'text-1' ), array_column( $report['rows'], 'item_id' ) );
+		$this->assertSame( array( 'direct_link', 'self_text' ), array_column( $report['rows'], 'match_type' ) );
+		$this->assertSame( 'https://news.example.org/story', $report['rows'][0]['matched_target_url'] );
+		$this->assertSame( 'https://events.example.org/upcoming', $report['rows'][1]['matched_target_url'] );
+		$this->assertFalse( $report['truncated'] );
+	}
+
+	public function test_matches_bare_domain_in_self_text(): void {
+		$this->mockSearches(
+			array(
+				'url:example.org' => array(),
+				'example.org'     => array(
+					$this->redditPost( 'bare', array( 'selftext' => 'Browse guides.example.org for details.' ) ),
+				),
+			)
+		);
+
+		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input() );
+
+		$this->assertSame( 1, $result['report']['totals']['total'] );
+		$this->assertSame( 'guides.example.org', $result['report']['rows'][0]['matched_host'] );
+		$this->assertSame( '', $result['report']['rows'][0]['matched_target_url'] );
+	}
+
+	public function test_empty_searches_return_an_empty_report(): void {
+		$this->mockSearches(
+			array(
+				'url:example.org' => array(),
+				'example.org'     => array(),
+			)
+		);
+
+		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'total' => 0, 'owned' => 0, 'organic' => 0 ), $result['report']['totals'] );
+		$this->assertSame( array(), $result['report']['rows'] );
+		$this->assertFalse( $result['report']['truncated'] );
+	}
+
+	/**
+	 * @dataProvider malformedDomainProvider
+	 */
+	public function test_rejects_malformed_domains( string $domain ): void {
+		$result = ( new RedditDomainMentionsAbility() )->execute(
+			array(
+				'domain'       => $domain,
+				'access_token' => 'reddit-token',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_domain', $result->get_error_code() );
+	}
+
+	public function malformedDomainProvider(): array {
+		return array(
+			'path'        => array( 'example.org/articles' ),
+			'credentials' => array( 'https://user:pass@example.org/' ),
+			'query'       => array( 'https://example.org/?source=reddit' ),
+			'port'        => array( 'example.org:8080' ),
+			'not public'  => array( 'localhost' ),
+		);
+	}
+
+	public function test_marks_report_truncated_when_deduplicated_rows_exceed_the_limit(): void {
+		$this->mockSearches(
+			array(
+				'url:example.org' => array(
+					$this->redditPost(
+						'direct-1',
+						array(
+							'is_self' => false,
+							'url'     => 'https://example.org/story',
+						)
+					),
+				),
+				'example.org'     => array(
+					$this->redditPost( 'text-1', array( 'selftext' => 'Read example.org for more.' ) ),
+				),
+			)
+		);
+
+		$result = ( new RedditDomainMentionsAbility() )->execute( $this->input( array( 'limit' => 1 ) ) );
+
+		$this->assertSame( 1, $result['report']['totals']['total'] );
+		$this->assertTrue( $result['report']['truncated'] );
+	}
+
+	/**
+	 * @param array<string,array<int,array<string,mixed>>> $searches
+	 */
+	private function mockSearches( array $searches ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $searches ): array {
+				parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $params );
+				$posts = $searches[ $params['q'] ?? '' ] ?? array();
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'data' => array(
+								'after'    => null,
+								'children' => array_map(
+									static fn( array $post ): array => array(
+										'kind' => 't3',
+										'data' => $post,
+									),
+									$posts
+								),
+							),
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	private function input( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'domain'       => 'example.org',
+				'access_token' => 'reddit-token',
+				'limit'        => 10,
+			),
+			$overrides
+		);
+	}
+
+	private function redditPost( string $id, array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'           => $id,
+				'title'        => 'Post ' . $id,
+				'selftext'     => '',
+				'created_utc'  => 1704067200,
+				'score'        => 10,
+				'num_comments' => 3,
+				'permalink'    => '/r/testing/comments/' . $id . '/',
+				'url'          => 'https://www.reddit.com/r/testing/comments/' . $id . '/',
+				'subreddit'    => 'testing',
+				'author'       => 'reddit_user',
+				'is_self'      => true,
+			),
+			$overrides
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add the read-only `datamachine/reddit-domain-mentions` ability and `wp datamachine-socials reddit mentions <domain>` CLI report
- validate domains, compose bounded direct-link and self-text Reddit searches, deduplicate by item ID, and classify owned versus organic posts
- return rows plus totals and author, subreddit, matched-host, date, and year breakdowns with explicit truncation and post-search-only coverage

## Contracts

Ability: `datamachine/reddit-domain-mentions`

Inputs:
- required `domain` and `access_token`
- optional `owners` username array
- optional `timeframe_limit` (default `all_time`)
- optional `limit` from 1 to 500 (default 100)
- optional `max_pages` from 1 to 10 per query variant (default 5)

Output: `{ success, report }`, where `report` contains normalized `domain`, `owners`, `totals`, `breakdowns`, `rows`, `truncated`, `limits`, and `coverage`. Rows include Reddit item ID, title, Reddit permalink, matched target URL and host, author, subreddit, UTC timestamp, score, comment count, match type, and ownership.

CLI:

```text
wp datamachine-socials reddit mentions <domain> \
  [--owner=<username>] \
  [--timeframe=<timeframe>] \
  [--limit=<1-500>] \
  [--max-pages=<1-10>] \
  [--format=table|json]
```

`--owner` accepts repeated and comma-separated values. Table output includes the summary, coverage/truncation state, and report rows; JSON emits the complete report.

## Design

The report composes the existing `datamachine/fetch-reddit` ability for OAuth, HTTP, Reddit global-search pagination, timeframe handling, and post normalization. It only adds the normalized outbound target URL and pagination truncation evidence needed by this report; it does not add another Reddit client, auth wrapper, storage model, or use `SocialShareTracker` for organic discovery.

Owner matching is case-insensitive. A row is `owned` when its author matches a supplied owner username; every other author is `organic`. Direct outbound URLs are `direct_link`; only text from Reddit self-posts can become `self_text`. Every returned host is locally checked as the requested domain or a true subdomain, excluding lookalikes.

## Coverage and limits

This uses Reddit's authenticated post search with `url:<domain>` and plain-domain query variants. Results are limited by Reddit search indexing and ranking and by the requested row/page budgets. Duplicate query results collapse by Reddit item ID. `truncated` is set when Reddit pagination, a partial later-page response, or the final deduplicated row cap prevents a complete bounded scan.

This does not provide global comment coverage. That separate bounded gap is tracked in #211.

## Verification

- `homeboy review lint --changed-only`: passed PHPCS and PHPStan level 7; zero errors, with one pre-existing `urlencode()` warning in `FetchRedditAbility.php`
- `homeboy review audit --profile pr --changed-since origin/main`: passed with no introduced findings (run `41c81068-28f4-4708-87b9-354fbb41be62`)
- `php -l` on all six changed PHP files: passed
- `git diff --check`: passed
- `npm run build`: passed (`wp-scripts build`, webpack compiled successfully)
- managed PHPUnit run `1851c6df-2ec1-4f32-8fd8-d8d69f032df8` selected 25 tests, including `FetchRedditAbilityTest` and `RedditDomainMentionsAbilityTest`, but the WP Codebox harness reported 0 executed tests after five minutes; a focused retry also produced no PHPUnit result beyond dependency resolution. No assertion failure was reported. Focused tests are included for direct links, self-text and bare-domain matches, dedupe, owner separation, subdomains/lookalikes, empty responses, malformed domains, and truncation.
- Homeboy's wrapper build was blocked by a missing installed helper at `extensions/nodejs/scripts/lib/local-workspace-deps.sh`; the underlying repository build passed directly as noted above

Closes #212