### PR TITLE
fix: preserve Reddit monitor lock refreshes

### DIFF
--- a/inc/Tracking/RedditCommentDomainStore.php
+++ b/inc/Tracking/RedditCommentDomainStore.php
@@ -116,6 +116,9 @@ class RedditCommentDomainStore {
 			'token'      => $token,
 			'expires_at' => time() + ( 30 * MINUTE_IN_SECONDS ),
 		);
+		if ( $current === $replacement ) {
+			return true;
+		}
 		return self::replaceLock( $current, $replacement );
 	}
 

--- a/tests/Unit/Abilities/Reddit/RedditCommentDomainMonitorAbilityTest.php
+++ b/tests/Unit/Abilities/Reddit/RedditCommentDomainMonitorAbilityTest.php
@@ -213,6 +213,9 @@ class RedditCommentDomainMonitorAbilityTest extends WP_UnitTestCase {
 		$token = RedditCommentDomainStore::acquireLock();
 		$this->assertIsString( $token );
 		$this->assertWPError( RedditCommentDomainStore::acquireLock() );
+		$this->assertTrue( RedditCommentDomainStore::refreshLock( $token ) );
+		$this->assertTrue( RedditCommentDomainStore::refreshLock( $token ), 'A same-second owner refresh must remain idempotent.' );
+		$this->assertFalse( RedditCommentDomainStore::refreshLock( 'different-owner' ) );
 		RedditCommentDomainStore::releaseLock( 'different-owner' );
 		$this->assertWPError( RedditCommentDomainStore::acquireLock() );
 


### PR DESCRIPTION
## Summary
- treat a same-owner lock refresh as successful when the desired expiry value is already stored
- preserve compare-and-swap updates for changed expiries and reject different owners
- add regression assertions for repeated same-second refreshes

## Live evidence
The first production multi-scope poll after v0.19.0 safely checkpointed Charleston, then lost the shared lock while entering Nashville because a same-second expiry update changed zero MySQL rows. Remaining scopes were not processed; cursor state was retained.

## Verification
- runtime file: PHPCS and PHPStan level 7 passed
- regression test file: scoped syntax lint passed
- PHP syntax and `git diff --check` passed
- full managed PHPUnit remains blocked by #202

Closes #219