### PR TITLE
fix: stabilize delegated cross-user identity

### DIFF
--- a/inc/Operations/DelegatedCrossPostAction.php
+++ b/inc/Operations/DelegatedCrossPostAction.php
@@ -7,6 +7,8 @@
 
 namespace DataMachineSocials\Operations;
 
+use DataMachine\Core\Database\Jobs\Jobs;
+
 defined( 'ABSPATH' ) || exit;
 
 final class DelegatedCrossPostAction {
@@ -204,7 +206,6 @@ final class DelegatedCrossPostAction {
 			'source_url'              => $input['source_url'],
 			'delegated_operation_ref' => (string) ( $context['operation_ref'] ?? '' ),
 			'delegated_input'         => self::canonical_input( $input ),
-			'delegated_actor'         => self::bounded_actor( $context['actor'] ?? array() ),
 		);
 
 		return array(
@@ -411,6 +412,31 @@ final class DelegatedCrossPostAction {
 		}
 
 		return $normalized;
+	}
+
+	/** Resolve the frozen initiator from the verified delegated parent job. */
+	public static function resolve_effect_actor( int $parent_job_id, string $operation_ref ) {
+		if ( $parent_job_id <= 0 || ! preg_match( '/^dop_[a-f0-9]{64}$/', $operation_ref ) ) {
+			return self::error( 'effect_authorization_failed', 'The initiating actor could not be verified.' );
+		}
+
+		$job       = ( new Jobs() )->get_job( $parent_job_id );
+		$envelope  = is_array( $job['operation_envelope'] ?? null ) ? $job['operation_envelope'] : array();
+		$operation = is_array( $envelope['delegated_operation'] ?? null ) ? $envelope['delegated_operation'] : array();
+		if (
+			'delegated' !== ( $job['source'] ?? '' )
+			|| self::ACTION_ID !== ( $operation['action'] ?? '' )
+			|| ! hash_equals( (string) ( $operation['operation_ref'] ?? '' ), $operation_ref )
+		) {
+			return self::error( 'effect_authorization_failed', 'The initiating actor could not be verified.' );
+		}
+
+		$actor = self::bounded_actor( $operation['initiator'] ?? array() );
+		if ( 0 === $actor['user_id'] && 0 === $actor['agent_id'] ) {
+			return self::error( 'effect_authorization_failed', 'The initiating actor could not be verified.' );
+		}
+
+		return $actor;
 	}
 
 	private static function canonical_input( array $input ): array {

--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -38,11 +38,14 @@ class SocialCrossPostTask extends SystemTask {
 		$cover_url     = $params['cover_url'] ?? '';
 		$operation_ref = $params['delegated_operation_ref'] ?? '';
 		if ( '' !== $operation_ref ) {
-			$revalidated = DelegatedCrossPostAction::validate_effect(
-				is_array( $params['delegated_input'] ?? null ) ? $params['delegated_input'] : array(),
-				is_array( $params['delegated_actor'] ?? null ) ? $params['delegated_actor'] : array(),
-				$operation_ref
-			);
+			$actor       = DelegatedCrossPostAction::resolve_effect_actor( (int) ( $params['pipeline_job_id'] ?? 0 ), $operation_ref );
+			$revalidated = is_wp_error( $actor )
+				? $actor
+				: DelegatedCrossPostAction::validate_effect(
+					is_array( $params['delegated_input'] ?? null ) ? $params['delegated_input'] : array(),
+					$actor,
+					$operation_ref
+				);
 			if ( is_wp_error( $revalidated ) ) {
 				$this->complete_delegated_failure( $jobId, is_array( $platforms ) ? $platforms : array(), $revalidated->get_error_code() );
 				return;

--- a/tests/Integration/DelegatedCrossPostIntegrationTest.php
+++ b/tests/Integration/DelegatedCrossPostIntegrationTest.php
@@ -9,8 +9,9 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationRegistry;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\SystemTask\SystemTaskStep;
 use DataMachineSocials\Operations\DelegatedCrossPostAction;
-use DataMachineSocials\Tasks\SocialCrossPostTask;
 use DataMachineSocials\Tracking\SocialShareTracker;
 
 final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
@@ -21,6 +22,7 @@ final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
 	private int $post_id;
 	private int $attachment_id;
 	private bool $authority = true;
+	private array $authorization_observations = array();
 
 	public function set_up(): void {
 		parent::set_up();
@@ -49,6 +51,10 @@ final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
 
 	public function authorize( bool $authorized, array $context ): bool {
 		unset( $authorized );
+		$this->authorization_observations[] = array(
+			'phase' => (string) ( $context['phase'] ?? '' ),
+			'actor' => $context['actor'] ?? array(),
+		);
 		return $this->authority && in_array( (int) ( $context['actor']['user_id'] ?? 0 ), array( $this->first_actor, $this->second_actor ), true );
 	}
 
@@ -77,27 +83,34 @@ final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
 
 	public function test_effect_time_authority_and_live_resources_fail_closed(): void {
 		wp_set_current_user( $this->first_actor );
-		$normalized = DelegatedCrossPostAction::normalize_input( $this->submission_input( array( 'twitter' ) ) );
-		$this->assertIsArray( $normalized );
-		$prepared = DelegatedCrossPostAction::prepare(
-			$normalized,
+		$service    = new DelegatedOperationService();
+		$submitted  = $service->submit( $this->submission( 'effect-authority', array( 'twitter' ) ) );
+		$parent_job = $this->job( 'effect-authority' );
+		$actor      = DelegatedCrossPostAction::resolve_effect_actor( (int) $parent_job['job_id'], $submitted['operation_ref'] );
+		$this->assertSame( $this->first_actor, $actor['user_id'] );
+
+		$this->authority                  = false;
+		$this->authorization_observations = array();
+		( new SystemTaskStep() )->execute(
 			array(
-				'operation_ref' => 'dop_' . str_repeat( 'a', 64 ),
-				'actor'         => array( 'user_id' => $this->first_actor, 'agent_id' => 0 ),
+				'job_id'       => (int) $parent_job['job_id'],
+				'flow_step_id' => (string) $parent_job['operation_step_id'],
+				'data'         => array(),
+				'engine'       => new EngineData( $parent_job['engine_data'], (int) $parent_job['job_id'] ),
 			)
 		);
-		$params = $prepared['workflow']['steps'][0]['flow_step_settings']['params'];
-
-		$this->authority = false;
-		$child_job_id    = ( new Jobs() )->create_job( array( 'source' => 'test', 'status' => 'processing', 'engine_data' => array() ) );
-		$this->assertIsInt( $child_job_id );
-		( new SocialCrossPostTask() )->executeTask( $child_job_id, $params );
-		$denied = ( new Jobs() )->get_job( $child_job_id );
+		$this->assertSame( 'effect', $this->authorization_observations[0]['phase'] );
+		$this->assertSame( $this->first_actor, (int) $this->authorization_observations[0]['actor']['user_id'] );
+		$children = ( new Jobs() )->get_children( (int) $parent_job['job_id'] );
+		$this->assertCount( 1, $children );
+		$denied = $children[0];
 		$this->assertSame( 'failed - delegated_cross_post_effect_denied', $denied['engine_data']['job_status'] );
 		$this->assertSame( 'effect_authorization_failed', $denied['engine_data']['output_data_packets'][0]['metadata']['source_item_id'] );
 		$this->assertSame( array(), SocialShareTracker::get_shares( $this->post_id ) );
 
 		$this->authority = true;
+		$normalized      = DelegatedCrossPostAction::normalize_input( $this->submission_input( array( 'twitter' ) ) );
+		$this->assertIsArray( $normalized );
 		wp_update_post( array( 'ID' => $this->post_id, 'post_status' => 'draft' ) );
 		$this->assertWPError( DelegatedCrossPostAction::validate_effect( $normalized, array( 'user_id' => $this->first_actor ), 'dop_' . str_repeat( 'a', 64 ) ) );
 		wp_update_post( array( 'ID' => $this->post_id, 'post_status' => 'publish' ) );
@@ -109,6 +122,32 @@ final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
 		$changed_caption                 = $normalized;
 		$changed_caption['caption']      = 'Changed after approval.';
 		$this->assertWPError( DelegatedCrossPostAction::validate_effect( $changed_caption, array( 'user_id' => $this->first_actor ), 'dop_' . str_repeat( 'a', 64 ) ) );
+	}
+
+	public function test_cross_actor_replay_reuses_receipt_and_job_while_changed_input_conflicts(): void {
+		$service = new DelegatedOperationService();
+		$request = $this->submission( 'cross-actor-replay', array( 'instagram' ) );
+
+		wp_set_current_user( $this->first_actor );
+		$first     = $service->submit( $request );
+		$first_job = $this->job( 'cross-actor-replay' );
+
+		wp_set_current_user( $this->second_actor );
+		$second     = $service->submit( $request );
+		$second_job = $this->job( 'cross-actor-replay' );
+
+		$this->assertTrue( $first['success'] ?? false, wp_json_encode( $first ) );
+		$this->assertTrue( $second['success'] ?? false, wp_json_encode( $second ) );
+		$this->assertTrue( $second['replayed'] );
+		$this->assertSame( $first['operation_ref'], $second['operation_ref'] );
+		$this->assertSame( (int) $first_job['job_id'], (int) $second_job['job_id'] );
+
+		$changed                         = $request;
+		$changed['input']['caption']      = 'A different approved caption.';
+		$changed['input']['content_hash'] = hash( 'sha256', $changed['input']['caption'] );
+		$conflict                        = $service->submit( $changed );
+		$this->assertFalse( $conflict['success'] );
+		$this->assertSame( 'delegated_operation_conflict', $conflict['error_code'] );
 	}
 
 	public function test_cross_actor_partial_retry_reuses_parent_and_live_receipts(): void {

--- a/tests/delegated-cross-post-action-smoke.php
+++ b/tests/delegated-cross-post-action-smoke.php
@@ -10,6 +10,7 @@ namespace {
 
 	$GLOBALS['delegated_cross_post_filters'] = array();
 	$GLOBALS['delegated_cross_post_jobs']    = array();
+	$GLOBALS['delegated_cross_post_parent_jobs'] = array();
 	$GLOBALS['delegated_cross_post_shares']  = array();
 
 	class WP_Error {
@@ -102,6 +103,14 @@ namespace {
 		102 => array( 'url' => 'https://example.test/uploads/image-two.jpg', 'mime' => 'image/jpeg' ),
 		103 => array( 'url' => 'https://example.test/uploads/video.mp4', 'mime' => 'video/mp4' ),
 	);
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public function get_job( int $job_id ): ?array {
+			return $GLOBALS['delegated_cross_post_parent_jobs'][ $job_id ] ?? null;
+		}
+	}
 }
 
 namespace DataMachine\Engine\AI\System\Tasks {
@@ -203,13 +212,14 @@ namespace {
 	$assert( $normalized === $second_normalized, 'normalized fingerprint input is actor-neutral' );
 
 	$prepared = $action['prepare']( $normalized, array( 'operation_ref' => 'dop_' . str_repeat( 'a', 64 ), 'actor' => array( 'user_id' => 11 ) ) );
-	$second_prepared = $action['prepare']( $second_normalized, array( 'operation_ref' => 'dop_' . str_repeat( 'a', 64 ), 'actor' => array( 'user_id' => 11 ) ) );
+	$second_prepared = $action['prepare']( $second_normalized, array( 'operation_ref' => 'dop_' . str_repeat( 'a', 64 ), 'actor' => array( 'user_id' => 12 ) ) );
 	$settings = $prepared['workflow']['steps'][0]['flow_step_settings'] ?? array();
 	$assert( 7 === ( $prepared['owner_user_id'] ?? null ) && 9 === ( $prepared['agent_id'] ?? null ), 'prepare binds a stable owner and registered agent' );
 	$assert( 'system_task' === ( $prepared['workflow']['steps'][0]['step_type'] ?? null ) && 'social_cross_post' === ( $settings['task_type'] ?? null ), 'prepare composes the canonical system-task workflow' );
 	$assert( 'dop_' . str_repeat( 'a', 64 ) === ( $settings['params']['delegated_operation_ref'] ?? null ), 'opaque operation identity reaches the idempotent owner task' );
 	$assert( $prepared === $second_prepared, 'two authorized actors compose one frozen owner workflow' );
 	$encoded_prepare = json_encode( $prepared );
+	$assert( ! str_contains( $encoded_prepare, 'delegated_actor' ), 'frozen owner workflow excludes the initiating actor' );
 	$assert( ! str_contains( $encoded_prepare, 'TaskScheduler' ) && ! str_contains( $encoded_prepare, 'execute-workflow' ), 'owner workflow exposes no scheduler or arbitrary ability launch' );
 
 	$bad_hash                 = $input;
@@ -252,6 +262,17 @@ namespace {
 	$assert( is_wp_error( $action['normalize_input']( $instagram_boundary, array() ) ), 'Instagram rejects a caption that its publisher would truncate' );
 
 	$task = new SocialCrossPostTask();
+	$GLOBALS['delegated_cross_post_parent_jobs'][49] = array(
+		'source'             => 'delegated',
+		'operation_envelope' => array(
+			'delegated_operation' => array(
+				'action'        => DelegatedCrossPostAction::ACTION_ID,
+				'operation_ref' => 'dop_' . str_repeat( 'a', 64 ),
+				'initiator'     => array( 'user_id' => 11, 'agent_id' => 0 ),
+			),
+		),
+	);
+	$settings['params']['pipeline_job_id'] = 49;
 	$task->executeTask(
 		50,
 		array_merge(


### PR DESCRIPTION
## Summary
- keep owner-prepared cross-post workflows actor-neutral so authorized users share one delegated operation fingerprint and receipt
- reload and verify the frozen initiating actor from the durable delegated parent immediately before effects
- add real Data Machine contract coverage for cross-actor replay, changed-input conflict, and effect-time authorization through `SystemTaskStep`

## Checks
- `php -l` on all changed PHP files
- `php tests/delegated-cross-post-action-smoke.php` (44 assertions)
- Homeboy changed-file lint: PHPCS, PHPStan level 7, ESLint (0 findings)
- Homeboy PR audit (0 introduced findings)
- `npm run build`
- independent exact-diff review (no findings after fixing one test-coverage finding)

## Environment limitations
- WP Codebox PHPUnit selected both changed tests but returned `Total: 0` / `wp-codebox-unknown`; run `2291cc2d-6f1e-46fe-ace1-6fe9c51404bb`
- Homeboy build wrapper stopped before the project build because its installed Node extension helper `local-workspace-deps.sh` is missing; the native `npm run build` completed successfully

Fixes #217