### PR TITLE
fix: scope social publish assets to network sites

### DIFF
--- a/inc/Abilities/SocialPublishAbility.php
+++ b/inc/Abilities/SocialPublishAbility.php
@@ -317,8 +317,12 @@ class SocialPublishAbility extends AbstractSocialAbility {
 							'type'  => 'array',
 							'items' => array(
 								'type'                 => 'object',
-								'required'             => array( 'attachment_id', 'role' ),
+								'required'             => array( 'role' ),
 								'properties'           => array(
+									'source_id'     => array(
+										'type'    => 'string',
+										'pattern' => '^[1-9][0-9]*:[1-9][0-9]*$',
+									),
 									'attachment_id' => array(
 										'type'    => 'integer',
 										'minimum' => 1,
@@ -327,6 +331,10 @@ class SocialPublishAbility extends AbstractSocialAbility {
 										'type' => 'string',
 										'enum' => array( 'image', 'video', 'cover' ),
 									),
+								),
+								'oneOf'                => array(
+									array( 'required' => array( 'source_id' ) ),
+									array( 'required' => array( 'attachment_id' ) ),
 								),
 								'additionalProperties' => false,
 							),

--- a/inc/Operations/DelegatedCrossPostAction.php
+++ b/inc/Operations/DelegatedCrossPostAction.php
@@ -29,6 +29,7 @@ final class DelegatedCrossPostAction {
 	private const MEDIA_KINDS = array( 'image', 'carousel', 'reel', 'story' );
 
 	private const INPUT_KEYS = array(
+		'post_site_id',
 		'post_id',
 		'source_url',
 		'caption',
@@ -79,71 +80,87 @@ final class DelegatedCrossPostAction {
 	 * @return array|\WP_Error
 	 */
 	public static function normalize_input( array $input, array $context = array() ) {
-		unset( $context );
-
 		$unknown_keys = array_diff( array_keys( $input ), self::INPUT_KEYS );
 		if ( ! empty( $unknown_keys ) ) {
 			return self::error( 'social_cross_post_invalid_input', 'Unknown input fields are not allowed.' );
 		}
 
-		$post_id = self::strict_positive_int( $input['post_id'] ?? null );
-		if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
-			return self::error( 'social_cross_post_invalid_post', 'A published canonical post is required.' );
+		$phase = is_string( $context['phase'] ?? null ) ? $context['phase'] : 'submit';
+		if ( 'submit' === $phase && array_key_exists( 'post_site_id', $input ) ) {
+			return self::error( 'social_cross_post_invalid_input', 'The canonical post site is owner-controlled.' );
 		}
 
-		$canonical_url = get_permalink( $post_id );
-		$source_url    = $input['source_url'] ?? null;
-		if ( ! is_string( $source_url ) || ! self::is_public_url( $source_url ) || ! is_string( $canonical_url ) || ! hash_equals( $canonical_url, $source_url ) ) {
-			return self::error( 'social_cross_post_invalid_source_url', 'The source URL must match the canonical post URL.' );
+		$post_site_id = array_key_exists( 'post_site_id', $input )
+			? self::strict_positive_int( $input['post_site_id'] )
+			: get_current_blog_id();
+		if ( ! self::is_valid_site( $post_site_id ) ) {
+			return self::error( 'social_cross_post_invalid_post', 'The canonical post site is invalid.' );
 		}
 
-		$channels = self::normalize_channels( $input['channels'] ?? null );
-		if ( is_wp_error( $channels ) ) {
-			return $channels;
-		}
+		return self::with_site(
+			$post_site_id,
+			static function () use ( $input, $post_site_id ) {
+				$post_id = self::strict_positive_int( $input['post_id'] ?? null );
+				if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
+					return self::error( 'social_cross_post_invalid_post', 'A published canonical post is required.' );
+				}
 
-		$caption = $input['caption'] ?? null;
-		if ( ! is_string( $caption ) || sanitize_textarea_field( $caption ) !== $caption || '' === trim( $caption ) || mb_strlen( $caption ) > self::caption_limit( $channels, $source_url ) ) {
-			return self::error( 'social_cross_post_invalid_caption', 'The approved caption must be canonical text within every selected channel limit.' );
-		}
+				$canonical_url = get_permalink( $post_id );
+				$source_url    = $input['source_url'] ?? null;
+				if ( ! is_string( $source_url ) || ! self::is_public_url( $source_url ) || ! is_string( $canonical_url ) || ! hash_equals( $canonical_url, $source_url ) ) {
+					return self::error( 'social_cross_post_invalid_source_url', 'The source URL must match the canonical post URL.' );
+				}
 
-		$content_hash = $input['content_hash'] ?? null;
-		if ( ! is_string( $content_hash ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $content_hash ) || ! hash_equals( hash( 'sha256', $caption ), $content_hash ) ) {
-			return self::error( 'social_cross_post_content_hash_mismatch', 'The approved content hash does not match the caption.' );
-		}
+				$channels = self::normalize_channels( $input['channels'] ?? null );
+				if ( is_wp_error( $channels ) ) {
+					return $channels;
+				}
 
-		$media_kind = $input['media_kind'] ?? null;
-		if ( ! is_string( $media_kind ) || ! in_array( $media_kind, self::MEDIA_KINDS, true ) ) {
-			return self::error( 'social_cross_post_unsupported_media_kind', 'The requested media kind is not supported.' );
-		}
+				$caption = $input['caption'] ?? null;
+				if ( ! is_string( $caption ) || sanitize_textarea_field( $caption ) !== $caption || '' === trim( $caption ) || mb_strlen( $caption ) > self::caption_limit( $channels, $source_url ) ) {
+					return self::error( 'social_cross_post_invalid_caption', 'The approved caption must be canonical text within every selected channel limit.' );
+				}
 
-		if ( in_array( $media_kind, array( 'reel', 'story' ), true ) && array_diff( $channels, array( 'instagram' ) ) ) {
-			return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support the requested media kind.' );
-		}
-		if ( 'carousel' === $media_kind && array_diff( $channels, array( 'instagram', 'twitter' ) ) ) {
-			return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support carousel publishing.' );
-		}
+				$content_hash = $input['content_hash'] ?? null;
+				if ( ! is_string( $content_hash ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $content_hash ) || ! hash_equals( hash( 'sha256', $caption ), $content_hash ) ) {
+					return self::error( 'social_cross_post_content_hash_mismatch', 'The approved content hash does not match the caption.' );
+				}
 
-		$assets = self::normalize_asset_refs( $input['asset_refs'] ?? null, $media_kind );
-		if ( is_wp_error( $assets ) ) {
-			return $assets;
-		}
-		if ( 'carousel' === $media_kind && in_array( 'twitter', $channels, true ) && count( $assets['images'] ) > 4 ) {
-			return self::error( 'social_cross_post_unsupported_channel_media', 'Twitter carousels support at most four image assets.' );
-		}
+				$media_kind = $input['media_kind'] ?? null;
+				if ( ! is_string( $media_kind ) || ! in_array( $media_kind, self::MEDIA_KINDS, true ) ) {
+					return self::error( 'social_cross_post_unsupported_media_kind', 'The requested media kind is not supported.' );
+				}
 
-		return array(
-			'post_id'       => $post_id,
-			'source_url'    => $source_url,
-			'caption'       => $caption,
-			'content_hash'  => $content_hash,
-			'channels'      => $channels,
-			'media_kind'    => $media_kind,
-			'asset_refs'    => $assets['refs'],
-			'images'        => $assets['images'],
-			'video_url'     => $assets['video_url'],
-			'cover_url'     => $assets['cover_url'],
-			'share_to_feed' => true,
+				if ( in_array( $media_kind, array( 'reel', 'story' ), true ) && array_diff( $channels, array( 'instagram' ) ) ) {
+					return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support the requested media kind.' );
+				}
+				if ( 'carousel' === $media_kind && array_diff( $channels, array( 'instagram', 'twitter' ) ) ) {
+					return self::error( 'social_cross_post_unsupported_channel_media', 'A selected channel does not support carousel publishing.' );
+				}
+
+				$assets = self::normalize_asset_refs( $input['asset_refs'] ?? null, $media_kind );
+				if ( is_wp_error( $assets ) ) {
+					return $assets;
+				}
+				if ( 'carousel' === $media_kind && in_array( 'twitter', $channels, true ) && count( $assets['images'] ) > 4 ) {
+					return self::error( 'social_cross_post_unsupported_channel_media', 'Twitter carousels support at most four image assets.' );
+				}
+
+				return array(
+					'post_site_id'  => $post_site_id,
+					'post_id'       => $post_id,
+					'source_url'    => $source_url,
+					'caption'       => $caption,
+					'content_hash'  => $content_hash,
+					'channels'      => $channels,
+					'media_kind'    => $media_kind,
+					'asset_refs'    => $assets['refs'],
+					'images'        => $assets['images'],
+					'video_url'     => $assets['video_url'],
+					'cover_url'     => $assets['cover_url'],
+					'share_to_feed' => true,
+				);
+			}
 		);
 	}
 
@@ -198,6 +215,7 @@ final class DelegatedCrossPostAction {
 		}
 
 		$params = array(
+			'post_site_id'            => $input['post_site_id'],
 			'post_id'                 => $input['post_id'],
 			'platforms'               => $input['channels'],
 			'caption'                 => $input['caption'],
@@ -268,8 +286,12 @@ final class DelegatedCrossPostAction {
 			}
 
 			if ( 'social_share_ref' === ( $ref['type'] ?? '' ) ) {
+				$post_site_id = self::strict_positive_int( $input['post_site_id'] ?? null );
+				if ( 0 === $post_site_id ) {
+					$post_site_id = get_current_blog_id();
+				}
 				$receipt = $post_id && '' !== $operation_ref
-					? \DataMachineSocials\Tracking\SocialShareTracker::get_operation_share( $post_id, $channel, $operation_ref )
+					? self::with_site( $post_site_id, static fn() => \DataMachineSocials\Tracking\SocialShareTracker::get_operation_share( $post_id, $channel, $operation_ref ) )
 					: null;
 
 				$packet_id = sanitize_text_field( (string) ( $ref['source_item_id'] ?? '' ) );
@@ -359,7 +381,11 @@ final class DelegatedCrossPostAction {
 				return self::error( 'social_cross_post_retry_unsafe', 'The prior delivery effects cannot be reconciled safely.' );
 			}
 
-			$receipt = \DataMachineSocials\Tracking\SocialShareTracker::get_operation_share( $post_id, $channel, $operation_ref );
+			$post_site_id = self::strict_positive_int( $live_input['post_site_id'] ?? null );
+			if ( 0 === $post_site_id ) {
+				$post_site_id = get_current_blog_id();
+			}
+			$receipt = self::with_site( $post_site_id, static fn() => \DataMachineSocials\Tracking\SocialShareTracker::get_operation_share( $post_id, $channel, $operation_ref ) );
 			if ( is_array( $receipt ) ) {
 				$recorded_id = (string) ( $receipt['platform_post_id'] ?? '' );
 				if ( isset( $shares[ $channel ] ) && ! hash_equals( $recorded_id, $shares[ $channel ] ) ) {
@@ -540,18 +566,46 @@ final class DelegatedCrossPostAction {
 		$valid_roles = array( 'image', 'video', 'cover' );
 
 		foreach ( $asset_refs as $ref ) {
-			if ( ! is_array( $ref ) || array_diff( array_keys( $ref ), array( 'attachment_id', 'role' ) ) || ! isset( $ref['attachment_id'], $ref['role'] ) ) {
-				return self::error( 'social_cross_post_invalid_asset_ref', 'Each asset reference requires only an attachment ID and role.' );
+			if ( ! is_array( $ref ) || array_diff( array_keys( $ref ), array( 'source_id', 'attachment_id', 'role' ) ) || ! isset( $ref['role'] ) ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'Each asset reference requires one canonical identity and role.' );
 			}
 
-			$attachment_id = self::strict_positive_int( $ref['attachment_id'] );
-			$role          = $ref['role'];
-			if ( ! $attachment_id || ! is_string( $role ) || ! in_array( $role, $valid_roles, true ) || in_array( $attachment_id, $seen_ids, true ) || 'attachment' !== get_post_type( $attachment_id ) ) {
+			$has_source_id     = array_key_exists( 'source_id', $ref );
+			$has_attachment_id = array_key_exists( 'attachment_id', $ref );
+			if ( $has_source_id === $has_attachment_id ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'Each asset reference requires exactly one canonical identity.' );
+			}
+
+			$identity = $has_source_id
+				? self::parse_asset_source_id( $ref['source_id'] )
+				: array(
+					'site_id'       => get_current_blog_id(),
+					'attachment_id' => self::strict_positive_int( $ref['attachment_id'] ),
+				);
+			$role     = $ref['role'];
+			if ( is_wp_error( $identity ) || ! is_string( $role ) || ! in_array( $role, $valid_roles, true ) ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'An asset reference is malformed or duplicated.' );
+			}
+			$site_id       = $identity['site_id'];
+			$attachment_id = $identity['attachment_id'];
+			$source_id     = $site_id . ':' . $attachment_id;
+			if ( in_array( $source_id, $seen_ids, true ) || ! self::is_valid_site( $site_id ) ) {
 				return self::error( 'social_cross_post_invalid_asset_ref', 'An asset reference is malformed or duplicated.' );
 			}
 
-			$url  = wp_get_attachment_url( $attachment_id );
-			$mime = (string) get_post_mime_type( $attachment_id );
+			$asset = self::with_site(
+				$site_id,
+				static fn(): array => array(
+					'type' => get_post_type( $attachment_id ),
+					'url'  => wp_get_attachment_url( $attachment_id ),
+					'mime' => (string) get_post_mime_type( $attachment_id ),
+				)
+			);
+			if ( 'attachment' !== $asset['type'] ) {
+				return self::error( 'social_cross_post_invalid_asset_ref', 'An asset reference is malformed or duplicated.' );
+			}
+			$url  = $asset['url'];
+			$mime = $asset['mime'];
 			if ( ! is_string( $url ) || ! self::is_public_url( $url ) ) {
 				return self::error( 'social_cross_post_asset_not_public', 'Every asset must resolve to a public URL.' );
 			}
@@ -574,10 +628,10 @@ final class DelegatedCrossPostAction {
 			}
 
 			$refs[]     = array(
-				'attachment_id' => $attachment_id,
-				'role'          => $role,
+				'source_id' => $source_id,
+				'role'      => $role,
 			);
-			$seen_ids[] = $attachment_id;
+			$seen_ids[] = $source_id;
 		}
 
 		$image_count = count( $images );
@@ -606,6 +660,54 @@ final class DelegatedCrossPostAction {
 
 	private static function strict_positive_int( $value ): int {
 		return is_int( $value ) && $value > 0 ? $value : 0;
+	}
+
+	/** @return array{site_id:int,attachment_id:int}|\WP_Error */
+	private static function parse_asset_source_id( $source_id ) {
+		if ( ! is_string( $source_id ) || 1 !== preg_match( '/^([1-9][0-9]*):([1-9][0-9]*)$/', $source_id, $matches ) ) {
+			return self::error( 'social_cross_post_invalid_asset_ref', 'The asset identity is invalid.' );
+		}
+
+		$site_id       = filter_var( $matches[1], FILTER_VALIDATE_INT, array( 'options' => array( 'min_range' => 1 ) ) );
+		$attachment_id = filter_var( $matches[2], FILTER_VALIDATE_INT, array( 'options' => array( 'min_range' => 1 ) ) );
+		return false !== $site_id && false !== $attachment_id
+			? array(
+				'site_id'       => $site_id,
+				'attachment_id' => $attachment_id,
+			)
+			: self::error( 'social_cross_post_invalid_asset_ref', 'The asset identity is invalid.' );
+	}
+
+	private static function is_valid_site( int $site_id ): bool {
+		if ( $site_id <= 0 ) {
+			return false;
+		}
+		if ( ! is_multisite() ) {
+			return get_current_blog_id() === $site_id;
+		}
+
+		$site = get_site( $site_id );
+		return $site instanceof \WP_Site
+			&& get_current_network_id() === (int) $site->network_id
+			&& ! $site->archived
+			&& ! $site->deleted
+			&& ! $site->spam;
+	}
+
+	/** @return mixed */
+	private static function with_site( int $site_id, callable $callback ) {
+		$switched = get_current_blog_id() !== $site_id;
+		if ( $switched ) {
+			switch_to_blog( $site_id );
+		}
+
+		try {
+			return $callback();
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
 	}
 
 	private static function is_public_url( string $url ): bool {

--- a/inc/Tasks/SocialCrossPostTask.php
+++ b/inc/Tasks/SocialCrossPostTask.php
@@ -47,13 +47,14 @@ class SocialCrossPostTask extends SystemTask {
 					$operation_ref
 				);
 			if ( is_wp_error( $revalidated ) ) {
-				$this->complete_delegated_failure( $jobId, is_array( $platforms ) ? $platforms : array(), $revalidated->get_error_code() );
+				$this->complete_delegated_failure( $jobId, is_array( $platforms ) ? $platforms : array(), (string) $revalidated->get_error_code() );
 				return;
 			}
 
 			$params    = array_replace(
 				$params,
 				array(
+					'post_site_id'  => $revalidated['post_site_id'],
 					'post_id'       => $revalidated['post_id'],
 					'platforms'     => $revalidated['channels'],
 					'caption'       => $revalidated['caption'],
@@ -92,7 +93,8 @@ class SocialCrossPostTask extends SystemTask {
 		}
 
 		// Publish directly via Publisher utility (no REST round-trip).
-		$publish_result = Publisher::cross_post( $params );
+		$post_site_id   = absint( $params['post_site_id'] ?? get_current_blog_id() );
+		$publish_result = $this->with_site( $post_site_id, static fn(): array => Publisher::cross_post( $params ) );
 
 		if ( ! empty( $publish_result['error'] ) && empty( $publish_result['results'] ) ) {
 			// Validation-level failure (e.g. missing video_url for reel).
@@ -119,10 +121,14 @@ class SocialCrossPostTask extends SystemTask {
 
 		// Store results in post meta when post_id is available.
 		if ( $post_id ) {
-			$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true );
-			$existing_log = $existing_log ? $existing_log : array();
-			$merged_log   = array_merge( $existing_log, $log );
-			update_post_meta( $post_id, '_studio_social_publish_log', $merged_log );
+			$this->with_site(
+				$post_site_id,
+				static function () use ( $post_id, $log ): void {
+					$existing_log = get_post_meta( $post_id, '_studio_social_publish_log', true );
+					$existing_log = $existing_log ? $existing_log : array();
+					update_post_meta( $post_id, '_studio_social_publish_log', array_merge( $existing_log, $log ) );
+				}
+			);
 		}
 
 		// Write full results to job engine_data.
@@ -211,6 +217,22 @@ class SocialCrossPostTask extends SystemTask {
 				'suppress_result_packet' => true,
 			)
 		);
+	}
+
+	/** @return mixed */
+	private function with_site( int $site_id, callable $callback ) {
+		$switched = get_current_blog_id() !== $site_id;
+		if ( $switched ) {
+			switch_to_blog( $site_id );
+		}
+
+		try {
+			return $callback();
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
 	}
 
 	/**

--- a/tests/Integration/DelegatedCrossPostIntegrationTest.php
+++ b/tests/Integration/DelegatedCrossPostIntegrationTest.php
@@ -156,6 +156,10 @@ final class DelegatedCrossPostIntegrationTest extends WP_UnitTestCase {
 		$submitted = $service->submit( $this->submission( 'partial-retry', array( 'instagram', 'twitter' ) ) );
 		$this->assertTrue( $submitted['success'] ?? false, wp_json_encode( $submitted ) );
 		$job       = $this->job( 'partial-retry' );
+		$this->assertSame(
+			get_current_blog_id() . ':' . $this->attachment_id,
+			$job['operation_envelope']['delegated_operation']['input']['asset_refs'][0]['source_id']
+		);
 		$this->assertTrue(
 			SocialShareTracker::record(
 				$this->post_id,

--- a/tests/Integration/DelegatedCrossPostMultisiteTest.php
+++ b/tests/Integration/DelegatedCrossPostMultisiteTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Multisite identity coverage for delegated social publishing.
+ *
+ * @package DataMachineSocials\Tests\Integration
+ */
+
+use DataMachineSocials\Operations\DelegatedCrossPostAction;
+
+final class DelegatedCrossPostMultisiteTest extends WP_UnitTestCase {
+	private int $canonical_site_id;
+	private int $asset_site_id;
+	private int $post_id;
+	private int $attachment_id;
+	private string $canonical_url;
+	private string $asset_url;
+
+	public function set_up(): void {
+		parent::set_up();
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		$this->canonical_site_id = self::factory()->blog->create();
+		$this->asset_site_id     = self::factory()->blog->create();
+
+		switch_to_blog( $this->canonical_site_id );
+		try {
+			$this->attachment_id = self::factory()->attachment->create(
+				array(
+					'post_mime_type' => 'image/jpeg',
+					'guid'           => 'https://canonical.example.test/colliding-image.jpg',
+				)
+			);
+			$this->post_id       = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+			$this->canonical_url = get_permalink( $this->post_id );
+		} finally {
+			restore_current_blog();
+		}
+
+		switch_to_blog( $this->asset_site_id );
+		try {
+			$this->asset_url = 'https://assets.example.test/canonical-image.jpg';
+			$created         = wp_insert_attachment(
+				array(
+					'import_id'      => $this->attachment_id,
+					'post_mime_type' => 'image/jpeg',
+					'post_status'    => 'inherit',
+					'guid'           => $this->asset_url,
+				)
+			);
+			$this->assertSame( $this->attachment_id, $created, 'The fixture must create colliding attachment IDs.' );
+		} finally {
+			restore_current_blog();
+		}
+
+		add_filter( 'datamachine_socials_delegated_cross_post_authorized', '__return_true' );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_socials_delegated_cross_post_authorized', '__return_true' );
+		parent::tear_down();
+	}
+
+	public function test_cross_site_asset_identity_survives_effect_validation_and_retry(): void {
+		$this->require_multisite();
+		$original_site_id = get_current_blog_id();
+
+		switch_to_blog( $this->canonical_site_id );
+		try {
+			$normalized = DelegatedCrossPostAction::normalize_input( $this->input( $this->asset_site_id . ':' . $this->attachment_id ) );
+			$this->assertIsArray( $normalized );
+			$this->assertSame( $this->canonical_site_id, get_current_blog_id() );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertSame( $original_site_id, get_current_blog_id() );
+		$this->assertSame( $this->canonical_site_id, $normalized['post_site_id'] );
+		$this->assertSame( $this->asset_site_id . ':' . $this->attachment_id, $normalized['asset_refs'][0]['source_id'] );
+		$this->assertSame( $this->asset_url, $normalized['images'][0]['url'] );
+
+		$operation_ref = 'dop_' . str_repeat( 'a', 64 );
+		$revalidated   = DelegatedCrossPostAction::validate_effect( $normalized, array( 'user_id' => 1 ), $operation_ref );
+		$this->assertIsArray( $revalidated );
+		$this->assertSame( $this->asset_site_id . ':' . $this->attachment_id, $revalidated['asset_refs'][0]['source_id'] );
+		$this->assertSame( $original_site_id, get_current_blog_id() );
+
+		$retry = DelegatedCrossPostAction::retry(
+			array(
+				'status'      => 'failed',
+				'packet_refs' => array(
+					array(
+						'type'           => 'social_share_error',
+						'source_type'    => 'datamachine_socials_cross_post',
+						'source_id'      => 'instagram',
+						'source_item_id' => 'undelivered',
+					),
+				),
+			),
+			array(
+				'input'         => $normalized,
+				'actor'         => array( 'user_id' => 1 ),
+				'operation_ref' => $operation_ref,
+			)
+		);
+		$this->assertTrue( $retry );
+		$this->assertSame( $original_site_id, get_current_blog_id() );
+	}
+
+	public function test_invalid_sites_and_attachments_fail_without_leaking_context(): void {
+		$this->require_multisite();
+		$original_site_id = get_current_blog_id();
+
+		switch_to_blog( $this->canonical_site_id );
+		try {
+			$missing_site = DelegatedCrossPostAction::normalize_input( $this->input( PHP_INT_MAX . ':' . $this->attachment_id ) );
+			$this->assertWPError( $missing_site );
+			$this->assertSame( $this->canonical_site_id, get_current_blog_id() );
+
+			$missing_attachment = DelegatedCrossPostAction::normalize_input( $this->input( $this->asset_site_id . ':' . PHP_INT_MAX ) );
+			$this->assertWPError( $missing_attachment );
+			$this->assertSame( $this->canonical_site_id, get_current_blog_id() );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertSame( $original_site_id, get_current_blog_id() );
+	}
+
+	public function test_bare_attachment_compatibility_is_explicitly_same_site(): void {
+		$this->require_multisite();
+
+		switch_to_blog( $this->canonical_site_id );
+		try {
+			$input                         = $this->input( $this->canonical_site_id . ':' . $this->attachment_id );
+			$input['asset_refs'][0]        = array( 'attachment_id' => $this->attachment_id, 'role' => 'image' );
+			$normalized                    = DelegatedCrossPostAction::normalize_input( $input );
+			$this->assertIsArray( $normalized );
+			$this->assertSame( $this->canonical_site_id . ':' . $this->attachment_id, $normalized['asset_refs'][0]['source_id'] );
+			$this->assertSame( 'https://canonical.example.test/colliding-image.jpg', $normalized['images'][0]['url'] );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	private function input( string $source_id ): array {
+		$caption = 'Approved multisite caption.';
+		return array(
+			'post_id'      => $this->post_id,
+			'source_url'   => $this->canonical_url,
+			'caption'      => $caption,
+			'content_hash' => hash( 'sha256', $caption ),
+			'channels'     => array( 'instagram' ),
+			'media_kind'   => 'image',
+			'asset_refs'   => array( array( 'source_id' => $source_id, 'role' => 'image' ) ),
+		);
+	}
+
+	private function require_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite is required for site-scoped attachment coverage.' );
+		}
+	}
+}

--- a/tests/Unit/Abilities/SocialPublishAbilityTest.php
+++ b/tests/Unit/Abilities/SocialPublishAbilityTest.php
@@ -30,6 +30,7 @@ final class SocialPublishAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( $this->deliveryRef(), $result['delivery']['delivery_ref'] );
 		$this->assertTrue( $result['delivery']['duplicate'] );
 		$this->assertSame( 'duplicate-key', $ability->requests['submit']['operation_id'] );
+		$this->assertSame( '2:84', $ability->requests['submit']['input']['asset_refs'][0]['source_id'] );
 	}
 
 	public function test_conflicting_idempotency_reuse_has_a_stable_error(): void {
@@ -179,7 +180,7 @@ final class SocialPublishAbilityTest extends WP_UnitTestCase {
 				'source_url'   => 'https://example.org/canonical-post/',
 				'caption'      => $caption,
 				'content_hash' => hash( 'sha256', $caption ),
-				'asset_refs'   => array( array( 'attachment_id' => 84, 'role' => 'image' ) ),
+				'asset_refs'   => array( array( 'source_id' => '2:84', 'role' => 'image' ) ),
 			),
 			'target_policy' => array(
 				'channels'   => array( 'instagram' ),


### PR DESCRIPTION
## Summary
- extend `datamachine/enqueue-social-publish` asset refs with canonical `<site_id>:<attachment_id>` identities and freeze the canonical post site in delegated input
- resolve posts, assets, provider effects, logs, and delivery receipts under exact WordPress multisite contexts with `try/finally` restoration and fail-closed site validation
- retain shipped bare `attachment_id` input only as explicit same-site compatibility, normalizing it immediately to the canonical identity

## Multisite Contract
WordPress core provides `get_site()`, `switch_to_blog()`, and `restore_current_blog()`, but no network-global attachment resolver. Socials therefore validates the referenced site belongs to the current network, rejects archived/deleted/spam or nonexistent sites, switches only for bounded resource reads/effects, and restores the caller's context on success and failure.

Authorization continues to receive bounded normalized input. It now includes owner-frozen `post_site_id` and canonical asset `source_id` values, so effect-time revalidation and retry cannot drift to a colliding ID on another site. Caller-supplied `post_site_id` is rejected during submit.

## Compatibility
Existing same-site callers may continue sending bare `attachment_id`. The owner resolves that ID only on the submission/post site and freezes it as `<site_id>:<attachment_id>` before enqueue. Cross-site callers must use `source_id`.

## Tests
- added multisite integration coverage for posts and assets on different sites, colliding attachment IDs, nonexistent sites/attachments, success/failure context restoration, effect-time revalidation, retry identity, and same-site compatibility
- focused delegated-operation PHPUnit: 6 passed, 3 multisite-only skipped in the single-site profile
- SocialPublishAbility PHPUnit: 9 passed
- PHPCS, ESLint, and PHPStan level 7: passed with no findings
- scoped Homeboy audit: passed with no introduced findings
- production package build and PHP syntax checks: passed

The local Homeboy multisite Codebox profile exited after dependency activation and reported zero executed tests; the multisite-native suite remains included for the upstream/CI multisite runtime.

Closes #226.
Unblocks Extra-Chill/extrachill-studio#166.