### PR TITLE
feat: monitor bounded Reddit comment mentions

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -132,6 +132,7 @@ function datamachine_socials_bootstrap() {
 
 	// Reddit
 	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
+	new \DataMachineSocials\Abilities\Reddit\RedditCommentDomainMonitorAbility();
 	new \DataMachineSocials\Abilities\Reddit\ReplyRedditAbility();
 	new \DataMachineSocials\Abilities\Reddit\SubmitRedditAbility();
 	new \DataMachineSocials\Abilities\Reddit\VoteRedditAbility();
@@ -213,6 +214,9 @@ add_action( 'plugins_loaded', 'datamachine_socials_register_agents_md_section', 
 
 // Temp file cleanup runs independently (doesn't need DM core)
 \DataMachineSocials\Cleanup::register();
+\DataMachineSocials\Tracking\RedditCommentDomainStore::register();
+
+register_deactivation_hook( __FILE__, array( \DataMachineSocials\Tracking\RedditCommentDomainStore::class, 'deactivate' ) );
 
 /**
  * Enqueue Gutenberg sidebar assets

--- a/inc/Abilities/Reddit/RedditCommentDomainMonitorAbility.php
+++ b/inc/Abilities/Reddit/RedditCommentDomainMonitorAbility.php
@@ -1,0 +1,722 @@
+<?php
+/**
+ * Bounded incremental Reddit comment-domain monitoring ability.
+ *
+ * @package DataMachineSocials
+ * @subpackage Abilities\Reddit
+ */
+
+namespace DataMachineSocials\Abilities\Reddit;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachineSocials\Abilities\AbstractSocialAbility;
+use DataMachineSocials\Tracking\RedditCommentDomainStore;
+use DataMachineSocials\Tracking\RedditCommentUrlMatcher;
+
+defined( 'ABSPATH' ) || exit;
+
+class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
+
+	protected static bool $registered = false;
+
+	public function __construct() {
+		$this->registerAbility( $this->registerCallback(), true );
+	}
+
+	private function registerCallback(): callable {
+		return function (): void {
+			wp_register_ability(
+				'datamachine/reddit-comment-mentions-poll',
+				array(
+					'label'               => __( 'Poll Reddit Comment Mentions', 'data-machine-socials' ),
+					'description'         => __( 'Poll explicitly bounded subreddit comment listings and persist matching domain observations. This mutates checkpoints and retained observations.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'required'             => array( 'domains', 'subreddits' ),
+						'additionalProperties' => false,
+						'properties'           => array(
+							'domains'            => array(
+								'type'        => 'array',
+								'minItems'    => 1,
+								'maxItems'    => 25,
+								'uniqueItems' => true,
+								'items'       => array(
+									'type'      => 'string',
+									'minLength' => 4,
+									'maxLength' => 253,
+								),
+							),
+							'subreddits'         => array(
+								'type'        => 'array',
+								'minItems'    => 1,
+								'maxItems'    => 25,
+								'uniqueItems' => true,
+								'items'       => array(
+									'type'      => 'string',
+									'minLength' => 2,
+									'maxLength' => 24,
+								),
+							),
+							'include_subdomains' => array(
+								'type'    => 'boolean',
+								'default' => false,
+							),
+							'known_owners'       => array(
+								'type'        => 'array',
+								'maxItems'    => 100,
+								'uniqueItems' => true,
+								'items'       => array(
+									'type'      => 'string',
+									'minLength' => 3,
+									'maxLength' => 23,
+								),
+							),
+							'page_size'          => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+								'maximum' => 100,
+								'default' => 100,
+							),
+							'max_pages'          => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+								'maximum' => 10,
+								'default' => 5,
+							),
+						),
+					),
+					'output_schema'       => $this->pollOutputSchema(),
+					'execute_callback'    => array( $this, 'executePoll' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/reddit-comment-mentions-report',
+				array(
+					'label'               => __( 'Report Reddit Comment Mentions', 'data-machine-socials' ),
+					'description'         => __( 'Read retained observations from explicitly monitored subreddit comment listings, with bounded coverage metadata.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => array(
+							'domain'       => array(
+								'type'      => 'string',
+								'maxLength' => 253,
+							),
+							'subreddit'    => array(
+								'type'      => 'string',
+								'maxLength' => 24,
+							),
+							'date_from'    => array(
+								'type'      => 'string',
+								'maxLength' => 32,
+							),
+							'date_to'      => array(
+								'type'      => 'string',
+								'maxLength' => 32,
+							),
+							'ownership'    => array(
+								'type'    => 'string',
+								'enum'    => array( 'all', 'known_owner', 'organic' ),
+								'default' => 'all',
+							),
+							'known_owners' => array(
+								'type'        => 'array',
+								'maxItems'    => 100,
+								'uniqueItems' => true,
+								'items'       => array(
+									'type'      => 'string',
+									'minLength' => 3,
+									'maxLength' => 23,
+								),
+							),
+							'min_score'    => array( 'type' => 'integer' ),
+							'limit'        => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+								'maximum' => 500,
+								'default' => 100,
+							),
+						),
+					),
+					'output_schema'       => $this->reportOutputSchema(),
+					'execute_callback'    => array( $this, 'executeReport' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/reddit-comment-mentions-cleanup',
+				array(
+					'label'               => __( 'Clean Up Reddit Comment Mentions', 'data-machine-socials' ),
+					'description'         => __( 'Delete expired Reddit comment observations and enforce the hard site-local record cap.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => array(),
+					),
+					'output_schema'       => $this->cleanupOutputSchema(),
+					'execute_callback'    => array( $this, 'executeCleanup' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => true,
+						),
+					),
+				)
+			);
+		};
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can( 'use_tools' );
+	}
+
+	/** Poll each explicitly configured subreddit scope. */
+	public function executePoll( array $input ): array|\WP_Error {
+		$allowed = array( 'domains', 'subreddits', 'include_subdomains', 'known_owners', 'page_size', 'max_pages' );
+		if ( array_diff( array_keys( $input ), $allowed ) || ! is_array( $input['domains'] ?? null ) || ! is_array( $input['subreddits'] ?? null ) || ( isset( $input['known_owners'] ) && ! is_array( $input['known_owners'] ) ) ) {
+			return new \WP_Error( 'invalid_param', 'Poll input contains an unknown property or invalid list.', array( 'status' => 400 ) );
+		}
+		$domains    = $this->normalizeDomains( $input['domains'] ?? array() );
+		$subreddits = $this->normalizeSubreddits( $input['subreddits'] ?? array() );
+		$owners     = $this->normalizeOwners( $input['known_owners'] ?? array() );
+		if ( empty( $domains ) || empty( $subreddits ) ) {
+			return new \WP_Error( 'missing_param', 'Poll requires at least one valid domain and subreddit.', array( 'status' => 400 ) );
+		}
+		if ( count( $domains ) > 25 || count( $subreddits ) > 25 || count( $owners ) > 100 ) {
+			return new \WP_Error( 'invalid_param', 'Poll supports at most 25 domains, 25 subreddits, and 100 known owners.', array( 'status' => 400 ) );
+		}
+
+		$token = $this->getRedditAccessToken();
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+
+		$page_size = $input['page_size'] ?? 100;
+		$max_pages = $input['max_pages'] ?? 5;
+		if ( ! is_int( $page_size ) || $page_size < 1 || $page_size > 100 || ! is_int( $max_pages ) || $max_pages < 1 || $max_pages > 10 || ( isset( $input['include_subdomains'] ) && ! is_bool( $input['include_subdomains'] ) ) ) {
+			return new \WP_Error( 'invalid_param', 'page_size, max_pages, or include_subdomains is invalid.', array( 'status' => 400 ) );
+		}
+		$include_subdomains = (bool) ( $input['include_subdomains'] ?? false );
+		$lock               = RedditCommentDomainStore::acquireLock();
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		$results = array();
+		$errors  = array();
+		try {
+			foreach ( $subreddits as $subreddit ) {
+				$result = $this->pollScope( $subreddit, $domains, $include_subdomains, $owners, $token, $page_size, $max_pages, $lock );
+				if ( is_wp_error( $result ) ) {
+					$errors[ $subreddit ] = array(
+						'code'    => $result->get_error_code(),
+						'message' => $result->get_error_message(),
+						'data'    => $result->get_error_data(),
+					);
+					if ( 429 === (int) ( $result->get_error_data()['status'] ?? 0 ) ) {
+						break;
+					}
+					continue;
+				}
+				$results[ $subreddit ] = $result;
+			}
+		} finally {
+			RedditCommentDomainStore::releaseLock( $lock );
+		}
+
+		return array(
+			'success'  => empty( $errors ),
+			'action'   => 'poll',
+			'data'     => array(
+				'scopes' => $results,
+				'errors' => $errors,
+			),
+			'coverage' => $this->coverage( $subreddits ),
+		);
+	}
+
+	/** Poll one subreddit with resumable traversal from a captured head. */
+	private function pollScope( string $subreddit, array $domains, bool $include_subdomains, array $owners, string $token, int $page_size, int $max_pages, string $lock ): array|\WP_Error {
+		$scope            = RedditCommentDomainStore::getScope( $subreddit );
+		$config_signature = hash( 'sha256', wp_json_encode( array( $domains, $include_subdomains, $owners ) ) );
+		$pending          = is_array( $scope['pending'] ?? null ) ? $scope['pending'] : array();
+		if ( ! empty( $pending ) && ( $pending['config_signature'] ?? '' ) !== $config_signature ) {
+			$pending = array();
+		}
+
+		$checkpoint          = (string) ( $scope['checkpoint'] ?? '' );
+		$after               = (string) ( $pending['after'] ?? '' );
+		$target_head         = (string) ( $pending['head'] ?? '' );
+		$target_head_created = (int) ( $pending['head_created_utc'] ?? 0 );
+		$oldest_seen         = (int) ( $pending['oldest_created_utc'] ?? 0 );
+		$pages               = 0;
+		$checked             = 0;
+		$inserted            = 0;
+		$updated             = 0;
+		$reached_checkpoint  = false;
+		$source_exhausted    = false;
+		$now                 = time();
+
+		while ( $pages < $max_pages ) {
+			if ( ! RedditCommentDomainStore::refreshLock( $lock ) ) {
+				return new \WP_Error( 'reddit_comment_monitor_lock_lost', 'The Reddit comment-domain poll lock was lost before the next page.', array( 'status' => 409 ) );
+			}
+			$response = $this->fetchCommentPage( $subreddit, $token, $page_size, $after );
+			if ( is_wp_error( $response ) ) {
+				$scope['last_poll_at'] = $now;
+				$scope['last_status']  = 'error';
+				$scope['last_error']   = $response->get_error_message();
+				RedditCommentDomainStore::putScope( $subreddit, $scope );
+				return $response;
+			}
+
+			++$pages;
+			$children = $response['data']['children'] ?? array();
+			if ( empty( $children ) ) {
+				$source_exhausted = true;
+				break;
+			}
+			if ( ! is_array( $children ) ) {
+				return new \WP_Error( 'reddit_api_error', 'Reddit returned malformed comment-listing children; the cursor was not advanced.', array( 'status' => 502 ) );
+			}
+
+			$page_records = array();
+			foreach ( $children as $wrapper ) {
+				if ( ! is_array( $wrapper ) || 't1' !== (string) ( $wrapper['kind'] ?? '' ) || ! is_array( $wrapper['data'] ?? null ) ) {
+					return new \WP_Error( 'reddit_api_error', 'Reddit returned a malformed comment entry; the cursor was not advanced.', array( 'status' => 502 ) );
+				}
+				$comment  = $wrapper['data'];
+				$fullname = (string) ( $comment['name'] ?? ( ! empty( $comment['id'] ) ? 't1_' . $comment['id'] : '' ) );
+				if ( ! preg_match( '/^t1_[a-z0-9]+$/i', $fullname ) || empty( $comment['id'] ) || ! isset( $comment['created_utc'] ) ) {
+					return new \WP_Error( 'reddit_api_error', 'Reddit returned a comment without a valid ID or timestamp; the cursor was not advanced.', array( 'status' => 502 ) );
+				}
+				if ( '' === $target_head ) {
+					$target_head         = $fullname;
+					$target_head_created = (int) ( $comment['created_utc'] ?? 0 );
+				}
+				if ( '' !== $checkpoint && $fullname === $checkpoint ) {
+					$reached_checkpoint = true;
+					break;
+				}
+
+				++$checked;
+				$created_utc = (int) $comment['created_utc'];
+				$oldest_seen = 0 === $oldest_seen ? $created_utc : min( $oldest_seen, $created_utc );
+				foreach ( RedditCommentUrlMatcher::match( (string) ( $comment['body'] ?? '' ), $domains, $include_subdomains ) as $match ) {
+					$author         = trim( (string) ( $comment['author'] ?? '[deleted]' ) );
+					$author         = '' !== $author ? $author : '[deleted]';
+					$comment_id     = (string) ( $comment['id'] ?? preg_replace( '/^t1_/', '', $fullname ) );
+					$parent_post_id = preg_replace( '/^t3_/', '', (string) ( $comment['link_id'] ?? '' ) );
+					$page_records[] = array(
+						'comment_id'          => $comment_id,
+						'comment_fullname'    => $fullname,
+						'parent_post_id'      => $parent_post_id,
+						'parent_post_title'   => (string) ( $comment['link_title'] ?? '' ),
+						'subreddit'           => (string) ( $comment['subreddit'] ?? $subreddit ),
+						'author'              => $author,
+						'comment_created_utc' => (int) ( $comment['created_utc'] ?? 0 ),
+						'score'               => (int) ( $comment['score'] ?? 0 ),
+						'permalink'           => $this->redditPermalink( (string) ( $comment['permalink'] ?? '' ) ),
+						'domain'              => $match['domain'],
+						'matched_url'         => $match['url'],
+						'matched_host'        => $match['host'],
+						'known_owner'         => in_array( strtolower( $author ), $owners, true ),
+						'first_seen'          => $now,
+						'last_seen'           => $now,
+					);
+				}
+			}
+
+			$stored = RedditCommentDomainStore::upsert( $page_records );
+			if ( is_wp_error( $stored ) ) {
+				return $stored;
+			}
+			$inserted += $stored['inserted'];
+			$updated  += $stored['updated'];
+
+			$next_after = (string) ( $response['data']['after'] ?? '' );
+			if ( $reached_checkpoint ) {
+				break;
+			}
+			if ( '' === $next_after ) {
+				$source_exhausted = true;
+				break;
+			}
+
+			$after                       = $next_after;
+			$scope['pending']            = array(
+				'head'               => $target_head,
+				'head_created_utc'   => $target_head_created,
+				'oldest_created_utc' => $oldest_seen,
+				'after'              => $after,
+				'started_at'         => (int) ( $pending['started_at'] ?? $now ),
+				'config_signature'   => $config_signature,
+			);
+			$scope['last_poll_at']       = $now;
+			$scope['last_status']        = 'truncated';
+			$scope['configured_domains'] = $domains;
+			$scope['include_subdomains'] = $include_subdomains;
+			RedditCommentDomainStore::putScope( $subreddit, $scope );
+		}
+
+		$complete = $reached_checkpoint || ( '' === $checkpoint && $source_exhausted );
+		if ( $complete && '' !== $target_head ) {
+			$scope['checkpoint']             = $target_head;
+			$scope['checkpoint_created_utc'] = $target_head_created;
+			$scope['observed_from']          = 0 === (int) ( $scope['observed_from'] ?? 0 )
+				? $oldest_seen
+				: min( (int) $scope['observed_from'], $oldest_seen );
+			$scope['observed_to']            = max( (int) ( $scope['observed_to'] ?? 0 ), $target_head_created );
+			$scope['pending']                = array();
+			$scope['last_status']            = 'complete';
+			$scope['last_error']             = '';
+		} elseif ( '' !== $checkpoint && $source_exhausted && ! $reached_checkpoint ) {
+			$scope['pending']     = array();
+			$scope['last_status'] = 'checkpoint_unavailable';
+			$scope['last_error']  = 'The prior checkpoint was not present in Reddit\'s bounded recent-comment listing; the checkpoint was not advanced.';
+		}
+
+		$scope['last_poll_at']       = $now;
+		$scope['configured_domains'] = $domains;
+		$scope['include_subdomains'] = $include_subdomains;
+		RedditCommentDomainStore::putScope( $subreddit, $scope );
+
+		return array(
+			'checked'            => $checked,
+			'inserted'           => $inserted,
+			'updated'            => $updated,
+			'pages'              => $pages,
+			'checkpoint_reached' => $reached_checkpoint,
+			'source_exhausted'   => $source_exhausted,
+			'truncated'          => ! $complete,
+			'checkpoint'         => (string) ( $scope['checkpoint'] ?? '' ),
+			'continuation'       => (string) ( $scope['pending']['after'] ?? '' ),
+		);
+	}
+
+	/** Fetch one subreddit recent-comment listing page. */
+	private function fetchCommentPage( string $subreddit, string $token, int $limit, string $after ): array|\WP_Error {
+		$params = array(
+			'limit'    => $limit,
+			'raw_json' => 1,
+		);
+		if ( '' !== $after ) {
+			$params['after'] = $after;
+		}
+		$url      = 'https://oauth.reddit.com/r/' . rawurlencode( $subreddit ) . '/comments.json?' . http_build_query( $params );
+		$response = HttpClient::get(
+			$url,
+			array(
+				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
+				'context' => 'Reddit Comment Domain Monitor',
+			)
+		);
+		if ( empty( $response['success'] ) ) {
+			$status = (int) ( $response['status_code'] ?? 500 );
+			$data   = array( 'status' => $status );
+			foreach ( array( 'retry-after', 'x-ratelimit-remaining', 'x-ratelimit-reset' ) as $header ) {
+				$value = isset( $response['response'] ) ? wp_remote_retrieve_header( $response['response'], $header ) : '';
+				if ( '' !== (string) $value ) {
+					$data['rate_limit'][ str_replace( array( 'x-ratelimit-', '-' ), array( '', '_' ), $header ) ] = (string) $value;
+				}
+			}
+			return new \WP_Error( 429 === $status ? 'reddit_rate_limited' : 'reddit_api_error', (string) ( $response['error'] ?? 'Reddit comment request failed.' ), $data );
+		}
+
+		$decoded = json_decode( (string) ( $response['data'] ?? '' ), true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) || ! is_array( $decoded['data'] ?? null ) || ! array_key_exists( 'children', $decoded['data'] ) || ! array_key_exists( 'after', $decoded['data'] ) ) {
+			return new \WP_Error( 'reddit_api_error', 'Reddit returned an invalid comment listing.', array( 'status' => 502 ) );
+		}
+		return $decoded;
+	}
+
+	/** Report retained matches and explicit bounded coverage metadata. */
+	public function executeReport( array $input ): array|\WP_Error {
+		$allowed = array( 'domain', 'subreddit', 'date_from', 'date_to', 'ownership', 'known_owners', 'min_score', 'limit' );
+		if ( array_diff( array_keys( $input ), $allowed ) || ( isset( $input['known_owners'] ) && ! is_array( $input['known_owners'] ) ) ) {
+			return new \WP_Error( 'invalid_param', 'Report input contains an unknown property or invalid owner list.', array( 'status' => 400 ) );
+		}
+		$domain    = RedditCommentUrlMatcher::normalizeDomain( (string) ( $input['domain'] ?? '' ) );
+		$subreddit = $this->normalizeSubreddits( array( $input['subreddit'] ?? '' ) );
+		$ownership = (string) ( $input['ownership'] ?? 'all' );
+		$owners    = $this->normalizeOwners( $input['known_owners'] ?? array() );
+		$date_from = (string) ( $input['date_from'] ?? '' );
+		$date_to   = (string) ( $input['date_to'] ?? '' );
+		$limit     = $input['limit'] ?? 100;
+		if ( '' !== trim( (string) ( $input['domain'] ?? '' ) ) && '' === $domain ) {
+			return new \WP_Error( 'invalid_param', 'domain must be a valid hostname or HTTP(S) URL.', array( 'status' => 400 ) );
+		}
+		if ( '' !== trim( (string) ( $input['subreddit'] ?? '' ) ) && empty( $subreddit ) ) {
+			return new \WP_Error( 'invalid_param', 'subreddit must be a valid subreddit name.', array( 'status' => 400 ) );
+		}
+		if ( ! in_array( $ownership, array( 'all', 'known_owner', 'organic' ), true ) || count( $owners ) > 100 || ! is_int( $limit ) || $limit < 1 || $limit > 500 || ( isset( $input['min_score'] ) && ! is_int( $input['min_score'] ) ) ) {
+			return new \WP_Error( 'invalid_param', 'Invalid ownership, owner count, or limit.', array( 'status' => 400 ) );
+		}
+		foreach ( array( $date_from, $date_to ) as $date ) {
+			if ( '' !== trim( $date ) && false === strtotime( $date ) ) {
+				return new \WP_Error( 'invalid_param', 'date_from and date_to must be valid dates.', array( 'status' => 400 ) );
+			}
+		}
+		$subreddits = empty( $subreddit ) ? array() : $subreddit;
+		$records    = RedditCommentDomainStore::report(
+			array(
+				'domain'       => $domain,
+				'subreddit'    => $subreddit[0] ?? '',
+				'date_from'    => $date_from,
+				'date_to'      => $date_to,
+				'ownership'    => $ownership,
+				'min_score'    => (int) ( $input['min_score'] ?? PHP_INT_MIN ),
+				'known_owners' => $owners,
+				'limit'        => $limit,
+			)
+		);
+
+		return array(
+			'success'  => true,
+			'action'   => 'report',
+			'data'     => array(
+				'matches' => $records,
+				'count'   => count( $records ),
+			),
+			'coverage' => $this->coverage( $subreddits ),
+		);
+	}
+
+	/** Apply retention to the current site's observation table. */
+	public function executeCleanup( array $input ): array|\WP_Error {
+		if ( ! empty( $input ) ) {
+			return new \WP_Error( 'invalid_param', 'Cleanup does not accept input properties.', array( 'status' => 400 ) );
+		}
+		return array(
+			'success' => true,
+			'data'    => RedditCommentDomainStore::cleanup(),
+		);
+	}
+
+	/** Build coverage metadata that cannot be mistaken for global search. */
+	private function coverage( array $subreddits ): array {
+		$scopes    = RedditCommentDomainStore::getScopes( $subreddits );
+		$truncated = false;
+		foreach ( $scopes as $scope ) {
+			if ( ! empty( $scope['pending'] ) || in_array( $scope['last_status'] ?? '', array( 'truncated', 'checkpoint_unavailable', 'error' ), true ) ) {
+				$truncated = true;
+				break;
+			}
+		}
+
+		return array(
+			'kind'                => 'bounded_incremental_subreddit_comment_streams',
+			'all_reddit_search'   => false,
+			'historical_complete' => false,
+			'configured_scopes'   => array_keys( $scopes ),
+			'scopes'              => $scopes,
+			'truncated'           => $truncated,
+			'limitation'          => 'Reddit provides bounded recent-comment listings, not complete global historical comment search. Results cover only configured subreddit scopes since their retained checkpoints.',
+		);
+	}
+
+	private function pollOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success', 'action', 'data', 'coverage' ),
+			'properties' => array(
+				'success'  => array( 'type' => 'boolean' ),
+				'action'   => array(
+					'type' => 'string',
+					'enum' => array( 'poll' ),
+				),
+				'data'     => array(
+					'type'       => 'object',
+					'required'   => array( 'scopes', 'errors' ),
+					'properties' => array(
+						'scopes' => array(
+							'type'                 => 'object',
+							'additionalProperties' => array( 'type' => 'object' ),
+						),
+						'errors' => array(
+							'type'                 => 'object',
+							'additionalProperties' => array( 'type' => 'object' ),
+						),
+					),
+				),
+				'coverage' => $this->coverageSchema(),
+			),
+		);
+	}
+
+	private function reportOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success', 'action', 'data', 'coverage' ),
+			'properties' => array(
+				'success'  => array( 'type' => 'boolean' ),
+				'action'   => array(
+					'type' => 'string',
+					'enum' => array( 'report' ),
+				),
+				'data'     => array(
+					'type'       => 'object',
+					'required'   => array( 'matches', 'count' ),
+					'properties' => array(
+						'matches' => array(
+							'type'  => 'array',
+							'items' => $this->recordSchema(),
+						),
+						'count'   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'maximum' => 500,
+						),
+					),
+				),
+				'coverage' => $this->coverageSchema(),
+			),
+		);
+	}
+
+	private function cleanupOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success', 'data' ),
+			'properties' => array(
+				'success' => array( 'type' => 'boolean' ),
+				'data'    => array(
+					'type'       => 'object',
+					'required'   => array( 'deleted', 'retained', 'retention_days', 'max_records' ),
+					'properties' => array(
+						'deleted'        => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'retained'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'maximum' => 10000,
+						),
+						'retention_days' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 365,
+						),
+						'max_records'    => array(
+							'type'    => 'integer',
+							'minimum' => 100,
+							'maximum' => 10000,
+						),
+					),
+				),
+			),
+		);
+	}
+
+	private function coverageSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'kind', 'all_reddit_search', 'historical_complete', 'configured_scopes', 'scopes', 'truncated', 'limitation' ),
+			'properties' => array(
+				'kind'                => array( 'type' => 'string' ),
+				'all_reddit_search'   => array( 'type' => 'boolean' ),
+				'historical_complete' => array( 'type' => 'boolean' ),
+				'configured_scopes'   => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'scopes'              => array(
+					'type'                 => 'object',
+					'additionalProperties' => array( 'type' => 'object' ),
+				),
+				'truncated'           => array( 'type' => 'boolean' ),
+				'limitation'          => array( 'type' => 'string' ),
+			),
+		);
+	}
+
+	private function recordSchema(): array {
+		$strings    = array( 'comment_id', 'comment_fullname', 'parent_post_id', 'parent_post_title', 'subreddit', 'author', 'permalink', 'domain', 'matched_url', 'matched_host' );
+		$properties = array();
+		foreach ( $strings as $field ) {
+			$properties[ $field ] = array( 'type' => 'string' );
+		}
+		foreach ( array( 'comment_created_utc', 'score', 'first_seen', 'last_seen' ) as $field ) {
+			$properties[ $field ] = array( 'type' => 'integer' );
+		}
+		$properties['known_owner'] = array( 'type' => 'boolean' );
+		return array(
+			'type'       => 'object',
+			'required'   => array_keys( $properties ),
+			'properties' => $properties,
+		);
+	}
+
+	private function normalizeDomains( mixed $domains ): array {
+		$domains = is_array( $domains ) ? $domains : array();
+		return array_values( array_filter( array_unique( array_map( array( RedditCommentUrlMatcher::class, 'normalizeDomain' ), array_map( 'strval', $domains ) ) ) ) );
+	}
+
+	private function normalizeSubreddits( mixed $subreddits ): array {
+		$subreddits = is_array( $subreddits ) ? $subreddits : array();
+		$normalized = array();
+		foreach ( $subreddits as $subreddit ) {
+			$subreddit = preg_replace( '~^/?r/~i', '', trim( (string) $subreddit ) );
+			if ( preg_match( '/^[a-z0-9_]{2,21}$/i', $subreddit ) ) {
+				$normalized[] = $subreddit;
+			}
+		}
+		return array_values( array_unique( $normalized ) );
+	}
+
+	private function normalizeOwners( mixed $owners ): array {
+		$owners     = is_array( $owners ) ? $owners : array();
+		$normalized = array();
+		foreach ( $owners as $owner ) {
+			$owner = strtolower( trim( (string) $owner ) );
+			$owner = preg_replace( '~^/?u/~i', '', $owner );
+			if ( preg_match( '/^[a-z0-9_-]{3,20}$/', $owner ) ) {
+				$normalized[] = $owner;
+			}
+		}
+		return array_values( array_unique( $normalized ) );
+	}
+
+	private function redditPermalink( string $permalink ): string {
+		if ( '' === $permalink ) {
+			return '';
+		}
+		return str_starts_with( $permalink, 'http' ) ? esc_url_raw( $permalink ) : 'https://www.reddit.com' . $permalink;
+	}
+
+	/** Resolve and refresh credentials entirely server-side. */
+	protected function getRedditAccessToken(): string|\WP_Error {
+		$provider = $this->resolveProvider( 'reddit', 'Reddit' );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
+		}
+		$token = $provider->get_valid_access_token();
+		return empty( $token ) ? new \WP_Error( 'missing_auth', 'Could not obtain a valid Reddit access token.', array( 'status' => 401 ) ) : $token;
+	}
+}

--- a/inc/Abilities/Reddit/RedditCommentDomainMonitorAbility.php
+++ b/inc/Abilities/Reddit/RedditCommentDomainMonitorAbility.php
@@ -267,6 +267,7 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 		$pending          = is_array( $scope['pending'] ?? null ) ? $scope['pending'] : array();
 		if ( ! empty( $pending ) && ( $pending['config_signature'] ?? '' ) !== $config_signature ) {
 			$pending = array();
+			unset( $scope['pending'] );
 		}
 
 		$checkpoint          = (string) ( $scope['checkpoint'] ?? '' );
@@ -392,11 +393,11 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 				? $oldest_seen
 				: min( (int) $scope['observed_from'], $oldest_seen );
 			$scope['observed_to']            = max( (int) ( $scope['observed_to'] ?? 0 ), $target_head_created );
-			$scope['pending']                = array();
-			$scope['last_status']            = 'complete';
-			$scope['last_error']             = '';
+			unset( $scope['pending'] );
+			$scope['last_status'] = 'complete';
+			$scope['last_error']  = '';
 		} elseif ( '' !== $checkpoint && $source_exhausted && ! $reached_checkpoint ) {
-			$scope['pending']     = array();
+			unset( $scope['pending'] );
 			$scope['last_status'] = 'checkpoint_unavailable';
 			$scope['last_error']  = 'The prior checkpoint was not present in Reddit\'s bounded recent-comment listing; the checkpoint was not advanced.';
 		}
@@ -542,25 +543,27 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 
 	private function pollOutputSchema(): array {
 		return array(
-			'type'       => 'object',
-			'required'   => array( 'success', 'action', 'data', 'coverage' ),
-			'properties' => array(
+			'type'                 => 'object',
+			'required'             => array( 'success', 'action', 'data', 'coverage' ),
+			'additionalProperties' => false,
+			'properties'           => array(
 				'success'  => array( 'type' => 'boolean' ),
 				'action'   => array(
 					'type' => 'string',
 					'enum' => array( 'poll' ),
 				),
 				'data'     => array(
-					'type'       => 'object',
-					'required'   => array( 'scopes', 'errors' ),
-					'properties' => array(
+					'type'                 => 'object',
+					'required'             => array( 'scopes', 'errors' ),
+					'additionalProperties' => false,
+					'properties'           => array(
 						'scopes' => array(
 							'type'                 => 'object',
-							'additionalProperties' => array( 'type' => 'object' ),
+							'additionalProperties' => $this->pollScopeSchema(),
 						),
 						'errors' => array(
 							'type'                 => 'object',
-							'additionalProperties' => array( 'type' => 'object' ),
+							'additionalProperties' => $this->errorSchema(),
 						),
 					),
 				),
@@ -571,18 +574,20 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 
 	private function reportOutputSchema(): array {
 		return array(
-			'type'       => 'object',
-			'required'   => array( 'success', 'action', 'data', 'coverage' ),
-			'properties' => array(
+			'type'                 => 'object',
+			'required'             => array( 'success', 'action', 'data', 'coverage' ),
+			'additionalProperties' => false,
+			'properties'           => array(
 				'success'  => array( 'type' => 'boolean' ),
 				'action'   => array(
 					'type' => 'string',
 					'enum' => array( 'report' ),
 				),
 				'data'     => array(
-					'type'       => 'object',
-					'required'   => array( 'matches', 'count' ),
-					'properties' => array(
+					'type'                 => 'object',
+					'required'             => array( 'matches', 'count' ),
+					'additionalProperties' => false,
+					'properties'           => array(
 						'matches' => array(
 							'type'  => 'array',
 							'items' => $this->recordSchema(),
@@ -601,14 +606,16 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 
 	private function cleanupOutputSchema(): array {
 		return array(
-			'type'       => 'object',
-			'required'   => array( 'success', 'data' ),
-			'properties' => array(
+			'type'                 => 'object',
+			'required'             => array( 'success', 'data' ),
+			'additionalProperties' => false,
+			'properties'           => array(
 				'success' => array( 'type' => 'boolean' ),
 				'data'    => array(
-					'type'       => 'object',
-					'required'   => array( 'deleted', 'retained', 'retention_days', 'max_records' ),
-					'properties' => array(
+					'type'                 => 'object',
+					'required'             => array( 'deleted', 'retained', 'retention_days', 'max_records' ),
+					'additionalProperties' => false,
+					'properties'           => array(
 						'deleted'        => array(
 							'type'    => 'integer',
 							'minimum' => 0,
@@ -636,9 +643,10 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 
 	private function coverageSchema(): array {
 		return array(
-			'type'       => 'object',
-			'required'   => array( 'kind', 'all_reddit_search', 'historical_complete', 'configured_scopes', 'scopes', 'truncated', 'limitation' ),
-			'properties' => array(
+			'type'                 => 'object',
+			'required'             => array( 'kind', 'all_reddit_search', 'historical_complete', 'configured_scopes', 'scopes', 'truncated', 'limitation' ),
+			'additionalProperties' => false,
+			'properties'           => array(
 				'kind'                => array( 'type' => 'string' ),
 				'all_reddit_search'   => array( 'type' => 'boolean' ),
 				'historical_complete' => array( 'type' => 'boolean' ),
@@ -648,7 +656,7 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 				),
 				'scopes'              => array(
 					'type'                 => 'object',
-					'additionalProperties' => array( 'type' => 'object' ),
+					'additionalProperties' => $this->coverageScopeSchema(),
 				),
 				'truncated'           => array( 'type' => 'boolean' ),
 				'limitation'          => array( 'type' => 'string' ),
@@ -667,9 +675,78 @@ class RedditCommentDomainMonitorAbility extends AbstractSocialAbility {
 		}
 		$properties['known_owner'] = array( 'type' => 'boolean' );
 		return array(
-			'type'       => 'object',
-			'required'   => array_keys( $properties ),
-			'properties' => $properties,
+			'type'                 => 'object',
+			'required'             => array_keys( $properties ),
+			'additionalProperties' => false,
+			'properties'           => $properties,
+		);
+	}
+
+	private function pollScopeSchema(): array {
+		$properties = array(
+			'checked'            => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'inserted'           => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'updated'            => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'pages'              => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+				'maximum' => 10,
+			),
+			'checkpoint_reached' => array( 'type' => 'boolean' ),
+			'source_exhausted'   => array( 'type' => 'boolean' ),
+			'truncated'          => array( 'type' => 'boolean' ),
+			'checkpoint'         => array( 'type' => 'string' ),
+			'continuation'       => array( 'type' => 'string' ),
+		);
+		return array(
+			'type'                 => 'object',
+			'required'             => array_keys( $properties ),
+			'additionalProperties' => false,
+			'properties'           => $properties,
+		);
+	}
+
+	private function errorSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'required'             => array( 'code', 'message', 'data' ),
+			'additionalProperties' => false,
+			'properties'           => array(
+				'code'    => array( 'type' => 'string' ),
+				'message' => array( 'type' => 'string' ),
+				'data'    => array( 'type' => array( 'object', 'array', 'null' ) ),
+			),
+		);
+	}
+
+	private function coverageScopeSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'checkpoint'             => array( 'type' => 'string' ),
+				'checkpoint_created_utc' => array( 'type' => 'integer' ),
+				'observed_from'          => array( 'type' => 'integer' ),
+				'observed_to'            => array( 'type' => 'integer' ),
+				'pending'                => array( 'type' => 'object' ),
+				'last_poll_at'           => array( 'type' => 'integer' ),
+				'last_status'            => array( 'type' => 'string' ),
+				'last_error'             => array( 'type' => 'string' ),
+				'configured_domains'     => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'include_subdomains'     => array( 'type' => 'boolean' ),
+			),
 		);
 	}
 

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -637,6 +637,207 @@ class RedditCommand {
 	}
 
 	/**
+	 * Poll bounded subreddit comment streams for configured domains.
+	 *
+	 * This is incremental monitoring of explicit subreddit scopes. It is not a
+	 * global or comprehensive historical Reddit comment search.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --domains=<domains>
+	 * : Comma-separated domains to monitor.
+	 *
+	 * --subreddits=<subreddits>
+	 * : Comma-separated subreddit scopes.
+	 *
+	 * [--include-subdomains]
+	 * : Match child hosts in addition to each exact domain.
+	 *
+	 * [--owners=<usernames>]
+	 * : Comma-separated known owner usernames, classified separately from organic mentions.
+	 *
+	 * [--page-size=<count>]
+	 * : Comments per Reddit page, 1-100. Default 100.
+	 *
+	 * [--max-pages=<count>]
+	 * : Maximum pages per scope and invocation, 1-10. Default 5.
+	 *
+	 * [--format=<format>]
+	 * : Output format: table or json. Default table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit monitor-comments --domains=example.com --subreddits=music,festivals
+	 *     wp datamachine-socials reddit monitor-comments --domains=example.com --subreddits=music --include-subdomains --owners=account_name --format=json
+	 *
+	 * @subcommand monitor-comments
+	 */
+	public function monitor_comments( $args, $assoc_args ) {
+		$args;
+		$domains    = $this->csv_values( (string) ( $assoc_args['domains'] ?? '' ) );
+		$subreddits = $this->csv_values( (string) ( $assoc_args['subreddits'] ?? '' ) );
+		if ( empty( $domains ) || empty( $subreddits ) ) {
+			WP_CLI::error( '--domains and --subreddits are required comma-separated lists.' );
+		}
+
+		$page_size = $this->bounded_integer_arg( $assoc_args, 'page-size', 100, 1, 100 );
+		$max_pages = $this->bounded_integer_arg( $assoc_args, 'max-pages', 5, 1, 10 );
+		$format    = $this->format_arg( $assoc_args, array( 'table', 'json' ) );
+		$ability   = wp_get_ability( 'datamachine/reddit-comment-mentions-poll' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/reddit-comment-mentions-poll ability not registered.' );
+		}
+		$result = $ability->execute(
+			array(
+				'domains'            => $domains,
+				'subreddits'         => $subreddits,
+				'include_subdomains' => isset( $assoc_args['include-subdomains'] ),
+				'known_owners'       => $this->csv_values( (string) ( $assoc_args['owners'] ?? '' ) ),
+				'page_size'          => $page_size,
+				'max_pages'          => $max_pages,
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $result['data']['scopes'] ?? array() as $subreddit => $scope ) {
+			$rows[] = array(
+				'subreddit'    => 'r/' . $subreddit,
+				'checked'      => $scope['checked'],
+				'inserted'     => $scope['inserted'],
+				'updated'      => $scope['updated'],
+				'pages'        => $scope['pages'],
+				'truncated'    => $scope['truncated'] ? 'yes' : 'no',
+				'checkpoint'   => $scope['checkpoint'],
+				'continuation' => $scope['continuation'],
+			);
+		}
+		if ( ! empty( $rows ) ) {
+			WP_CLI\Utils\format_items( 'table', $rows, array( 'subreddit', 'checked', 'inserted', 'updated', 'pages', 'truncated', 'checkpoint', 'continuation' ) );
+		}
+		foreach ( $result['data']['errors'] ?? array() as $subreddit => $error ) {
+			WP_CLI::warning( sprintf( 'r/%s: %s', $subreddit, $error['message'] ) );
+		}
+		WP_CLI::log( 'Coverage: bounded incremental subreddit comment streams only; not all Reddit comments or historical global search.' );
+	}
+
+	/**
+	 * Report retained bounded Reddit comment-domain observations.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--domain=<domain>]
+	 * : Filter by monitored domain.
+	 *
+	 * [--subreddit=<subreddit>]
+	 * : Filter by subreddit.
+	 *
+	 * [--from=<date>]
+	 * : Earliest comment date or timestamp.
+	 *
+	 * [--to=<date>]
+	 * : Latest comment date or timestamp.
+	 *
+	 * [--ownership=<ownership>]
+	 * : all, known_owner, or organic. Default all.
+	 *
+	 * [--owners=<usernames>]
+	 * : Reclassify against comma-separated known owner usernames at report time.
+	 *
+	 * [--min-score=<score>]
+	 * : Minimum current observed score.
+	 *
+	 * [--limit=<count>]
+	 * : Maximum rows, 1-500. Default 100.
+	 *
+	 * [--format=<format>]
+	 * : Output format: table, json, or csv. Default table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-socials reddit comment-mentions --domain=example.com --ownership=organic
+	 *     wp datamachine-socials reddit comment-mentions --subreddit=music --from=2026-07-01 --format=json
+	 *
+	 * @subcommand comment-mentions
+	 */
+	public function comment_mentions( $args, $assoc_args ) {
+		$args;
+		$format  = $this->format_arg( $assoc_args, array( 'table', 'json', 'csv' ) );
+		$limit   = $this->bounded_integer_arg( $assoc_args, 'limit', 100, 1, 500 );
+		$ability = wp_get_ability( 'datamachine/reddit-comment-mentions-report' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/reddit-comment-mentions-report ability not registered.' );
+		}
+		$result = $ability->execute(
+			array(
+				'domain'       => (string) ( $assoc_args['domain'] ?? '' ),
+				'subreddit'    => (string) ( $assoc_args['subreddit'] ?? '' ),
+				'date_from'    => (string) ( $assoc_args['from'] ?? '' ),
+				'date_to'      => (string) ( $assoc_args['to'] ?? '' ),
+				'ownership'    => (string) ( $assoc_args['ownership'] ?? 'all' ),
+				'known_owners' => $this->csv_values( (string) ( $assoc_args['owners'] ?? '' ) ),
+				'min_score'    => (int) ( $assoc_args['min-score'] ?? PHP_INT_MIN ),
+				'limit'        => $limit,
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+		$rows = array_map(
+			static fn( array $record ): array => array(
+				'date'        => gmdate( 'Y-m-d H:i:s', (int) $record['comment_created_utc'] ),
+				'domain'      => $record['domain'],
+				'subreddit'   => 'r/' . $record['subreddit'],
+				'author'      => $record['author'],
+				'ownership'   => $record['known_owner'] ? 'known_owner' : 'organic',
+				'score'       => $record['score'],
+				'matched_url' => $record['matched_url'],
+				'permalink'   => $record['permalink'],
+			),
+			$result['data']['matches'] ?? array()
+		);
+		if ( ! empty( $rows ) ) {
+			WP_CLI\Utils\format_items( $format, $rows, array( 'date', 'domain', 'subreddit', 'author', 'ownership', 'score', 'matched_url', 'permalink' ) );
+		} else {
+			WP_CLI::warning( 'No retained observations matched the filters.' );
+		}
+		WP_CLI::log( 'Coverage: bounded incremental subreddit comment streams only; not all Reddit comments or historical global search.' );
+		if ( ! empty( $result['coverage']['truncated'] ) ) {
+			WP_CLI::warning( 'One or more configured scopes is truncated, pending, or has a cursor gap/error.' );
+		}
+	}
+
+	/**
+	 * Apply Reddit comment observation retention immediately.
+	 *
+	 * @subcommand cleanup-comment-mentions
+	 */
+	public function cleanup_comment_mentions( $args, $assoc_args ) {
+		$args;
+		$assoc_args;
+		$ability = wp_get_ability( 'datamachine/reddit-comment-mentions-cleanup' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/reddit-comment-mentions-cleanup ability not registered.' );
+		}
+		$result = $ability->execute( array() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		WP_CLI::success( sprintf( 'Deleted %d observations; %d retained (%d-day retention, %d-record cap).', $result['data']['deleted'], $result['data']['retained'], $result['data']['retention_days'], $result['data']['max_records'] ) );
+	}
+
+	/**
 	 * Validate and map the optional CLI limit to the direct ability contract.
 	 */
 	private function applyFetchLimit( array $input, array $assoc_args ): array {
@@ -651,6 +852,32 @@ class RedditCommand {
 
 		$input['max_items'] = (int) $limit;
 		return $input;
+	}
+
+	/** Parse a comma-separated CLI list. */
+	private function csv_values( string $value ): array {
+		return array_values( array_filter( array_map( 'trim', explode( ',', $value ) ), static fn( string $item ): bool => '' !== $item ) );
+	}
+
+	/** Validate a bounded whole-number option. */
+	private function bounded_integer_arg( array $assoc_args, string $name, int $default_value, int $minimum, int $maximum ): int {
+		if ( ! array_key_exists( $name, $assoc_args ) ) {
+			return $default_value;
+		}
+		$value = $assoc_args[ $name ];
+		if ( ! is_string( $value ) || ! preg_match( '/^[0-9]+$/', $value ) || (int) $value < $minimum || (int) $value > $maximum ) {
+			WP_CLI::error( sprintf( '--%s must be a whole number between %d and %d.', $name, $minimum, $maximum ) );
+		}
+		return (int) $value;
+	}
+
+	/** Validate a command output format. */
+	private function format_arg( array $assoc_args, array $allowed ): string {
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( ! in_array( $format, $allowed, true ) ) {
+			WP_CLI::error( sprintf( '--format must be one of: %s.', implode( ', ', $allowed ) ) );
+		}
+		return $format;
 	}
 
 	/**

--- a/inc/Cli/Commands/RedditCommand.php
+++ b/inc/Cli/Commands/RedditCommand.php
@@ -768,9 +768,10 @@ class RedditCommand {
 	 */
 	public function comment_mentions( $args, $assoc_args ) {
 		$args;
-		$format  = $this->format_arg( $assoc_args, array( 'table', 'json', 'csv' ) );
-		$limit   = $this->bounded_integer_arg( $assoc_args, 'limit', 100, 1, 500 );
-		$ability = wp_get_ability( 'datamachine/reddit-comment-mentions-report' );
+		$format    = $this->format_arg( $assoc_args, array( 'table', 'json', 'csv' ) );
+		$limit     = $this->bounded_integer_arg( $assoc_args, 'limit', 100, 1, 500 );
+		$min_score = $this->signed_integer_arg( $assoc_args, 'min-score', PHP_INT_MIN );
+		$ability   = wp_get_ability( 'datamachine/reddit-comment-mentions-report' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'datamachine/reddit-comment-mentions-report ability not registered.' );
 		}
@@ -782,7 +783,7 @@ class RedditCommand {
 				'date_to'      => (string) ( $assoc_args['to'] ?? '' ),
 				'ownership'    => (string) ( $assoc_args['ownership'] ?? 'all' ),
 				'known_owners' => $this->csv_values( (string) ( $assoc_args['owners'] ?? '' ) ),
-				'min_score'    => (int) ( $assoc_args['min-score'] ?? PHP_INT_MIN ),
+				'min_score'    => $min_score,
 				'limit'        => $limit,
 			)
 		);
@@ -867,6 +868,18 @@ class RedditCommand {
 		$value = $assoc_args[ $name ];
 		if ( ! is_string( $value ) || ! preg_match( '/^[0-9]+$/', $value ) || (int) $value < $minimum || (int) $value > $maximum ) {
 			WP_CLI::error( sprintf( '--%s must be a whole number between %d and %d.', $name, $minimum, $maximum ) );
+		}
+		return (int) $value;
+	}
+
+	/** Validate a signed whole-number option. */
+	private function signed_integer_arg( array $assoc_args, string $name, int $default_value ): int {
+		if ( ! array_key_exists( $name, $assoc_args ) ) {
+			return $default_value;
+		}
+		$value = $assoc_args[ $name ];
+		if ( ! is_string( $value ) || ! preg_match( '/^-?[0-9]+$/', $value ) ) {
+			WP_CLI::error( sprintf( '--%s must be a whole number.', $name ) );
 		}
 		return (int) $value;
 	}

--- a/inc/Tracking/RedditCommentDomainStore.php
+++ b/inc/Tracking/RedditCommentDomainStore.php
@@ -16,7 +16,7 @@ class RedditCommentDomainStore {
 	public const CRON_HOOK    = 'datamachine_socials_reddit_comment_retention';
 	private const LOCK_OPTION = 'datamachine_socials_reddit_comment_monitor_lock';
 	private const DB_VERSION  = '1';
-	private const MAX_SCOPES  = 100;
+	private const MAX_SCOPES  = 25;
 
 	/** Register the site-local table and daily retention task. */
 	public static function register(): void {

--- a/inc/Tracking/RedditCommentDomainStore.php
+++ b/inc/Tracking/RedditCommentDomainStore.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * Site-owned persistence for bounded Reddit comment-domain observations.
+ *
+ * @package DataMachineSocials
+ * @subpackage Tracking
+ */
+
+namespace DataMachineSocials\Tracking;
+
+defined( 'ABSPATH' ) || exit;
+
+class RedditCommentDomainStore {
+
+	public const STATE_OPTION = 'datamachine_socials_reddit_comment_monitor_state';
+	public const CRON_HOOK    = 'datamachine_socials_reddit_comment_retention';
+	private const LOCK_OPTION = 'datamachine_socials_reddit_comment_monitor_lock';
+	private const DB_VERSION  = '1';
+	private const MAX_SCOPES  = 100;
+
+	/** Register the site-local table and daily retention task. */
+	public static function register(): void {
+		add_action( 'init', array( self::class, 'install' ) );
+		add_action( 'init', array( self::class, 'scheduleRetention' ) );
+		add_action( self::CRON_HOOK, array( self::class, 'cleanup' ) );
+	}
+
+	/** Create or update the current site's narrow observation table. */
+	public static function install(): void {
+		if ( self::DB_VERSION === get_option( 'datamachine_socials_reddit_comment_db_version' ) ) {
+			return;
+		}
+
+		global $wpdb;
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		$table   = self::tableName();
+		$charset = $wpdb->get_charset_collate();
+		dbDelta(
+			"CREATE TABLE {$table} (
+				mention_key char(64) NOT NULL,
+				comment_id varchar(32) NOT NULL,
+				comment_fullname varchar(35) NOT NULL,
+				parent_post_id varchar(32) NOT NULL DEFAULT '',
+				parent_post_title text NOT NULL,
+				subreddit varchar(21) NOT NULL,
+				author varchar(64) NOT NULL,
+				comment_created_utc bigint(20) unsigned NOT NULL DEFAULT 0,
+				score bigint(20) NOT NULL DEFAULT 0,
+				permalink text NOT NULL,
+				domain varchar(253) NOT NULL,
+				matched_url text NOT NULL,
+				matched_host varchar(253) NOT NULL,
+				known_owner tinyint(1) NOT NULL DEFAULT 0,
+				first_seen bigint(20) unsigned NOT NULL,
+				last_seen bigint(20) unsigned NOT NULL,
+				PRIMARY KEY  (mention_key),
+				KEY domain (domain),
+				KEY subreddit (subreddit),
+				KEY comment_created (comment_created_utc),
+				KEY last_seen (last_seen)
+			) {$charset};"
+		);
+		update_option( 'datamachine_socials_reddit_comment_db_version', self::DB_VERSION, false );
+	}
+
+	/** Schedule site-local daily cleanup when no event exists. */
+	public static function scheduleRetention(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/** Remove this site's scheduled task on deactivation. Retained data is preserved. */
+	public static function deactivate( bool $network_wide = false ): void {
+		if ( $network_wide && is_multisite() ) {
+			$site_ids = get_sites( array(
+				'fields' => 'ids',
+				'number' => 0,
+			) );
+			foreach ( $site_ids as $site_id ) {
+				switch_to_blog( (int) $site_id );
+				wp_clear_scheduled_hook( self::CRON_HOOK );
+				restore_current_blog();
+			}
+			return;
+		}
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/** Acquire an atomic site-local poll lock and return its owner token. */
+	public static function acquireLock(): string|\WP_Error {
+		$token = wp_generate_uuid4();
+		$value = array(
+			'token'      => $token,
+			'expires_at' => time() + ( 30 * MINUTE_IN_SECONDS ),
+		);
+		if ( add_option( self::LOCK_OPTION, $value, '', false ) ) {
+			return $token;
+		}
+
+		$current = get_option( self::LOCK_OPTION, array() );
+		if ( is_array( $current ) && (int) ( $current['expires_at'] ?? 0 ) < time() && self::replaceLock( $current, $value ) ) {
+			return $token;
+		}
+
+		return new \WP_Error( 'reddit_comment_monitor_locked', 'A Reddit comment-domain poll is already running on this site.', array( 'status' => 409 ) );
+	}
+
+	/** Extend a lock only while the caller remains its owner. */
+	public static function refreshLock( string $token ): bool {
+		$current = get_option( self::LOCK_OPTION, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+		$replacement = array(
+			'token'      => $token,
+			'expires_at' => time() + ( 30 * MINUTE_IN_SECONDS ),
+		);
+		return self::replaceLock( $current, $replacement );
+	}
+
+	/** Release a lock only while the caller remains its owner. */
+	public static function releaseLock( string $token ): void {
+		global $wpdb;
+		$current = get_option( self::LOCK_OPTION, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return;
+		}
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+				self::LOCK_OPTION,
+				maybe_serialize( $current )
+			)
+		);
+		wp_cache_delete( self::LOCK_OPTION, 'options' );
+	}
+
+	/** Read checkpoint state for one subreddit on the current site. */
+	public static function getScope( string $subreddit ): array {
+		$state = get_option( self::STATE_OPTION, array() );
+		return is_array( $state ) && is_array( $state[ strtolower( $subreddit ) ] ?? null ) ? $state[ strtolower( $subreddit ) ] : array();
+	}
+
+	/** Persist compact checkpoint state with a hard cross-invocation scope cap. */
+	public static function putScope( string $subreddit, array $scope ): bool {
+		$state                             = get_option( self::STATE_OPTION, array() );
+		$state                             = is_array( $state ) ? $state : array();
+		$state[ strtolower( $subreddit ) ] = $scope;
+		uasort( $state, static fn( array $left, array $right ): int => (int) ( $right['last_poll_at'] ?? 0 ) <=> (int) ( $left['last_poll_at'] ?? 0 ) );
+		$state = array_slice( $state, 0, self::MAX_SCOPES, true );
+		return update_option( self::STATE_OPTION, $state, false );
+	}
+
+	/** Return all scope states, optionally restricted to requested scopes. */
+	public static function getScopes( array $subreddits = array() ): array {
+		$state = get_option( self::STATE_OPTION, array() );
+		$state = is_array( $state ) ? $state : array();
+		return empty( $subreddits ) ? $state : array_intersect_key( $state, array_flip( array_map( 'strtolower', $subreddits ) ) );
+	}
+
+	/** Upsert normalized observations using one row per comment and canonical URL. */
+	public static function upsert( array $records ): array|\WP_Error {
+		global $wpdb;
+		self::install();
+		$inserted = 0;
+		$updated  = 0;
+		$table    = self::tableName();
+
+		foreach ( $records as $record ) {
+			$key    = hash( 'sha256', (string) $record['comment_fullname'] . '|' . (string) $record['matched_url'] . '|' . (string) $record['matched_host'] );
+			$sql    = $wpdb->prepare(
+				'INSERT INTO %i (mention_key, comment_id, comment_fullname, parent_post_id, parent_post_title, subreddit, author, comment_created_utc, score, permalink, domain, matched_url, matched_host, known_owner, first_seen, last_seen)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %d, %d, %s, %s, %s, %s, %d, %d, %d)
+				ON DUPLICATE KEY UPDATE parent_post_id = VALUES(parent_post_id), parent_post_title = VALUES(parent_post_title), subreddit = VALUES(subreddit), author = VALUES(author), comment_created_utc = VALUES(comment_created_utc), score = VALUES(score), permalink = VALUES(permalink), known_owner = VALUES(known_owner), last_seen = VALUES(last_seen)',
+				$table,
+				$key,
+				(string) $record['comment_id'],
+				(string) $record['comment_fullname'],
+				(string) $record['parent_post_id'],
+				(string) $record['parent_post_title'],
+				(string) $record['subreddit'],
+				(string) $record['author'],
+				(int) $record['comment_created_utc'],
+				(int) $record['score'],
+				(string) $record['permalink'],
+				(string) $record['domain'],
+				(string) $record['matched_url'],
+				(string) $record['matched_host'],
+				(int) $record['known_owner'],
+				(int) $record['first_seen'],
+				(int) $record['last_seen']
+			);
+			$result = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Fully prepared above, including the table identifier.
+			if ( false === $result ) {
+				return new \WP_Error( 'reddit_comment_store_failed', 'Could not persist Reddit comment-domain observations.' );
+			}
+			1 === $result ? ++$inserted : ++$updated;
+		}
+
+		self::enforceBounds();
+		return array(
+			'inserted' => $inserted,
+			'updated'  => $updated,
+		);
+	}
+
+	/** Query current-site observations with bounded filters. */
+	public static function report( array $filters ): array {
+		global $wpdb;
+		self::install();
+		$table  = self::tableName();
+		$where  = array( '1=1' );
+		$values = array();
+		$from   = self::timestamp( (string) ( $filters['date_from'] ?? '' ), false );
+		$to     = self::timestamp( (string) ( $filters['date_to'] ?? '' ), true );
+
+		foreach ( array( 'domain', 'subreddit' ) as $field ) {
+			if ( '' !== (string) ( $filters[ $field ] ?? '' ) ) {
+				$where[]  = "LOWER({$field}) = LOWER(%s)";
+				$values[] = (string) $filters[ $field ];
+			}
+		}
+		if ( $from ) {
+			$where[]  = 'comment_created_utc >= %d';
+			$values[] = $from;
+		}
+		if ( $to ) {
+			$where[]  = 'comment_created_utc <= %d';
+			$values[] = $to;
+		}
+		$where[]   = 'score >= %d';
+		$values[]  = (int) ( $filters['min_score'] ?? PHP_INT_MIN );
+		$owners    = array_map( 'strtolower', is_array( $filters['known_owners'] ?? null ) ? $filters['known_owners'] : array() );
+		$ownership = (string) ( $filters['ownership'] ?? 'all' );
+		if ( 'all' !== $ownership ) {
+			if ( empty( $owners ) ) {
+				$where[] = 'known_owner = ' . ( 'known_owner' === $ownership ? '1' : '0' );
+			} else {
+				$placeholders = implode( ', ', array_fill( 0, count( $owners ), '%s' ) );
+				$where[]      = 'LOWER(author) ' . ( 'organic' === $ownership ? 'NOT ' : '' ) . "IN ({$placeholders})";
+				$values       = array_merge( $values, $owners );
+			}
+		}
+		$limit    = max( 1, min( 500, (int) ( $filters['limit'] ?? 100 ) ) );
+		$values[] = $limit;
+		$sql      = 'SELECT * FROM %i WHERE ' . implode( ' AND ', $where ) . ' ORDER BY comment_created_utc DESC LIMIT %d';
+		$values   = array_merge( array( $table ), $values );
+		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic clauses are code-owned and every value plus identifier uses a placeholder.
+
+		$records = array();
+		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
+			$is_owner = empty( $owners ) ? (bool) $row['known_owner'] : in_array( strtolower( (string) $row['author'] ), $owners, true );
+			unset( $row['mention_key'] );
+			foreach ( array( 'comment_created_utc', 'score', 'first_seen', 'last_seen' ) as $integer ) {
+				$row[ $integer ] = (int) $row[ $integer ];
+			}
+			$row['known_owner'] = $is_owner;
+			$records[]          = $row;
+		}
+		return $records;
+	}
+
+	/** Delete expired rows and enforce the current site's hard record cap. */
+	public static function cleanup(): array {
+		global $wpdb;
+		self::install();
+		$table  = self::tableName();
+		$before = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table ) );
+		self::enforceBounds();
+		$retained = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table ) );
+		$result   = array(
+			'deleted'        => $before - $retained,
+			'retained'       => $retained,
+			'retention_days' => self::retentionDays(),
+			'max_records'    => self::maxRecords(),
+		);
+		do_action( 'datamachine_log', 'info', 'Cleaned Reddit comment-domain observations', $result );
+		return $result;
+	}
+
+	private static function enforceBounds(): void {
+		global $wpdb;
+		$table  = self::tableName();
+		$cutoff = time() - ( self::retentionDays() * DAY_IN_SECONDS );
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE last_seen < %d', $table, $cutoff ) );
+		$max = self::maxRecords();
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE mention_key NOT IN (SELECT mention_key FROM (SELECT mention_key FROM %i ORDER BY last_seen DESC, mention_key ASC LIMIT %d) retained)', $table, $table, $max ) );
+	}
+
+	private static function replaceLock( array $current, array $replacement ): bool {
+		global $wpdb;
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->options} SET option_value = %s, autoload = %s WHERE option_name = %s AND option_value = %s",
+				maybe_serialize( $replacement ),
+				'no',
+				self::LOCK_OPTION,
+				maybe_serialize( $current )
+			)
+		);
+		wp_cache_delete( self::LOCK_OPTION, 'options' );
+		return 1 === $updated;
+	}
+
+	private static function tableName(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'datamachine_socials_reddit_comment_mentions';
+	}
+
+	private static function retentionDays(): int {
+		return max( 1, min( 365, (int) apply_filters( 'datamachine_socials_reddit_comment_retention_days', 90 ) ) );
+	}
+
+	private static function maxRecords(): int {
+		return max( 100, min( 10000, (int) apply_filters( 'datamachine_socials_reddit_comment_max_records', 5000 ) ) );
+	}
+
+	private static function timestamp( string $date, bool $end_of_day ): int {
+		if ( '' === trim( $date ) ) {
+			return 0;
+		}
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			$date .= $end_of_day ? ' 23:59:59 UTC' : ' 00:00:00 UTC';
+		}
+		$timestamp = strtotime( $date );
+		return false === $timestamp ? 0 : $timestamp;
+	}
+}

--- a/inc/Tracking/RedditCommentUrlMatcher.php
+++ b/inc/Tracking/RedditCommentUrlMatcher.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Canonical URL matching for bounded Reddit comment monitoring.
+ *
+ * @package DataMachineSocials
+ * @subpackage Tracking
+ */
+
+namespace DataMachineSocials\Tracking;
+
+defined( 'ABSPATH' ) || exit;
+
+class RedditCommentUrlMatcher {
+
+	/**
+	 * Extract canonical HTTP(S) URLs that match configured domains.
+	 *
+	 * @param string   $body               Reddit comment body.
+	 * @param string[] $domains            Canonical monitored domains.
+	 * @param bool     $include_subdomains Whether child hosts match.
+	 * @return array<int,array{domain:string,url:string,host:string}>
+	 */
+	public static function match( string $body, array $domains, bool $include_subdomains ): array {
+		$domains = array_values( array_filter( array_unique( array_map( array( self::class, 'normalizeDomain' ), $domains ) ) ) );
+		usort( $domains, static fn( string $left, string $right ): int => strlen( $right ) <=> strlen( $left ) );
+		if ( '' === trim( $body ) || empty( $domains ) ) {
+			return array();
+		}
+
+		$pattern = '~(?<![a-z0-9@._-])(?:https?://)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::[0-9]{1,5})?(?:/[^\s<>"\'\]\)]*)?~iu';
+		preg_match_all( $pattern, html_entity_decode( $body, ENT_QUOTES | ENT_HTML5, 'UTF-8' ), $found );
+
+		$matches = array();
+		foreach ( $found[0] ?? array() as $candidate ) {
+			$canonical = self::canonicalizeUrl( (string) $candidate );
+			if ( null === $canonical ) {
+				continue;
+			}
+
+			foreach ( $domains as $domain ) {
+				if ( $canonical['host'] !== $domain && ( ! $include_subdomains || ! str_ends_with( $canonical['host'], '.' . $domain ) ) ) {
+					continue;
+				}
+
+				$key             = $canonical['url'] . '|' . $canonical['host'];
+				$matches[ $key ] = array(
+					'domain' => $domain,
+					'url'    => $canonical['url'],
+					'host'   => $canonical['host'],
+				);
+				break;
+			}
+		}
+
+		return array_values( $matches );
+	}
+
+	/** Normalize a configured domain or URL to its registrable input host. */
+	public static function normalizeDomain( string $domain ): string {
+		$domain = strtolower( trim( $domain ) );
+		if ( '' === $domain ) {
+			return '';
+		}
+
+		$host = wp_parse_url( str_contains( $domain, '://' ) ? $domain : 'https://' . $domain, PHP_URL_HOST );
+		if ( ! is_string( $host ) ) {
+			return '';
+		}
+
+		$host = self::normalizeHost( $host );
+		return preg_match( '/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/', $host ) ? $host : '';
+	}
+
+	/**
+	 * Canonicalize one URL-like token.
+	 *
+	 * @return array{url:string,host:string}|null
+	 */
+	private static function canonicalizeUrl( string $candidate ): ?array {
+		$candidate = rtrim( trim( $candidate ), '.,;:!?}>' );
+		$url       = preg_match( '~^https?://~i', $candidate ) ? $candidate : 'https://' . $candidate;
+		$parts     = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return null;
+		}
+
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? 'https' ) );
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) || isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+			return null;
+		}
+
+		$host = self::normalizeHost( (string) $parts['host'] );
+		if ( '' === $host ) {
+			return null;
+		}
+
+		$port  = isset( $parts['port'] ) && ! ( 80 === $parts['port'] && 'http' === $scheme ) && ! ( 443 === $parts['port'] && 'https' === $scheme )
+			? ':' . (int) $parts['port']
+			: '';
+		$path  = isset( $parts['path'] ) ? (string) $parts['path'] : '';
+		$query = isset( $parts['query'] ) && '' !== $parts['query'] ? '?' . $parts['query'] : '';
+
+		return array(
+			'url'  => $scheme . '://' . $host . $port . $path . $query,
+			'host' => $host,
+		);
+	}
+
+	/** Normalize case, IDN form, trailing dot, and conventional www alias. */
+	private static function normalizeHost( string $host ): string {
+		$host = strtolower( rtrim( trim( $host ), '.' ) );
+		if ( function_exists( 'idn_to_ascii' ) ) {
+			$ascii = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+			$host  = false !== $ascii ? strtolower( $ascii ) : $host;
+		}
+		return str_starts_with( $host, 'www.' ) ? substr( $host, 4 ) : $host;
+	}
+}

--- a/tests/Unit/Abilities/Reddit/RedditCommentDomainMonitorAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/RedditCommentDomainMonitorAbilityTest.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * RedditCommentDomainMonitorAbility tests.
+ *
+ * @package DataMachineSocials\Tests\Unit\Abilities\Reddit
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities\Reddit;
+
+use DataMachineSocials\Abilities\Reddit\RedditCommentDomainMonitorAbility;
+use DataMachineSocials\Tracking\RedditCommentDomainStore;
+use DataMachineSocials\Tracking\RedditCommentUrlMatcher;
+use WP_UnitTestCase;
+
+class RedditCommentDomainMonitorAbilityTest extends WP_UnitTestCase {
+
+	private RedditCommentDomainMonitorAbility $ability;
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( RedditCommentDomainStore::STATE_OPTION );
+		delete_option( 'datamachine_socials_reddit_comment_db_version' );
+		delete_option( 'datamachine_socials_reddit_comment_monitor_lock' );
+		RedditCommentDomainStore::install();
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_socials_reddit_comment_mentions" );
+		$this->ability = new class() extends RedditCommentDomainMonitorAbility {
+			protected function getRedditAccessToken(): string|\WP_Error {
+				return 'test-token';
+			}
+		};
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'datamachine_socials_reddit_comment_retention_days' );
+		remove_all_filters( 'datamachine_socials_reddit_comment_max_records' );
+		delete_option( RedditCommentDomainStore::STATE_OPTION );
+		delete_option( 'datamachine_socials_reddit_comment_monitor_lock' );
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_socials_reddit_comment_mentions" );
+		parent::tear_down();
+	}
+
+	public function test_url_parser_matches_exact_domain_without_lookalikes(): void {
+		$matches = RedditCommentUrlMatcher::match(
+			'Valid https://www.example.com/path?x=1 and example.com/other; invalid example.com.evil.test/path and notexample.com/x.',
+			array( 'example.com' ),
+			false
+		);
+
+		$this->assertSame( array( 'https://example.com/path?x=1', 'https://example.com/other' ), array_column( $matches, 'url' ) );
+		$this->assertSame( array( 'example.com', 'example.com' ), array_column( $matches, 'host' ) );
+	}
+
+	public function test_url_parser_only_matches_subdomains_when_enabled(): void {
+		$body = 'https://news.example.com/story https://example.com/root';
+
+		$exact = RedditCommentUrlMatcher::match( $body, array( 'example.com' ), false );
+		$with  = RedditCommentUrlMatcher::match( $body, array( 'example.com' ), true );
+
+		$this->assertSame( array( 'example.com' ), array_column( $exact, 'host' ) );
+		$this->assertSame( array( 'news.example.com', 'example.com' ), array_column( $with, 'host' ) );
+	}
+
+	public function test_url_parser_handles_markdown_punctuation_and_multiple_urls(): void {
+		$matches = RedditCommentUrlMatcher::match(
+			'[First](https://example.com/one), then <https://example.com/two?x=1>. Not https://example.com.evil.test/no.',
+			array( 'example.com' ),
+			false
+		);
+
+		$this->assertSame( array( 'https://example.com/one', 'https://example.com/two?x=1' ), array_column( $matches, 'url' ) );
+	}
+
+	public function test_initial_poll_normalizes_matches_and_establishes_checkpoint(): void {
+		$this->mockPages(
+			array(
+				$this->page(
+					array(
+						$this->comment( 'newest', 'https://example.com/story', 'known_account', 12 ),
+						$this->comment( 'deletedauthor', 'example.com/other', '[deleted]', 2 ),
+						$this->comment( 'deletedbody', '[deleted]', 'someone', 0 ),
+					),
+					null
+				),
+			)
+		);
+
+		$result = $this->ability->executePoll( $this->pollInput( array( 'known_owners' => array( 'Known_Account' ) ) ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['data']['scopes']['WordPress']['truncated'] );
+		$this->assertSame( 't1_newest', $result['data']['scopes']['WordPress']['checkpoint'] );
+		$records = RedditCommentDomainStore::report( array( 'limit' => 100 ) );
+		$this->assertCount( 2, $records );
+		$this->assertSame( 'post-newest', $records[0]['parent_post_id'] );
+		$this->assertSame( 'Parent newest', $records[0]['parent_post_title'] );
+		$this->assertSame( 'https://www.reddit.com/r/WordPress/comments/post-newest/x/newest/', $records[0]['permalink'] );
+		$this->assertTrue( $records[0]['known_owner'] );
+		$this->assertSame( '[deleted]', $records[1]['author'] );
+	}
+
+	public function test_cursor_replay_advances_to_new_head_without_duplicates(): void {
+		$this->mockPages(
+			array(
+				$this->page( array( $this->comment( 'one', 'example.com/one' ) ), null ),
+				$this->page(
+					array(
+						$this->comment( 'two', 'example.com/two' ),
+						$this->comment( 'one', 'example.com/one' ),
+					),
+					null
+				),
+			)
+		);
+
+		$first  = $this->ability->executePoll( $this->pollInput() );
+		$second = $this->ability->executePoll( $this->pollInput() );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 1, $second['data']['scopes']['WordPress']['inserted'] );
+		$this->assertSame( 't1_two', RedditCommentDomainStore::getScope( 'WordPress' )['checkpoint'] );
+		$this->assertCount( 2, RedditCommentDomainStore::report( array( 'limit' => 100 ) ) );
+	}
+
+	public function test_store_suppresses_duplicate_comment_url_and_preserves_first_seen(): void {
+		$first_seen           = time();
+		$record               = $this->storedRecord( 'same', $first_seen );
+		$first                = RedditCommentDomainStore::upsert( array( $record ) );
+		$record['first_seen'] = $first_seen + 1;
+		$record['last_seen']  = $first_seen + 1;
+		$second               = RedditCommentDomainStore::upsert( array( $record ) );
+		$stored               = RedditCommentDomainStore::report( array( 'limit' => 10 ) );
+
+		$this->assertSame( array( 'inserted' => 1, 'updated' => 0 ), $first );
+		$this->assertSame( array( 'inserted' => 0, 'updated' => 1 ), $second );
+		$this->assertSame( $first_seen, $stored[0]['first_seen'] );
+		$this->assertSame( $first_seen + 1, $stored[0]['last_seen'] );
+	}
+
+	public function test_truncated_initial_scan_resumes_after_cursor_before_committing_head(): void {
+		$requested_after = array();
+		$newer           = $this->comment( 'three', 'example.com/three' );
+		$older           = $this->comment( 'two', 'example.com/two' );
+		$newer['created_utc'] = time();
+		$older['created_utc'] = $newer['created_utc'] - 60;
+		$this->mockPages(
+			array(
+				$this->page( array( $newer ), 'page-two' ),
+				$this->page( array( $older ), null ),
+			),
+			$requested_after
+		);
+
+		$first  = $this->ability->executePoll( $this->pollInput( array( 'max_pages' => 1 ) ) );
+		$scope  = RedditCommentDomainStore::getScope( 'WordPress' );
+		$second = $this->ability->executePoll( $this->pollInput( array( 'max_pages' => 1 ) ) );
+
+		$this->assertTrue( $first['data']['scopes']['WordPress']['truncated'] );
+		$this->assertArrayNotHasKey( 'checkpoint', $scope );
+		$this->assertSame( 'page-two', $scope['pending']['after'] );
+		$this->assertFalse( $second['data']['scopes']['WordPress']['truncated'] );
+		$this->assertSame( 't1_three', RedditCommentDomainStore::getScope( 'WordPress' )['checkpoint'] );
+		$this->assertSame( $older['created_utc'], RedditCommentDomainStore::getScope( 'WordPress' )['observed_from'] );
+		$this->assertSame( $newer['created_utc'], RedditCommentDomainStore::getScope( 'WordPress' )['observed_to'] );
+		$this->assertSame( array( '', 'page-two' ), $requested_after );
+	}
+
+	public function test_rate_limit_preserves_completed_checkpoint_and_safe_continuation(): void {
+		$this->mockPages(
+			array(
+				$this->page( array( $this->comment( 'one', 'example.com/one' ) ), null ),
+				$this->page( array( $this->comment( 'two', 'example.com/two' ) ), 'older-page' ),
+				$this->errorResponse( 429, 'Too Many Requests', array( 'retry-after' => '60' ) ),
+				$this->page( array( $this->comment( 'one', 'example.com/one' ) ), null ),
+			)
+		);
+
+		$this->ability->executePoll( $this->pollInput() );
+		$limited = $this->ability->executePoll( $this->pollInput( array( 'max_pages' => 2 ) ) );
+		$scope   = RedditCommentDomainStore::getScope( 'WordPress' );
+
+		$this->assertFalse( $limited['success'] );
+		$this->assertSame( 429, $limited['data']['errors']['WordPress']['data']['status'] );
+		$this->assertSame( '60', $limited['data']['errors']['WordPress']['data']['rate_limit']['retry_after'] );
+		$this->assertSame( 't1_one', $scope['checkpoint'] );
+		$this->assertSame( 'older-page', $scope['pending']['after'] );
+
+		$recovered = $this->ability->executePoll( $this->pollInput() );
+		$this->assertTrue( $recovered['success'] );
+		$this->assertSame( 't1_two', RedditCommentDomainStore::getScope( 'WordPress' )['checkpoint'] );
+		$this->assertCount( 2, RedditCommentDomainStore::report( array( 'limit' => 100 ) ) );
+	}
+
+	public function test_malformed_comment_does_not_advance_checkpoint(): void {
+		RedditCommentDomainStore::putScope( 'WordPress', array( 'checkpoint' => 't1_old', 'last_poll_at' => time() ) );
+		$this->mockPages(
+			array(
+				$this->page( array( array( 'body' => 'example.com/missing-id' ) ), 'next-page' ),
+			)
+		);
+
+		$result = $this->ability->executePoll( $this->pollInput() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 't1_old', RedditCommentDomainStore::getScope( 'WordPress' )['checkpoint'] );
+		$this->assertArrayNotHasKey( 'pending', RedditCommentDomainStore::getScope( 'WordPress' ) );
+	}
+
+	public function test_lock_is_non_autoloaded_and_only_owner_can_release_it(): void {
+		$token = RedditCommentDomainStore::acquireLock();
+		$this->assertIsString( $token );
+		$this->assertWPError( RedditCommentDomainStore::acquireLock() );
+		RedditCommentDomainStore::releaseLock( 'different-owner' );
+		$this->assertWPError( RedditCommentDomainStore::acquireLock() );
+
+		global $wpdb;
+		$autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", 'datamachine_socials_reddit_comment_monitor_lock' ) );
+		$this->assertNotContains( $autoload, wp_autoload_values_to_autoload() );
+
+		RedditCommentDomainStore::releaseLock( $token );
+		$this->assertIsString( RedditCommentDomainStore::acquireLock() );
+	}
+
+	public function test_poll_rejects_raw_access_token_input(): void {
+		$result = $this->ability->executePoll( $this->pollInput( array( 'access_token' => 'must-not-be-accepted' ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_param', $result->get_error_code() );
+	}
+
+	public function test_report_filters_owner_organic_date_and_engagement(): void {
+		$owner                  = $this->storedRecord( 'owner', time() );
+		$owner['author']        = 'team_account';
+		$owner['known_owner']   = false;
+		$owner['score']         = 20;
+		$organic                = $this->storedRecord( 'organic', time() - DAY_IN_SECONDS );
+		$organic['author']      = 'community_member';
+		$organic['known_owner'] = false;
+		$organic['score']       = 2;
+		RedditCommentDomainStore::upsert( array( $owner, $organic ) );
+
+		$result = $this->ability->executeReport(
+			array(
+				'domain'       => 'example.com',
+				'ownership'    => 'known_owner',
+				'known_owners' => array( 'TEAM_ACCOUNT' ),
+				'min_score'    => 10,
+				'date_from'    => gmdate( 'Y-m-d', time() - HOUR_IN_SECONDS ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['data']['count'] );
+		$this->assertSame( 'team_account', $result['data']['matches'][0]['author'] );
+		$this->assertTrue( $result['data']['matches'][0]['known_owner'] );
+		$this->assertFalse( $result['coverage']['all_reddit_search'] );
+		$this->assertFalse( $result['coverage']['historical_complete'] );
+	}
+
+	public function test_writes_remove_old_observations_and_enforce_cap(): void {
+		add_filter( 'datamachine_socials_reddit_comment_retention_days', static fn(): int => 7 );
+		add_filter( 'datamachine_socials_reddit_comment_max_records', static fn(): int => 100 );
+		$records = array();
+		for ( $index = 0; $index < 101; ++$index ) {
+			$records[] = $this->storedRecord( 'recent-' . $index, time() - $index );
+		}
+		$records[] = $this->storedRecord( 'old', time() - ( 8 * DAY_IN_SECONDS ) );
+		RedditCommentDomainStore::upsert( $records );
+
+		$result = RedditCommentDomainStore::cleanup();
+
+		$this->assertSame( 0, $result['deleted'] );
+		$this->assertSame( 100, $result['retained'] );
+		$this->assertCount( 100, RedditCommentDomainStore::report( array( 'limit' => 500 ) ) );
+	}
+
+	/** @param array<int,array<string,mixed>> $responses */
+	private function mockPages( array $responses, ?array &$requested_after = null ): void {
+		$requested_after = array();
+		$index           = 0;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $responses, &$requested_after, &$index ) {
+				parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+				$requested_after[] = (string) ( $query['after'] ?? '' );
+				$response          = $responses[ $index ] ?? end( $responses );
+				++$index;
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+
+	private function page( array $comments, ?string $after ): array {
+		return array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode(
+				array(
+					'data' => array(
+						'after'    => $after,
+						'children' => array_map( static fn( array $comment ): array => array( 'kind' => 't1', 'data' => $comment ), $comments ),
+					),
+				)
+			),
+		);
+	}
+
+	private function errorResponse( int $status, string $message, array $headers ): array {
+		return array(
+			'response' => array( 'code' => $status, 'message' => $message ),
+			'headers'  => $headers,
+			'body'     => wp_json_encode( array( 'message' => $message ) ),
+		);
+	}
+
+	private function comment( string $id, string $body, string $author = 'reader', int $score = 5 ): array {
+		return array(
+			'id'          => $id,
+			'name'        => 't1_' . $id,
+			'body'        => $body,
+			'author'      => $author,
+			'created_utc' => time(),
+			'score'       => $score,
+			'subreddit'   => 'WordPress',
+			'link_id'     => 't3_post-' . $id,
+			'link_title'  => 'Parent ' . $id,
+			'permalink'   => '/r/WordPress/comments/post-' . $id . '/x/' . $id . '/',
+		);
+	}
+
+	private function pollInput( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'domains'      => array( 'example.com' ),
+				'subreddits'   => array( 'WordPress' ),
+				'page_size'    => 100,
+				'max_pages'    => 5,
+			),
+			$overrides
+		);
+	}
+
+	private function storedRecord( string $id, int $seen ): array {
+		return array(
+			'comment_id'          => $id,
+			'comment_fullname'    => 't1_' . $id,
+			'parent_post_id'      => 'post-' . $id,
+			'parent_post_title'   => 'Parent ' . $id,
+			'subreddit'           => 'WordPress',
+			'author'              => 'reader',
+			'comment_created_utc' => $seen,
+			'score'               => 5,
+			'permalink'           => 'https://www.reddit.com/comment/' . $id,
+			'domain'              => 'example.com',
+			'matched_url'         => 'https://example.com/' . $id,
+			'matched_host'        => 'example.com',
+			'known_owner'         => false,
+			'first_seen'          => $seen,
+			'last_seen'           => $seen,
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add bounded incremental Reddit comment-domain polling for explicitly configured subreddit scopes
- persist normalized observations in a narrow site-owned table with durable compact checkpoints, atomic locks, hard retention/cap enforcement, and multisite-safe scheduling
- expose separate poll, read-only report, and destructive cleanup abilities plus validated WP-CLI commands and focused tests

## Contracts
- `datamachine/reddit-comment-mentions-poll` accepts up to 25 domains and 25 subreddit scopes, resolves Reddit OAuth exclusively through the existing server-side provider, and rejects injected access tokens or unknown properties
- `datamachine/reddit-comment-mentions-report` provides bounded domain, subreddit, date, ownership, score, and result filters with a fully declared read-only schema
- `datamachine/reddit-comment-mentions-cleanup` enforces retention and row caps under explicit mutating/destructive metadata
- WP-CLI exposes discoverable `monitor-comments`, `comment-mentions`, and `cleanup-comment-mentions` commands with strict integer and format validation

## Persistence and concurrency
- observations use the site-prefixed `datamachine_socials_reddit_comment_mentions` table, avoiding serialized observation growth and enabling indexed reporting and targeted deletion
- only compact checkpoint/lock/schema state uses non-autoloaded site options; retained scope state is capped at 25 entries
- observations default to 90-day retention and 5,000 rows, with immutable upper bounds of 365 days and 10,000 rows enforced during writes and daily cleanup
- lock acquisition, stale takeover, refresh, and release use owner-checked atomic option updates; every page renews ownership
- network deactivation clears each site's scheduled cleanup while preserving retained observations

## Cursor and matching safety
- Reddit's newest-first subreddit comment listing is traversed with its returned `after` cursor
- page observations and continuation are persisted before fetching another page; completed checkpoints advance only after reaching the previous checkpoint or exhausting an initial listing
- rate limits, HTTP failures, malformed JSON/entries, lost locks, unavailable checkpoints, and storage failures never advance the completed checkpoint
- exact host and optional child-host matching reject lookalikes, normalize `www`/IDN hosts, handle Markdown punctuation and multiple URLs, and deduplicate by comment fullname plus canonical URL and host
- normalized rows include deleted-author handling, parent post ID/title, subreddit, timestamp, score, permalink, matched URL/host, ownership, and first/last seen without retaining comment bodies
- coverage is explicitly bounded and never presented as global or historically complete Reddit search

## Verification
- PASS: PHP syntax for every changed PHP file
- PASS: WordPress PHPCS and PHPStan level 7 on changed runtime files (`homeboy review lint` run `8ecfc490-7ed5-4c87-aeaf-cfc16a7fef69`)
- PASS: scoped architecture audit with no introduced findings (run `4977afb4-ac55-48ee-a18d-0f575a5e2800`)
- PASS: `npm run build`
- PASS: `composer audit --locked` with no advisories
- PASS: `git diff --check`
- BLOCKED: managed PHPUnit focused run `ce5e625b-0411-435f-a417-84954a02eee4` and full run `2612e8d7-f105-4a7f-99ef-fe7aeb779ab1` both reached the WP Codebox runner but reported `Total: 0` / `wp-codebox-unknown`; no assertions executed
- BLOCKED: Homeboy's wrapper build stops before compilation because `/home/opencode/.config/homeboy/extensions/nodejs/scripts/lib/local-workspace-deps.sh` is missing; direct `npm run build` succeeds
- TRACKED: pre-existing npm dependency advisories are isolated in #215 rather than mixed into this feature

Closes #211