### PR TITLE
feat: expose retryable social publish deliveries

### DIFF
--- a/inc/Abilities/SocialPublishAbility.php
+++ b/inc/Abilities/SocialPublishAbility.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Durable social publish abilities.
+ *
+ * @package DataMachineSocials\Abilities
+ */
+
+namespace DataMachineSocials\Abilities;
+
+use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\ExecutionScope;
+use DataMachineSocials\Operations\DelegatedCrossPostAction;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Expose the Socials-owned publish lifecycle without leaking scheduler details. */
+class SocialPublishAbility extends AbstractSocialAbility {
+
+	protected static bool $registered = false;
+
+	private const RETRYABLE_DELIVERY_ERRORS = array( 'channel_unavailable', 'undelivered' );
+
+	public function __construct() {
+		$this->registerAbility( array( $this, 'registerAbilities' ), true );
+	}
+
+	/** Register enqueue, state, and retry as one public owner contract. */
+	public function registerAbilities(): void {
+		$output   = array(
+			'type'                 => 'object',
+			'required'             => array( 'success' ),
+			'properties'           => array(
+				'success'  => array( 'type' => 'boolean' ),
+				'delivery' => array( 'type' => 'object' ),
+				'error'    => array( 'type' => 'object' ),
+			),
+			'additionalProperties' => false,
+		);
+		$identity = array(
+			'type'                 => 'object',
+			'required'             => array( 'delivery_ref' ),
+			'properties'           => array(
+				'delivery_ref' => array(
+					'type'    => 'string',
+					'pattern' => '^dop_[a-f0-9]{64}$',
+				),
+			),
+			'additionalProperties' => false,
+		);
+
+		wp_register_ability(
+			'datamachine/enqueue-social-publish',
+			array(
+				'label'               => __( 'Enqueue Social Publish', 'data-machine-socials' ),
+				'description'         => __( 'Idempotently enqueue an authorized publish of canonical content to a bounded target policy.', 'data-machine-socials' ),
+				'category'            => 'datamachine-socials',
+				'input_schema'        => $this->enqueueSchema(),
+				'output_schema'       => $output,
+				'execute_callback'    => array( $this, 'enqueue' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		foreach (
+			array(
+				'get'   => 'getState',
+				'retry' => 'retry',
+			) as $verb => $callback
+		) {
+			wp_register_ability(
+				'datamachine/' . $verb . '-social-publish',
+				array(
+					/* translators: %s: Get or Retry. */
+					'label'               => sprintf( __( '%s Social Publish', 'data-machine-socials' ), ucfirst( $verb ) ),
+					'description'         => __( 'Read or explicitly retry one owner-authorized social delivery.', 'data-machine-socials' ),
+					'category'            => 'datamachine-socials',
+					'input_schema'        => $identity,
+					'output_schema'       => $output,
+					'execute_callback'    => array( $this, $callback ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		}
+	}
+
+	/** Require an authenticated actor; owner policy performs resource authorization. */
+	public function checkPermission(): bool {
+		$scope = ExecutionScope::current( 'manage_flows' );
+		return $scope->acting_user_id() > 0 || (int) ( $scope->acting_agent_id() ?? 0 ) > 0;
+	}
+
+	/** Submit canonical content through Data Machine's public delegated operation ability. */
+	public function enqueue( array $input ): array {
+		$content = is_array( $input['content_ref'] ?? null ) ? $input['content_ref'] : array();
+		$policy  = is_array( $input['target_policy'] ?? null ) ? $input['target_policy'] : array();
+		$targets = is_array( $policy['channels'] ?? null ) ? $policy['channels'] : array();
+
+		$unavailable = array();
+		foreach ( $targets as $target ) {
+			$status = $this->providerStatus( (string) $target );
+			if ( 'ready' !== $status ) {
+				$unavailable[] = array(
+					'channel' => sanitize_key( (string) $target ),
+					'status'  => $status,
+				);
+			}
+		}
+		if ( $unavailable ) {
+			return $this->failure( 'social_publish_provider_unavailable', __( 'One or more target providers are unavailable.', 'data-machine-socials' ), false, array( 'providers' => $unavailable ) );
+		}
+
+		$result = $this->invokeDelegated(
+			'submit',
+			array(
+				'action'       => DelegatedCrossPostAction::ACTION_ID,
+				'operation_id' => (string) ( $input['idempotency_key'] ?? '' ),
+				'input'        => array(
+					'post_id'      => $content['post_id'] ?? null,
+					'source_url'   => $content['source_url'] ?? null,
+					'caption'      => $content['caption'] ?? null,
+					'content_hash' => $content['content_hash'] ?? null,
+					'channels'     => $targets,
+					'media_kind'   => $policy['media_kind'] ?? null,
+					'asset_refs'   => $content['asset_refs'] ?? null,
+				),
+			)
+		);
+
+		return $this->normalizeResult( $result );
+	}
+
+	/** Read durable delivery state by opaque Socials receipt. */
+	public function getState( array $input ): array {
+		return $this->normalizeResult(
+			$this->invokeDelegated(
+				'get',
+				array(
+					'action'        => DelegatedCrossPostAction::ACTION_ID,
+					'operation_ref' => (string) ( $input['delivery_ref'] ?? '' ),
+				)
+			)
+		);
+	}
+
+	/** Explicitly retry a failed delivery after owner authorization and reconciliation. */
+	public function retry( array $input ): array {
+		return $this->normalizeResult(
+			$this->invokeDelegated(
+				'retry',
+				array(
+					'action'        => DelegatedCrossPostAction::ACTION_ID,
+					'operation_ref' => (string) ( $input['delivery_ref'] ?? '' ),
+				)
+			)
+		);
+	}
+
+	/** Resolve provider registration and local configuration without contacting it. */
+	protected function providerStatus( string $channel ): string {
+		if ( ! wp_get_ability( 'datamachine/' . $channel . '-publish' ) ) {
+			return 'publish_ability_missing';
+		}
+
+		$auth     = new AuthAbilities();
+		$provider = $auth->getProviderForHandler( $channel );
+		if ( ! $provider ) {
+			return 'provider_missing';
+		}
+		if ( method_exists( $provider, 'is_configured' ) && ! $provider->is_configured() ) {
+			return 'provider_not_configured';
+		}
+		if ( ! method_exists( $provider, 'is_authenticated' ) || ! $provider->is_authenticated() ) {
+			return 'provider_not_authenticated';
+		}
+
+		return 'ready';
+	}
+
+	/** Invoke only Data Machine's bounded public delegated-operation abilities. */
+	protected function invokeDelegated( string $verb, array $input ): array {
+		$ability = wp_get_ability( 'datamachine/' . $verb . '-delegated-operation' );
+		if ( ! $ability ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'delegated_ability_unavailable',
+				'error'      => __( 'The durable operation service is unavailable.', 'data-machine-socials' ),
+				'retryable'  => true,
+			);
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error_code' => $result->get_error_code(),
+				'error'      => $result->get_error_message(),
+			);
+		}
+
+		return is_array( $result ) ? $result : array(
+			'success'    => false,
+			'error_code' => 'delegated_response_invalid',
+			'error'      => __( 'The durable operation service returned an invalid response.', 'data-machine-socials' ),
+			'retryable'  => true,
+		);
+	}
+
+	/** Project generic durable operation state into a stable Socials delivery schema. */
+	private function normalizeResult( array $result ): array {
+		if ( empty( $result['success'] ) ) {
+			$code      = (string) ( $result['error_code'] ?? 'delegated_response_invalid' );
+			$retryable = ! empty( $result['retryable'] );
+			if ( 'delegated_operation_conflict' === $code ) {
+				return $this->failure( 'social_publish_idempotency_conflict', __( 'The idempotency key is already bound to different content or policy.', 'data-machine-socials' ) );
+			}
+			if ( in_array( $code, array( 'delegated_enqueue_failed', 'delegated_operation_create_failed', 'delegated_operation_persist_failed', 'delegated_operation_load_failed', 'delegated_ability_unavailable', 'delegated_response_invalid' ), true ) ) {
+				return $this->failure( 'social_publish_scheduler_unavailable', __( 'The social delivery could not be scheduled.', 'data-machine-socials' ), true );
+			}
+			if ( in_array( $code, array( 'social_cross_post_forbidden', 'delegated_action_forbidden' ), true ) ) {
+				return $this->failure( 'social_publish_forbidden', __( 'The actor is not authorized for this social delivery.', 'data-machine-socials' ) );
+			}
+			if ( in_array( $code, array( 'delegated_operation_not_retryable', 'social_cross_post_retry_unsafe', 'delegated_operation_retry_unsafe' ), true ) ) {
+				return $this->failure( 'social_publish_terminal_failure', __( 'This social delivery cannot be retried safely.', 'data-machine-socials' ) );
+			}
+
+			return $this->failure( sanitize_key( $code ), (string) ( $result['error'] ?? __( 'The social delivery request failed.', 'data-machine-socials' ) ), $retryable );
+		}
+
+		$projection = is_array( $result['projection'] ?? null ) ? $result['projection'] : array();
+		$errors     = is_array( $projection['error_codes'] ?? null ) ? array_values( $projection['error_codes'] ) : array();
+		$status     = $this->deliveryStatus( (string) ( $result['status'] ?? '' ) );
+		$retryable  = 'failed' === $status && ! empty( $errors );
+		foreach ( $errors as $error ) {
+			if ( ! is_array( $error ) || ! in_array( $error['code'] ?? '', self::RETRYABLE_DELIVERY_ERRORS, true ) ) {
+				$retryable = false;
+				break;
+			}
+		}
+
+		$delivery = array(
+			'delivery_ref' => (string) ( $result['operation_ref'] ?? '' ),
+			'status'       => $status,
+			'duplicate'    => ! empty( $result['replayed'] ),
+			'retryable'    => $retryable,
+			'deliveries'   => is_array( $projection['share_refs'] ?? null ) ? array_values( $projection['share_refs'] ) : array(),
+			'errors'       => $errors,
+		);
+		if ( 'failed' === $status ) {
+			$delivery['failure_kind'] = $retryable ? 'transient' : 'terminal';
+		}
+		if ( is_array( $result['retry'] ?? null ) ) {
+			$delivery['retry'] = $result['retry'];
+		}
+
+		return array(
+			'success'  => true,
+			'delivery' => $delivery,
+		);
+	}
+
+	private function deliveryStatus( string $status ): string {
+		return array(
+			'submitted' => 'queued',
+			'executing' => 'delivering',
+			'executed'  => 'delivered',
+			'no-op'     => 'no_op',
+			'failed'    => 'failed',
+			'cancelled' => 'cancelled',
+			'retrying'  => 'retrying',
+		)[ $status ] ?? 'unknown';
+	}
+
+	private function failure( string $code, string $message, bool $retryable = false, array $details = array() ): array {
+		$error = array(
+			'code'      => $code,
+			'message'   => $message,
+			'retryable' => $retryable,
+		);
+		if ( $details ) {
+			$error['details'] = $details;
+		}
+
+		return array(
+			'success' => false,
+			'error'   => $error,
+		);
+	}
+
+	private function enqueueSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'required'             => array( 'content_ref', 'target_policy', 'idempotency_key' ),
+			'properties'           => array(
+				'content_ref'     => array(
+					'type'                 => 'object',
+					'required'             => array( 'post_id', 'source_url', 'caption', 'content_hash', 'asset_refs' ),
+					'properties'           => array(
+						'post_id'      => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'source_url'   => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'caption'      => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'content_hash' => array(
+							'type'    => 'string',
+							'pattern' => '^[a-f0-9]{64}$',
+						),
+						'asset_refs'   => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'                 => 'object',
+								'required'             => array( 'attachment_id', 'role' ),
+								'properties'           => array(
+									'attachment_id' => array(
+										'type'    => 'integer',
+										'minimum' => 1,
+									),
+									'role'          => array(
+										'type' => 'string',
+										'enum' => array( 'image', 'video', 'cover' ),
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'target_policy'   => array(
+					'type'                 => 'object',
+					'required'             => array( 'channels', 'media_kind' ),
+					'properties'           => array(
+						'channels'   => array(
+							'type'     => 'array',
+							'minItems' => 1,
+							'maxItems' => 6,
+							'items'    => array(
+								'type' => 'string',
+								'enum' => array( 'bluesky', 'facebook', 'instagram', 'pinterest', 'threads', 'twitter' ),
+							),
+						),
+						'media_kind' => array(
+							'type' => 'string',
+							'enum' => array( 'image', 'carousel', 'reel', 'story' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'idempotency_key' => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 191,
+				),
+			),
+			'additionalProperties' => false,
+		);
+	}
+}

--- a/inc/Operations/DelegatedCrossPostAction.php
+++ b/inc/Operations/DelegatedCrossPostAction.php
@@ -43,6 +43,7 @@ final class DelegatedCrossPostAction {
 	/** Register the owner action through Data Machine's public filter. */
 	public static function register(): void {
 		add_filter( 'datamachine_delegated_operation_actions', array( self::class, 'register_action' ) );
+		new \DataMachineSocials\Abilities\SocialPublishAbility();
 	}
 
 	/**
@@ -188,7 +189,9 @@ final class DelegatedCrossPostAction {
 		 * @param array $input   Normalized owner input.
 		 * @param array $context Delegated operation context.
 		 */
-		$owner = apply_filters( 'datamachine_socials_delegated_cross_post_execution_owner', $owner, $input, $context );
+		/** @var mixed $filtered_owner Owner filters must remain runtime-validated. */
+		$filtered_owner = apply_filters( 'datamachine_socials_delegated_cross_post_execution_owner', $owner, $input, $context );
+		$owner          = $filtered_owner;
 
 		if ( ! is_array( $owner ) || empty( $owner['user_id'] ) || empty( $owner['agent_id'] ) ) {
 			return self::error( 'social_cross_post_owner_unavailable', 'The stable Socials execution owner is unavailable.' );
@@ -511,7 +514,12 @@ final class DelegatedCrossPostAction {
 			'twitter'   => 256,
 		);
 
-		return empty( $channels ) ? 2200 : min( array_intersect_key( $limits, array_flip( $channels ) ) );
+		if ( empty( $channels ) ) {
+			return 2200;
+		}
+
+		$channel_limits = array_intersect_key( $limits, array_flip( $channels ) );
+		return empty( $channel_limits ) ? 2200 : min( $channel_limits );
 	}
 
 	/**

--- a/tests/Unit/Abilities/SocialPublishAbilityTest.php
+++ b/tests/Unit/Abilities/SocialPublishAbilityTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Contract tests for durable social publishing.
+ *
+ * @package DataMachineSocials\Tests\Unit\Abilities
+ */
+
+namespace DataMachineSocials\Tests\Unit\Abilities;
+
+use DataMachineSocials\Abilities\SocialPublishAbility;
+use WP_UnitTestCase;
+
+final class SocialPublishAbilityTest extends WP_UnitTestCase {
+
+	public function test_duplicate_enqueue_returns_the_same_delivery_as_a_duplicate(): void {
+		$ability = $this->ability(
+			array(
+				'submit' => array(
+					'success'       => true,
+					'operation_ref' => $this->deliveryRef(),
+					'status'        => 'submitted',
+					'replayed'      => true,
+				),
+			)
+		);
+
+		$result = $ability->enqueue( $this->enqueueInput() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $this->deliveryRef(), $result['delivery']['delivery_ref'] );
+		$this->assertTrue( $result['delivery']['duplicate'] );
+		$this->assertSame( 'duplicate-key', $ability->requests['submit']['operation_id'] );
+	}
+
+	public function test_conflicting_idempotency_reuse_has_a_stable_error(): void {
+		$ability = $this->ability(
+			array(
+				'submit' => array(
+					'success'    => false,
+					'error_code' => 'delegated_operation_conflict',
+					'error'      => 'Private core conflict text.',
+				),
+			)
+		);
+
+		$result = $ability->enqueue( $this->enqueueInput() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'social_publish_idempotency_conflict', $result['error']['code'] );
+		$this->assertFalse( $result['error']['retryable'] );
+	}
+
+	public function test_provider_unavailable_fails_before_scheduling(): void {
+		$ability = $this->ability( array(), array( 'instagram' => 'provider_not_configured' ) );
+
+		$result = $ability->enqueue( $this->enqueueInput() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'social_publish_provider_unavailable', $result['error']['code'] );
+		$this->assertSame( 'provider_not_configured', $result['error']['details']['providers'][0]['status'] );
+		$this->assertArrayNotHasKey( 'submit', $ability->requests );
+	}
+
+	public function test_scheduler_failure_is_retryable_and_stable(): void {
+		$ability = $this->ability(
+			array(
+				'submit' => array(
+					'success'    => false,
+					'error_code' => 'delegated_enqueue_failed',
+					'error'      => 'Internal scheduler failure.',
+					'retryable'  => true,
+				),
+			)
+		);
+
+		$result = $ability->enqueue( $this->enqueueInput() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'social_publish_scheduler_unavailable', $result['error']['code'] );
+		$this->assertTrue( $result['error']['retryable'] );
+	}
+
+	public function test_transient_delivery_failure_is_explicitly_retryable(): void {
+		$ability = $this->ability(
+			array(
+				'get' => $this->failedState( 'undelivered' ),
+			)
+		);
+
+		$result = $ability->getState( array( 'delivery_ref' => $this->deliveryRef() ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'failed', $result['delivery']['status'] );
+		$this->assertSame( 'transient', $result['delivery']['failure_kind'] );
+		$this->assertTrue( $result['delivery']['retryable'] );
+	}
+
+	public function test_authorized_retry_reuses_the_delivery_reference(): void {
+		$ability = $this->ability(
+			array(
+				'retry' => array(
+					'success'       => true,
+					'operation_ref' => $this->deliveryRef(),
+					'status'        => 'submitted',
+					'replayed'      => true,
+				),
+			)
+		);
+
+		$result = $ability->retry( array( 'delivery_ref' => $this->deliveryRef() ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'queued', $result['delivery']['status'] );
+		$this->assertSame( $this->deliveryRef(), $ability->requests['retry']['operation_ref'] );
+	}
+
+	public function test_unauthorized_retry_has_a_stable_error(): void {
+		$ability = $this->ability(
+			array(
+				'retry' => array(
+					'success'    => false,
+					'error_code' => 'social_cross_post_forbidden',
+					'error'      => 'Owner denied actor.',
+				),
+			)
+		);
+
+		$result = $ability->retry( array( 'delivery_ref' => $this->deliveryRef() ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'social_publish_forbidden', $result['error']['code'] );
+	}
+
+	public function test_terminal_failure_is_not_retryable(): void {
+		$ability = $this->ability( array( 'get' => $this->failedState( 'delivery_unknown' ) ) );
+
+		$result = $ability->getState( array( 'delivery_ref' => $this->deliveryRef() ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'terminal', $result['delivery']['failure_kind'] );
+		$this->assertFalse( $result['delivery']['retryable'] );
+	}
+
+	public function test_state_projection_exposes_only_delivery_receipts_and_bounded_errors(): void {
+		$ability = $this->ability(
+			array(
+				'get' => array(
+					'success'       => true,
+					'operation_ref' => $this->deliveryRef(),
+					'status'        => 'executed',
+					'replayed'      => true,
+					'projection'    => array(
+						'effect_count'   => 1,
+						'classification' => 'success',
+						'share_refs'     => array( array( 'channel' => 'instagram', 'platform_post_id' => 'ig-123' ) ),
+						'error_codes'    => array(),
+					),
+					'private_data'  => 'must not cross the Socials boundary',
+				),
+			)
+		);
+
+		$result = $ability->getState( array( 'delivery_ref' => $this->deliveryRef() ) );
+
+		$this->assertSame( 'delivered', $result['delivery']['status'] );
+		$this->assertSame( 'ig-123', $result['delivery']['deliveries'][0]['platform_post_id'] );
+		$this->assertStringNotContainsString( 'private_data', wp_json_encode( $result ) );
+	}
+
+	private function ability( array $responses, array $providers = array() ): TestableSocialPublishAbility {
+		return new TestableSocialPublishAbility( $responses, $providers );
+	}
+
+	private function enqueueInput(): array {
+		$caption = 'Approved social caption.';
+		return array(
+			'content_ref'    => array(
+				'post_id'      => 42,
+				'source_url'   => 'https://example.org/canonical-post/',
+				'caption'      => $caption,
+				'content_hash' => hash( 'sha256', $caption ),
+				'asset_refs'   => array( array( 'attachment_id' => 84, 'role' => 'image' ) ),
+			),
+			'target_policy' => array(
+				'channels'   => array( 'instagram' ),
+				'media_kind' => 'image',
+			),
+			'idempotency_key' => 'duplicate-key',
+		);
+	}
+
+	private function failedState( string $error_code ): array {
+		return array(
+			'success'       => true,
+			'operation_ref' => $this->deliveryRef(),
+			'status'        => 'failed',
+			'replayed'      => true,
+			'projection'    => array(
+				'effect_count'   => 0,
+				'classification' => 'failure',
+				'share_refs'     => array(),
+				'error_codes'    => array( array( 'channel' => 'instagram', 'code' => $error_code ) ),
+			),
+		);
+	}
+
+	private function deliveryRef(): string {
+		return 'dop_' . str_repeat( 'a', 64 );
+	}
+}
+
+/** Test double that prevents provider and scheduler side effects. */
+final class TestableSocialPublishAbility extends SocialPublishAbility {
+
+	public array $requests = array();
+
+	private array $responses;
+	private array $providers;
+
+	public function __construct( array $responses, array $providers ) {
+		$this->responses = $responses;
+		$this->providers = $providers;
+	}
+
+	protected function providerStatus( string $channel ): string {
+		return $this->providers[ $channel ] ?? 'ready';
+	}
+
+	protected function invokeDelegated( string $verb, array $input ): array {
+		$this->requests[ $verb ] = $input;
+		return $this->responses[ $verb ] ?? array(
+			'success'    => false,
+			'error_code' => 'unexpected_test_call',
+			'error'      => 'Unexpected delegated operation call.',
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add Socials-owned enqueue, state, and retry abilities over Data Machine's durable delegated-operation contract
- preflight provider availability and project idempotency, scheduler, authorization, transient, and terminal outcomes into stable delivery schemas
- add isolated behavior coverage for duplicate enqueue, conflicting reuse, unavailable providers, scheduler failure, retry authorization, failure classification, and state projection

## Verification
- changed-scope PHPCS and PHPStan: passed
- architecture audit: passed with no introduced findings
- PHP syntax checks: passed
- nine behavior tests use test doubles and never contact providers
- managed WordPress runner could not complete discovery because the host WP Codebox cache was missing its compiled CLI/runtime dependencies; no production queues or providers were contacted

Closes #224