### PR TITLE
feat: add recent social comments inbox contract

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -73,6 +73,8 @@ function datamachine_socials_bootstrap() {
 	}
 
 	// Load Abilities (they self-register)
+	new \DataMachineSocials\Abilities\SocialCommentsAbility();
+
 	// Pinterest
 	new \DataMachineSocials\Abilities\Pinterest\PinterestBoardsAbility();
 	new \DataMachineSocials\Abilities\Pinterest\PinterestPublishAbility();

--- a/inc/Abilities/SocialCommentsAbility.php
+++ b/inc/Abilities/SocialCommentsAbility.php
@@ -177,7 +177,7 @@ class SocialCommentsAbility extends AbstractSocialAbility {
 
 		return array(
 			'id'              => (string) ( $comment['id'] ?? '' ),
-			'provider'        => $provider,
+			'platform'        => $provider,
 			'media_id'        => $media_id,
 			'author_username' => (string) ( $comment['username'] ?? $comment['from']['name'] ?? '' ),
 			'text'            => $text,

--- a/inc/Abilities/SocialCommentsAbility.php
+++ b/inc/Abilities/SocialCommentsAbility.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Generic account-level social comments ability.
+ *
+ * @package DataMachineSocials
+ */
+
+namespace DataMachineSocials\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Fetch recent comments without requiring callers to enumerate media.
+ */
+class SocialCommentsAbility extends AbstractSocialAbility {
+
+	protected static bool $registered = false;
+
+	private const PROVIDERS = array(
+		'instagram' => 'datamachine/instagram-read',
+		'facebook'  => 'datamachine/facebook-read',
+	);
+
+	public function __construct() {
+		$this->registerAbility( $this->registerCallback(), true );
+	}
+
+	private function registerCallback(): callable {
+		return function () {
+			wp_register_ability(
+				'datamachine/social-comments',
+				array(
+					'label'               => __( 'Read Recent Social Comments', 'data-machine-socials' ),
+					'description'         => __( 'Read recent account comments through a normalized provider-independent contract.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'   => array( 'type' => 'string', 'enum' => array( 'recent_comments' ), 'default' => 'recent_comments' ),
+							'provider' => array( 'type' => 'string', 'description' => __( 'Provider slug.', 'data-machine-socials' ) ),
+							'limit'    => array( 'type' => 'integer', 'default' => 25, 'description' => __( 'Maximum comments to return.', 'data-machine-socials' ) ),
+							'after'    => array( 'type' => 'string', 'description' => __( 'Provider cursor for the next media page.', 'data-machine-socials' ) ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can( 'use_tools' );
+	}
+
+	/**
+	 * Return the stable account-level result envelope.
+	 *
+	 * Provider reads are deliberately performed through existing read abilities;
+	 * this layer owns only aggregation and normalization.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public function execute( array $input ): array {
+		if ( 'recent_comments' !== ( $input['action'] ?? 'recent_comments' ) ) {
+			return array(
+				'success' => false,
+				'data'    => array(
+					'provider' => sanitize_key( $input['provider'] ?? '' ),
+					'comments' => array(),
+					'count'    => 0,
+					'partial'  => false,
+					'status'   => 'invalid_action',
+				),
+				'error'   => 'Unknown action. Use recent_comments.',
+			);
+		}
+
+		$provider = sanitize_key( $input['provider'] ?? '' );
+		$base     = array(
+			'provider'    => $provider,
+			'comments'    => array(),
+			'count'       => 0,
+			'partial'     => false,
+			'status'      => 'ok',
+			'next_cursor' => null,
+		);
+
+		if ( ! isset( self::PROVIDERS[ $provider ] ) ) {
+			$base['status'] = 'unsupported';
+			$base['error']  = 'Recent comments are not supported for this provider.';
+			return array( 'success' => false, 'data' => $base, 'error' => 'Recent comments are not supported for this provider.' );
+		}
+
+		$ability = $this->getProviderAbility( $provider );
+		if ( ! $ability ) {
+			$base['status'] = 'provider_error';
+			$base['error']  = 'The provider read ability is not available.';
+			return array( 'success' => false, 'data' => $base, 'error' => 'The provider read ability is not available.' );
+		}
+
+		$limit = min( max( absint( $input['limit'] ?? 25 ), 1 ), 100 );
+		$list  = array( 'action' => 'list', 'limit' => 25 );
+		if ( ! empty( $input['after'] ) ) {
+			$list['after'] = sanitize_text_field( $input['after'] );
+		}
+
+		$media_result = $ability->execute( $list );
+		if ( is_wp_error( $media_result ) || empty( $media_result['success'] ) ) {
+			$base['status'] = 'provider_error';
+			$base['error']  = $this->errorMessage( $media_result, 'Provider media read failed.' );
+			return array( 'success' => false, 'data' => $base, 'error' => $base['error'] );
+		}
+
+		$media = $media_result['data']['media'] ?? $media_result['data']['posts'] ?? $media_result['data']['threads'] ?? array();
+		foreach ( $media as $item ) {
+			$media_id = $item['id'] ?? '';
+			if ( ! $media_id ) {
+				continue;
+			}
+
+			$comments_result = $ability->execute( array(
+				'action'   => 'comments',
+				'media_id' => $media_id,
+				'post_id'  => $media_id,
+				'limit'    => min( 25, $limit ),
+			) );
+			if ( is_wp_error( $comments_result ) || empty( $comments_result['success'] ) ) {
+				$base['partial'] = ! empty( $base['comments'] );
+				$base['status']  = $base['partial'] ? 'partial' : 'provider_error';
+				$base['error']   = $this->errorMessage( $comments_result, 'Provider comments read failed.' );
+				if ( ! $base['partial'] ) {
+					return array( 'success' => false, 'data' => $base, 'error' => $base['error'] );
+				}
+				break;
+			}
+
+			$raw_comments = $comments_result['data']['comments'] ?? array();
+			foreach ( $raw_comments as $comment ) {
+				$base['comments'][] = $this->normalizeComment( $comment, $provider, $media_id );
+			}
+		}
+
+		usort( $base['comments'], static function ( array $left, array $right ): int {
+			return strcmp( $right['timestamp'], $left['timestamp'] );
+		} );
+		$base['comments'] = array_slice( $base['comments'], 0, $limit );
+
+		$base['count'] = count( $base['comments'] );
+		if ( ! empty( $media_result['data']['has_next'] ) && 'ok' === $base['status'] ) {
+			$base['partial'] = true;
+			$base['status']  = 'partial';
+		}
+		$base['next_cursor'] = $media_result['data']['cursors']['after'] ?? null;
+
+		return array( 'success' => true, 'data' => $base );
+	}
+
+	private function normalizeComment( array $comment, string $provider, string $media_id ): array {
+		$text     = (string) ( $comment['text'] ?? $comment['message'] ?? '' );
+		$mentions = array();
+		if ( preg_match_all( '/@([a-zA-Z0-9._]{1,30})/', $text, $matches ) ) {
+			$mentions = array_values( array_unique( $matches[1] ) );
+		}
+
+		return array(
+			'id'              => (string) ( $comment['id'] ?? '' ),
+			'provider'        => $provider,
+			'media_id'        => $media_id,
+			'author_username' => (string) ( $comment['username'] ?? $comment['from']['name'] ?? '' ),
+			'text'            => $text,
+			'timestamp'       => (string) ( $comment['timestamp'] ?? $comment['created_time'] ?? '' ),
+			'like_count'      => (int) ( $comment['like_count'] ?? 0 ),
+			'reply_count'     => (int) ( $comment['reply_count'] ?? 0 ),
+			'mentions'        => $mentions,
+			'parent_id'       => $comment['parent_id'] ?? null,
+			'raw'             => $comment,
+		);
+	}
+
+	/** Resolve the existing platform read ability. Overridable for contract tests. */
+	protected function getProviderAbility( string $provider ) {
+		return wp_get_ability( self::PROVIDERS[ $provider ] );
+	}
+
+	private function errorMessage( $result, string $fallback ): string {
+		return is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? $fallback );
+	}
+}

--- a/inc/RestApi.php
+++ b/inc/RestApi.php
@@ -147,9 +147,9 @@ class RestApi {
 				),
 				'media_id' => array(
 					'type'              => 'string',
-					'required'          => true,
+					'required'          => false,
 					'sanitize_callback' => 'sanitize_text_field',
-					'description'       => 'Platform-specific post/media ID.',
+					'description'       => 'Optional platform-specific post/media ID. Omit for recent account comments.',
 				),
 				'all' => array(
 					'type'              => 'boolean',
@@ -720,6 +720,10 @@ class RestApi {
 		$media_id = $request->get_param( 'media_id' );
 		$all      = $request->get_param( 'all' );
 
+		if ( empty( $media_id ) ) {
+			return self::get_recent_comments( $request );
+		}
+
 		$slug_map = array(
 			'instagram' => 'datamachine/instagram-read',
 			'facebook'  => 'datamachine/facebook-read',
@@ -730,13 +734,6 @@ class RestApi {
 			return new \WP_REST_Response( array(
 				'success' => false,
 				'error'   => "Comments not supported for platform: {$platform}",
-			), 400 );
-		}
-
-		if ( empty( $media_id ) ) {
-			return new \WP_REST_Response( array(
-				'success' => false,
-				'error'   => 'media_id is required',
 			), 400 );
 		}
 
@@ -769,6 +766,22 @@ class RestApi {
 		}
 
 		return new \WP_REST_Response( $result, $result['success'] ? 200 : 500 );
+	}
+
+	/** Return recent account comments through the generic owner-layer ability. */
+	public static function get_recent_comments( \WP_REST_Request $request ) {
+		$ability = wp_get_ability( 'datamachine/social-comments' );
+		if ( ! $ability ) {
+			return new \WP_REST_Response( array( 'success' => false, 'error' => 'Social comments ability not registered.' ), 500 );
+		}
+
+		$result = $ability->execute( array(
+			'provider' => $request->get_param( 'platform' ),
+			'limit'    => $request->get_param( 'limit' ),
+			'after'    => $request->get_param( 'after' ),
+		) );
+
+		return new \WP_REST_Response( $result, $result['success'] ? 200 : ( 'unsupported' === ( $result['data']['status'] ?? '' ) ? 400 : 502 ) );
 	}
 
 	/**

--- a/tests/Unit/Abilities/SocialCommentsAbilityTest.php
+++ b/tests/Unit/Abilities/SocialCommentsAbilityTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Contract tests for the generic account-level comments ability.
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities;
+
+use DataMachineSocials\Abilities\SocialCommentsAbility;
+use WP_UnitTestCase;
+
+class SocialCommentsAbilityTest extends WP_UnitTestCase {
+
+	private SocialCommentsAbility $ability;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->ability = new SocialCommentsAbility();
+	}
+
+	public function test_unsupported_provider_is_explicit(): void {
+		$result = $this->ability->execute( array( 'provider' => 'threads' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'threads', $result['data']['provider'] );
+		$this->assertSame( 'unsupported', $result['data']['status'] );
+		$this->assertFalse( $result['data']['partial'] );
+	}
+
+	public function test_missing_provider_is_explicitly_unsupported(): void {
+		$result = $this->ability->execute( array() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'unsupported', $result['data']['status'] );
+	}
+
+	public function test_unknown_action_is_rejected_by_the_contract(): void {
+		$result = $this->ability->execute( array( 'action' => 'comments' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'invalid_action', $result['data']['status'] );
+	}
+
+	public function test_supported_provider_without_read_ability_is_provider_error(): void {
+		$result = $this->ability->execute( array( 'provider' => 'facebook' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'provider_error', $result['data']['status'] );
+		$this->assertNotEmpty( $result['data']['error'] );
+	}
+
+	public function test_supported_provider_returns_globally_sorted_normalized_comments(): void {
+		$ability = new class() extends SocialCommentsAbility {
+			protected function getProviderAbility( string $provider ) {
+				return new class() {
+					public function execute( array $input ): array {
+						if ( 'list' === $input['action'] ) {
+							return array(
+								'success' => true,
+								'data'    => array(
+									'media'    => array( array( 'id' => 'new-post' ), array( 'id' => 'old-post' ) ),
+									'has_next' => false,
+								),
+							);
+						}
+
+						$timestamp = 'new-post' === $input['media_id'] ? '2026-08-01T10:00:00Z' : '2026-08-02T10:00:00Z';
+						return array(
+							'success' => true,
+							'data'    => array(
+								'comments' => array( array(
+									'id'        => $input['media_id'] . '-comment',
+									'username'  => 'listener',
+									'text'      => 'Thanks @extrachill',
+									'timestamp' => $timestamp,
+								) ),
+							),
+						);
+					}
+				};
+			}
+		};
+
+		$result = $ability->execute( array( 'provider' => 'instagram', 'limit' => 2 ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'old-post-comment', $result['data']['comments'][0]['id'] );
+		$this->assertSame( 'old-post', $result['data']['comments'][0]['media_id'] );
+		$this->assertSame( array( 'extrachill' ), $result['data']['comments'][0]['mentions'] );
+		$this->assertSame( 2, $result['data']['count'] );
+	}
+}

--- a/tests/Unit/Abilities/SocialCommentsAbilityTest.php
+++ b/tests/Unit/Abilities/SocialCommentsAbilityTest.php
@@ -84,6 +84,7 @@ class SocialCommentsAbilityTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 'old-post-comment', $result['data']['comments'][0]['id'] );
+		$this->assertSame( 'instagram', $result['data']['comments'][0]['platform'] );
 		$this->assertSame( 'old-post', $result['data']['comments'][0]['media_id'] );
 		$this->assertSame( array( 'extrachill' ), $result['data']['comments'][0]['mentions'] );
 		$this->assertSame( 2, $result['data']['count'] );

--- a/tests/Unit/RestApiRecentCommentsTest.php
+++ b/tests/Unit/RestApiRecentCommentsTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Contract tests for account-level recent comments routing.
+ */
+
+namespace DataMachineSocials\Tests\Unit;
+
+use DataMachineSocials\RestApi;
+use WP_UnitTestCase;
+
+class RestApiRecentCommentsTest extends WP_UnitTestCase {
+
+	public function test_omitted_media_id_uses_recent_comments_contract(): void {
+		$request = new \WP_REST_Request( 'GET', '/datamachine/v1/socials/comments/threads' );
+		$request->set_param( 'platform', 'threads' );
+
+		$response = RestApi::get_comments( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertStringContainsString( 'not supported', $data['error'] );
+		$this->assertStringNotContainsString( 'media_id is required', $data['error'] );
+	}
+
+	public function test_comments_route_does_not_require_media_id(): void {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes();
+		$route  = $routes['/datamachine/v1/socials/comments/(?P<platform>[a-z]+)'][0];
+
+		$this->assertFalse( $route['args']['media_id']['required'] );
+	}
+}


### PR DESCRIPTION
## Summary
- allow the generic comments route to omit `media_id` and resolve an account-level recent-comments inbox
- aggregate existing Instagram and Facebook read abilities behind one normalized, globally sorted contract
- report unsupported providers, partial pagination, provider failures, and media-page cursors explicitly while preserving per-media reads

## Testing
- PHP syntax checks for implementation and tests
- `npm run build`
- `git diff --check`
- Homeboy changed-scope audit: no introduced findings
- added supported, unsupported, omitted-media, normalization, sorting, and route-schema PHPUnit coverage

Homeboy selected the PHPUnit files but activated only the validation dependency and reported zero tests; tracked in Extra-Chill/homeboy#11406.

Closes #221