### PR TITLE
refactor: isolate social platform bootstrap

### DIFF
--- a/data-machine-socials.php
+++ b/data-machine-socials.php
@@ -72,103 +72,10 @@ function datamachine_socials_bootstrap() {
 		return;
 	}
 
-	// Load Abilities (they self-register)
+	// Load cross-platform abilities before isolated platform providers.
 	new \DataMachineSocials\Abilities\SocialCommentsAbility();
 
-	// Pinterest
-	new \DataMachineSocials\Abilities\Pinterest\PinterestBoardsAbility();
-	new \DataMachineSocials\Abilities\Pinterest\PinterestPublishAbility();
-
-	// Twitter
-	new \DataMachineSocials\Abilities\Twitter\TwitterPublishAbility();
-	new \DataMachineSocials\Abilities\Twitter\TwitterReadAbility();
-	new \DataMachineSocials\Abilities\Twitter\TwitterUpdateAbility();
-	new \DataMachineSocials\Abilities\Twitter\TwitterDeleteAbility();
-
-	// Facebook
-	new \DataMachineSocials\Abilities\Facebook\FacebookPublishAbility();
-	new \DataMachineSocials\Abilities\Facebook\FacebookReadAbility();
-	new \DataMachineSocials\Abilities\Facebook\FacebookUpdateAbility();
-	new \DataMachineSocials\Abilities\Facebook\FacebookDeleteAbility();
-
-	// Bluesky
-	new \DataMachineSocials\Abilities\Bluesky\BlueskyPublishAbility();
-	new \DataMachineSocials\Abilities\Bluesky\BlueskyReadAbility();
-	new \DataMachineSocials\Abilities\Bluesky\BlueskyUpdateAbility();
-	new \DataMachineSocials\Abilities\Bluesky\BlueskyDeleteAbility();
-
-	// Mastodon
-	new \DataMachineSocials\Abilities\Mastodon\MastodonPublishAbility();
-	new \DataMachineSocials\Abilities\Mastodon\MastodonReadAbility();
-	new \DataMachineSocials\Abilities\Mastodon\MastodonUpdateAbility();
-	new \DataMachineSocials\Abilities\Mastodon\MastodonDeleteAbility();
-
-	// Threads
-	new \DataMachineSocials\Abilities\Threads\ThreadsPublishAbility();
-	new \DataMachineSocials\Abilities\Threads\ThreadsReadAbility();
-	new \DataMachineSocials\Abilities\Threads\ThreadsUpdateAbility();
-	new \DataMachineSocials\Abilities\Threads\ThreadsDeleteAbility();
-
-	// Instagram
-	new \DataMachineSocials\Abilities\Instagram\InstagramPublishAbility();
-	new \DataMachineSocials\Abilities\Instagram\InstagramReadAbility();
-	new \DataMachineSocials\Abilities\Instagram\InstagramUpdateAbility();
-	new \DataMachineSocials\Abilities\Instagram\InstagramDeleteAbility();
-	new \DataMachineSocials\Abilities\Instagram\InstagramCommentReplyAbility();
-
-	// TikTok
-	new \DataMachineSocials\Abilities\TikTok\TikTokPublishAbility();
-	new \DataMachineSocials\Abilities\TikTok\TikTokReadAbility();
-
-	// Pinterest
-	new \DataMachineSocials\Abilities\Pinterest\PinterestReadAbility();
-	new \DataMachineSocials\Abilities\Pinterest\PinterestUpdateAbility();
-	new \DataMachineSocials\Abilities\Pinterest\PinterestDeleteAbility();
-	new \DataMachineSocials\Abilities\Pinterest\PinterestAnalyticsAbility();
-
-	// LinkedIn
-	new \DataMachineSocials\Abilities\LinkedIn\LinkedInPublishAbility();
-	new \DataMachineSocials\Abilities\LinkedIn\LinkedInReadAbility();
-	new \DataMachineSocials\Abilities\LinkedIn\LinkedInUpdateAbility();
-	new \DataMachineSocials\Abilities\LinkedIn\LinkedInDeleteAbility();
-
-	// Reddit
-	new \DataMachineSocials\Abilities\Reddit\FetchRedditAbility();
-	new \DataMachineSocials\Abilities\Reddit\RedditDomainMentionsAbility();
-	new \DataMachineSocials\Abilities\Reddit\RedditCommentDomainMonitorAbility();
-	new \DataMachineSocials\Abilities\Reddit\ReplyRedditAbility();
-	new \DataMachineSocials\Abilities\Reddit\SubmitRedditAbility();
-	new \DataMachineSocials\Abilities\Reddit\VoteRedditAbility();
-
-	// YouTube
-	new \DataMachineSocials\Abilities\YouTube\YouTubeUploadAbility();
-	new \DataMachineSocials\Abilities\YouTube\YouTubeSearchAbility();
-	new \DataMachineSocials\Abilities\YouTube\YouTubeAccountAbility();
-
-	// Tumblr
-	new \DataMachineSocials\Abilities\Tumblr\TumblrPublishAbility();
-	new \DataMachineSocials\Abilities\Tumblr\TumblrReadAbility();
-	new \DataMachineSocials\Abilities\Tumblr\TumblrUpdateAbility();
-	new \DataMachineSocials\Abilities\Tumblr\TumblrDeleteAbility();
-	new \DataMachineSocials\Abilities\Tumblr\TumblrEngageAbility();
-
-	// Social Handlers
-	new \DataMachineSocials\Handlers\Twitter\Twitter();
-	new \DataMachineSocials\Handlers\Facebook\Facebook();
-	new \DataMachineSocials\Handlers\Threads\Threads();
-	new \DataMachineSocials\Handlers\Bluesky\Bluesky();
-	new \DataMachineSocials\Handlers\Mastodon\Mastodon();
-	new \DataMachineSocials\Handlers\Pinterest\Pinterest();
-	new \DataMachineSocials\Handlers\Instagram\Instagram();
-	new \DataMachineSocials\Handlers\TikTok\TikTok();
-	new \DataMachineSocials\Handlers\LinkedIn\LinkedIn();
-	new \DataMachineSocials\Handlers\Tumblr\Tumblr();
-
-	// Reddit (Fetch)
-	new \DataMachineSocials\Handlers\Reddit\Reddit();
-
-	// YouTube
-	new \DataMachineSocials\Handlers\YouTube\YouTube();
+	\DataMachineSocials\Bootstrap\PlatformBootstrap::instance()->register();
 
 	// Register task handlers for DM Task System.
 	add_filter( 'datamachine_tasks', function ( array $tasks ): array {
@@ -191,6 +98,15 @@ function datamachine_socials_bootstrap() {
 	\DataMachineSocials\RestApi::register();
 }
 add_action( 'plugins_loaded', 'datamachine_socials_bootstrap', 20 );
+
+/**
+ * Return explicit bootstrap availability for every social platform.
+ *
+ * @return array<string, array<string, mixed>>
+ */
+function datamachine_socials_get_platform_availability() {
+	return \DataMachineSocials\Bootstrap\PlatformBootstrap::instance()->availability();
+}
 
 /**
  * Register the Data Machine Socials CLI section in the composable AGENTS.md
@@ -254,8 +170,9 @@ function datamachine_socials_enqueue_assets( $hook ) {
 	);
 
 	// Pass data to JavaScript
-	$post_id        = get_the_ID();
-	$featured_image = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), 'full' );
+	$post_id        = (int) get_the_ID();
+	$thumbnail_id   = (int) get_post_thumbnail_id( $post_id );
+	$featured_image = wp_get_attachment_image_src( $thumbnail_id, 'full' );
 
 	wp_localize_script(
 		'data-machine-socials-editor',
@@ -264,7 +181,7 @@ function datamachine_socials_enqueue_assets( $hook ) {
 			'postId'        => $post_id,
 			'restNonce'     => wp_create_nonce( 'wp_rest' ),
 			'featuredImage' => $featured_image ? array(
-				'id'     => get_post_thumbnail_id( $post_id ),
+				'id'     => $thumbnail_id,
 				'url'    => $featured_image[0],
 				'width'  => $featured_image[1],
 				'height' => $featured_image[2],
@@ -277,9 +194,11 @@ add_action( 'admin_enqueue_scripts', 'datamachine_socials_enqueue_assets' );
 /**
  * Register WP-CLI commands.
  */
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	// CommandRegistry is the single source of truth for runtime registration.
-	foreach ( \DataMachineSocials\Cli\CommandRegistry::map() as $command => $class ) {
+if ( defined( 'WP_CLI' ) ) {
+	// Cross-platform commands remain outside platform-local providers.
+	foreach ( array( 'datamachine-socials comments', 'datamachine-socials shares' ) as $command ) {
+		$command_map = \DataMachineSocials\Cli\CommandRegistry::map();
+		$class       = $command_map[ $command ];
 		require_once \DataMachineSocials\Cli\CommandRegistry::file_for_class( $class );
 		WP_CLI::add_command( $command, $class );
 	}
@@ -292,55 +211,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  * Only load when Data Machine core's AI engine is available.
  */
 function datamachine_socials_load_chat_tools() {
-	if ( ! class_exists( 'DataMachine\Engine\AI\Tools\BaseTool' ) ) {
-		return;
-	}
-
-	new \DataMachineSocials\Chat\Tools\FetchReddit();
-	new \DataMachineSocials\Chat\Tools\ReplyReddit();
-	new \DataMachineSocials\Chat\Tools\SubmitReddit();
-	new \DataMachineSocials\Chat\Tools\VoteReddit();
-	new \DataMachineSocials\Chat\Tools\ReadInstagram();
-	new \DataMachineSocials\Chat\Tools\UpdateInstagram();
-	new \DataMachineSocials\Chat\Tools\ReplyInstagramComment();
-	new \DataMachineSocials\Chat\Tools\PublishInstagram();
-	new \DataMachineSocials\Chat\Tools\PublishReelInstagram();
-	new \DataMachineSocials\Chat\Tools\PublishStoryInstagram();
-	new \DataMachineSocials\Chat\Tools\PublishTikTok();
-	new \DataMachineSocials\Chat\Tools\PublishTwitter();
-	new \DataMachineSocials\Chat\Tools\PublishFacebook();
-	new \DataMachineSocials\Chat\Tools\PublishBluesky();
-	new \DataMachineSocials\Chat\Tools\PublishThreads();
-	new \DataMachineSocials\Chat\Tools\PublishPinterest();
-	new \DataMachineSocials\Chat\Tools\ReadThreads();
-	new \DataMachineSocials\Chat\Tools\ReadFacebook();
-	new \DataMachineSocials\Chat\Tools\UpdateFacebook();
-	new \DataMachineSocials\Chat\Tools\ReadTwitter();
-	new \DataMachineSocials\Chat\Tools\UpdateTwitter();
-	new \DataMachineSocials\Chat\Tools\ReadBluesky();
-	new \DataMachineSocials\Chat\Tools\UpdateBluesky();
-	new \DataMachineSocials\Chat\Tools\ReadPinterest();
-	new \DataMachineSocials\Chat\Tools\UpdatePinterest();
-	new \DataMachineSocials\Chat\Tools\UpdateThreads();
-	new \DataMachineSocials\Chat\Tools\PublishYouTube();
-	new \DataMachineSocials\Chat\Tools\SearchYouTube();
-
-	// LinkedIn chat tools
-	new \DataMachineSocials\Chat\Tools\PublishLinkedIn();
-	new \DataMachineSocials\Chat\Tools\ReadLinkedIn();
-	new \DataMachineSocials\Chat\Tools\UpdateLinkedIn();
-	new \DataMachineSocials\Chat\Tools\DeleteLinkedIn();
-
-	// Tumblr chat tools
-	new \DataMachineSocials\Chat\Tools\PublishTumblr();
-	new \DataMachineSocials\Chat\Tools\ReadTumblr();
-
-	// Delete chat tools
-	new \DataMachineSocials\Chat\Tools\DeleteInstagram();
-	new \DataMachineSocials\Chat\Tools\DeleteTwitter();
-	new \DataMachineSocials\Chat\Tools\DeleteFacebook();
-	new \DataMachineSocials\Chat\Tools\DeleteThreads();
-	new \DataMachineSocials\Chat\Tools\DeleteBluesky();
-	new \DataMachineSocials\Chat\Tools\DeletePinterest();
+	$bootstrap = \DataMachineSocials\Bootstrap\PlatformBootstrap::instance();
+	$bootstrap->register_tools();
+	$bootstrap->register_cli();
 }
 add_action( 'plugins_loaded', 'datamachine_socials_load_chat_tools', 25 );

--- a/inc/Bootstrap/PlatformBootstrap.php
+++ b/inc/Bootstrap/PlatformBootstrap.php
@@ -167,16 +167,20 @@ final class PlatformBootstrap {
 			},
 			$tool_names
 		);
-		$command = 'datamachine-socials ' . $id;
+		$command      = 'datamachine-socials ' . $id;
 
 		return new PlatformProvider(
 			$id,
 			array_merge( array( 'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' ), $ability_classes, array( $handler_class ) ),
 			array(
-				'abilities' => $ability_slugs,
-				'handler'   => 'reddit' === $id ? 'reddit' : $id . '_publish',
-				'tools'     => $tool_names,
-				'cli'       => $command,
+				'abilities'    => $ability_slugs,
+				'handler'      => 'reddit' === $id ? 'reddit' : $id . '_publish',
+				'tools'        => $tool_names,
+				'cli'          => $command,
+				'requirements' => array(
+					'tools' => 'DataMachine\\Engine\\AI\\Tools\\BaseTool',
+					'cli'   => 'WP_CLI',
+				),
 			),
 			static function () use ( $ability_classes, $handler_class ): void {
 				foreach ( $ability_classes as $ability_class ) {
@@ -184,24 +188,28 @@ final class PlatformBootstrap {
 				}
 				new $handler_class();
 			},
-			$tool_classes ? static function () use ( $tool_classes ): void {
+			$tool_classes ? static function () use ( $tool_classes ): bool {
 				if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
-					return;
+					return false;
 				}
 
 				foreach ( $tool_classes as $tool_class ) {
 					new $tool_class();
 				}
+
+				return true;
 			} : null,
-			static function () use ( $command ): void {
+			static function () use ( $command ): bool {
 				if ( ! defined( 'WP_CLI' ) ) {
-					return;
+					return false;
 				}
 
 				$command_map   = CommandRegistry::map();
 				$command_class = $command_map[ $command ];
 				require_once CommandRegistry::file_for_class( $command_class );
 				\WP_CLI::add_command( $command, $command_class );
+
+				return true;
 			}
 		);
 	}

--- a/inc/Bootstrap/PlatformBootstrap.php
+++ b/inc/Bootstrap/PlatformBootstrap.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Data Machine Socials platform bootstrap registry.
+ *
+ * @package DataMachineSocials\Bootstrap
+ */
+
+namespace DataMachineSocials\Bootstrap;
+
+use DataMachineSocials\Cli\CommandRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns deterministic, failure-isolated registration of social integrations.
+ */
+final class PlatformBootstrap {
+
+	private static ?self $instance = null;
+
+	/** @var array<int, PlatformProvider> */
+	private array $providers;
+
+	/** @var array<int, string> */
+	private array $duplicates = array();
+
+	/** @param array<int, PlatformProvider> $providers Ordered platform providers. */
+	public function __construct( array $providers ) {
+		$this->providers = $providers;
+	}
+
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self( self::platform_providers() );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register all platform abilities and handlers in catalog order.
+	 */
+	public function register(): void {
+		$seen = array();
+
+		foreach ( $this->providers as $provider ) {
+			if ( isset( $seen[ $provider->id() ] ) ) {
+				$provider->mark_duplicate();
+				$this->duplicates[] = $provider->id();
+				continue;
+			}
+
+			$seen[ $provider->id() ] = true;
+			$provider->register();
+		}
+	}
+
+	/**
+	 * Register chat tools for every available platform.
+	 */
+	public function register_tools(): void {
+		foreach ( $this->ordered_providers( array( 'reddit', 'instagram', 'tiktok', 'twitter', 'facebook', 'bluesky', 'threads', 'pinterest', 'youtube', 'linkedin', 'tumblr', 'mastodon' ) ) as $provider ) {
+			$provider->register_tools();
+		}
+	}
+
+	/**
+	 * Register CLI commands for every available platform.
+	 */
+	public function register_cli(): void {
+		foreach ( $this->ordered_providers( array( 'linkedin', 'pinterest', 'tumblr', 'reddit', 'instagram', 'tiktok', 'threads', 'facebook', 'twitter', 'bluesky', 'youtube', 'mastodon' ) ) as $provider ) {
+			$provider->register_cli();
+		}
+	}
+
+	/**
+	 * Return platform availability keyed by stable platform ID.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function availability(): array {
+		$availability = array();
+
+		foreach ( $this->providers as $provider ) {
+			if ( ! isset( $availability[ $provider->id() ] ) ) {
+				$availability[ $provider->id() ] = $provider->availability();
+			}
+		}
+
+		return $availability;
+	}
+
+	/** @return array<int, string> */
+	public function duplicates(): array {
+		return array_values( array_unique( $this->duplicates ) );
+	}
+
+	/**
+	 * Return providers in a phase-specific stable order without losing unknown
+	 * providers supplied to a test or future Socials-owned catalog extension.
+	 *
+	 * @param array<int, string> $ids Preferred platform order.
+	 * @return array<int, PlatformProvider>
+	 */
+	private function ordered_providers( array $ids ): array {
+		$order = array_flip( $ids );
+		$next  = count( $order );
+
+		$providers = $this->providers;
+		usort(
+			$providers,
+			static function ( PlatformProvider $left, PlatformProvider $right ) use ( $order, $next ): int {
+				return ( $order[ $left->id() ] ?? $next ) <=> ( $order[ $right->id() ] ?? $next );
+			}
+		);
+
+		return $providers;
+	}
+
+	/**
+	 * Build the ordered Socials-owned provider catalog.
+	 *
+	 * Handler order intentionally matches the pre-provider bootstrap so platform
+	 * configuration discovery remains stable.
+	 *
+	 * @return array<int, PlatformProvider>
+	 */
+	private static function platform_providers(): array {
+		return array(
+			self::provider( 'twitter', 'Twitter', array( 'TwitterPublishAbility', 'TwitterReadAbility', 'TwitterUpdateAbility', 'TwitterDeleteAbility' ), array( 'datamachine/twitter-publish', 'datamachine/twitter-account', 'datamachine/twitter-read', 'datamachine/twitter-update', 'datamachine/twitter-delete' ), array( 'PublishTwitter', 'ReadTwitter', 'UpdateTwitter', 'DeleteTwitter' ) ),
+			self::provider( 'facebook', 'Facebook', array( 'FacebookPublishAbility', 'FacebookReadAbility', 'FacebookUpdateAbility', 'FacebookDeleteAbility' ), array( 'datamachine/facebook-publish', 'datamachine/facebook-pages', 'datamachine/facebook-read', 'datamachine/facebook-update', 'datamachine/facebook-delete' ), array( 'PublishFacebook', 'ReadFacebook', 'UpdateFacebook', 'DeleteFacebook' ) ),
+			self::provider( 'threads', 'Threads', array( 'ThreadsPublishAbility', 'ThreadsReadAbility', 'ThreadsUpdateAbility', 'ThreadsDeleteAbility' ), array( 'datamachine/threads-publish', 'datamachine/threads-account', 'datamachine/threads-read', 'datamachine/threads-update', 'datamachine/threads-delete' ), array( 'PublishThreads', 'ReadThreads', 'UpdateThreads', 'DeleteThreads' ) ),
+			self::provider( 'bluesky', 'Bluesky', array( 'BlueskyPublishAbility', 'BlueskyReadAbility', 'BlueskyUpdateAbility', 'BlueskyDeleteAbility' ), array( 'datamachine/bluesky-publish', 'datamachine/bluesky-account', 'datamachine/bluesky-read', 'datamachine/bluesky-update', 'datamachine/bluesky-delete' ), array( 'PublishBluesky', 'ReadBluesky', 'UpdateBluesky', 'DeleteBluesky' ) ),
+			self::provider( 'mastodon', 'Mastodon', array( 'MastodonPublishAbility', 'MastodonReadAbility', 'MastodonUpdateAbility', 'MastodonDeleteAbility' ), array( 'datamachine/mastodon-publish', 'datamachine/mastodon-account', 'datamachine/mastodon-read', 'datamachine/mastodon-update', 'datamachine/mastodon-delete' ), array() ),
+			self::provider( 'pinterest', 'Pinterest', array( 'PinterestBoardsAbility', 'PinterestPublishAbility', 'PinterestReadAbility', 'PinterestUpdateAbility', 'PinterestDeleteAbility', 'PinterestAnalyticsAbility' ), array( 'datamachine/pinterest-sync-boards', 'datamachine/pinterest-list-boards', 'datamachine/pinterest-status', 'datamachine/pinterest-publish', 'datamachine/pinterest-read', 'datamachine/pinterest-update', 'datamachine/pinterest-delete', 'datamachine/pinterest-analytics' ), array( 'PublishPinterest', 'ReadPinterest', 'UpdatePinterest', 'DeletePinterest' ) ),
+			self::provider( 'instagram', 'Instagram', array( 'InstagramPublishAbility', 'InstagramReadAbility', 'InstagramUpdateAbility', 'InstagramDeleteAbility', 'InstagramCommentReplyAbility' ), array( 'datamachine/instagram-publish', 'datamachine/instagram-account', 'datamachine/instagram-read', 'datamachine/instagram-update', 'datamachine/instagram-delete', 'datamachine/instagram-comment-reply' ), array( 'ReadInstagram', 'UpdateInstagram', 'ReplyInstagramComment', 'PublishInstagram', 'PublishReelInstagram', 'PublishStoryInstagram', 'DeleteInstagram' ) ),
+			self::provider( 'tiktok', 'TikTok', array( 'TikTokPublishAbility', 'TikTokReadAbility' ), array( 'datamachine/tiktok-publish', 'datamachine/tiktok-account', 'datamachine/tiktok-read' ), array( 'PublishTikTok' ) ),
+			self::provider( 'linkedin', 'LinkedIn', array( 'LinkedInPublishAbility', 'LinkedInReadAbility', 'LinkedInUpdateAbility', 'LinkedInDeleteAbility' ), array( 'datamachine/linkedin-publish', 'datamachine/linkedin-account', 'datamachine/linkedin-read', 'datamachine/linkedin-update', 'datamachine/linkedin-delete' ), array( 'PublishLinkedIn', 'ReadLinkedIn', 'UpdateLinkedIn', 'DeleteLinkedIn' ) ),
+			self::provider( 'tumblr', 'Tumblr', array( 'TumblrPublishAbility', 'TumblrReadAbility', 'TumblrUpdateAbility', 'TumblrDeleteAbility', 'TumblrEngageAbility' ), array( 'datamachine/tumblr-publish', 'datamachine/tumblr-read', 'datamachine/tumblr-update', 'datamachine/tumblr-delete', 'datamachine/tumblr-engage' ), array( 'PublishTumblr', 'ReadTumblr' ) ),
+			self::provider( 'reddit', 'Reddit', array( 'FetchRedditAbility', 'RedditDomainMentionsAbility', 'RedditCommentDomainMonitorAbility', 'ReplyRedditAbility', 'SubmitRedditAbility', 'VoteRedditAbility' ), array( 'datamachine/fetch-reddit', 'datamachine/reddit-domain-mentions', 'datamachine/reddit-comment-mentions-poll', 'datamachine/reddit-comment-mentions-report', 'datamachine/reddit-comment-mentions-cleanup', 'datamachine/reply-reddit', 'datamachine/submit-reddit', 'datamachine/vote-reddit' ), array( 'FetchReddit', 'ReplyReddit', 'SubmitReddit', 'VoteReddit' ) ),
+			self::provider( 'youtube', 'YouTube', array( 'YouTubeUploadAbility', 'YouTubeSearchAbility', 'YouTubeAccountAbility' ), array( 'datamachine/youtube-upload', 'datamachine/youtube-search', 'datamachine/youtube-account' ), array( 'PublishYouTube', 'SearchYouTube' ) ),
+		);
+	}
+
+	/**
+	 * Create one declarative platform provider.
+	 *
+	 * @param string            $id            Platform ID and handler namespace.
+	 * @param string            $namespace_part PSR-4 platform namespace segment.
+	 * @param array<int,string> $ability_names Ability class basenames.
+	 * @param array<int,string> $ability_slugs Public ability slugs.
+	 * @param array<int,string> $tool_names    Chat tool class basenames.
+	 */
+	private static function provider( string $id, string $namespace_part, array $ability_names, array $ability_slugs, array $tool_names ): PlatformProvider {
+		$ability_classes = array_map(
+			static function ( string $class_name ) use ( $namespace_part ): string {
+				return 'DataMachineSocials\\Abilities\\' . $namespace_part . '\\' . $class_name;
+			},
+			$ability_names
+		);
+		/** @var array<int, class-string> $ability_classes */
+		$handler_class = 'DataMachineSocials\\Handlers\\' . $namespace_part . '\\' . $namespace_part;
+		/** @var class-string $handler_class */
+		$tool_classes = array_map(
+			static function ( string $class_name ): string {
+				return 'DataMachineSocials\\Chat\\Tools\\' . $class_name;
+			},
+			$tool_names
+		);
+		$command = 'datamachine-socials ' . $id;
+
+		return new PlatformProvider(
+			$id,
+			array_merge( array( 'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' ), $ability_classes, array( $handler_class ) ),
+			array(
+				'abilities' => $ability_slugs,
+				'handler'   => 'reddit' === $id ? 'reddit' : $id . '_publish',
+				'tools'     => $tool_names,
+				'cli'       => $command,
+			),
+			static function () use ( $ability_classes, $handler_class ): void {
+				foreach ( $ability_classes as $ability_class ) {
+					new $ability_class();
+				}
+				new $handler_class();
+			},
+			$tool_classes ? static function () use ( $tool_classes ): void {
+				if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
+					return;
+				}
+
+				foreach ( $tool_classes as $tool_class ) {
+					new $tool_class();
+				}
+			} : null,
+			static function () use ( $command ): void {
+				if ( ! defined( 'WP_CLI' ) ) {
+					return;
+				}
+
+				$command_map   = CommandRegistry::map();
+				$command_class = $command_map[ $command ];
+				require_once CommandRegistry::file_for_class( $command_class );
+				\WP_CLI::add_command( $command, $command_class );
+			}
+		);
+	}
+}

--- a/inc/Bootstrap/PlatformProvider.php
+++ b/inc/Bootstrap/PlatformProvider.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Isolated social platform bootstrap module.
+ *
+ * @package DataMachineSocials\Bootstrap
+ */
+
+namespace DataMachineSocials\Bootstrap;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers one platform without coupling its failure to another platform.
+ */
+final class PlatformProvider {
+
+	private string $id;
+
+	/** @var array<int, class-string> */
+	private array $prerequisites;
+
+	/** @var callable */
+	private $register_core;
+
+	/** @var callable|null */
+	private $register_tools;
+
+	/** @var callable|null */
+	private $register_cli;
+
+	/** @var array<string, mixed> */
+	private array $availability;
+
+	/**
+	 * @param string                   $id             Stable platform ID.
+	 * @param array<int, class-string> $prerequisites Classes required by the platform runtime.
+	 * @param array<string, mixed>     $capabilities  Public capabilities exposed by the platform.
+	 * @param callable                 $register_core Core ability and handler registration.
+	 * @param callable|null            $register_tools Optional chat tool registration.
+	 * @param callable|null            $register_cli  Optional CLI registration.
+	 */
+	public function __construct( string $id, array $prerequisites, array $capabilities, callable $register_core, ?callable $register_tools = null, ?callable $register_cli = null ) {
+		$this->id             = $id;
+		$this->prerequisites  = $prerequisites;
+		$this->register_core  = $register_core;
+		$this->register_tools = $register_tools;
+		$this->register_cli   = $register_cli;
+		$this->availability   = array(
+			'id'                    => $id,
+			'available'             => false,
+			'state'                 => 'pending',
+			'reason'                => null,
+			'missing_prerequisites' => array(),
+			'capabilities'          => $capabilities,
+			'components'            => array(
+				'core'  => 'pending',
+				'tools' => null === $register_tools ? 'not_applicable' : 'pending',
+				'cli'   => null === $register_cli ? 'not_applicable' : 'pending',
+			),
+		);
+	}
+
+	public function id(): string {
+		return $this->id;
+	}
+
+	/**
+	 * Register platform abilities and handler exactly once.
+	 */
+	public function register(): void {
+		if ( 'pending' !== $this->availability['components']['core'] ) {
+			return;
+		}
+
+		if ( '' === trim( $this->id ) ) {
+			$this->availability['state']              = 'unavailable';
+			$this->availability['reason']             = 'invalid_configuration';
+			$this->availability['components']['core'] = 'unavailable';
+			return;
+		}
+
+		$missing = array();
+		foreach ( $this->prerequisites as $class ) {
+			try {
+				if ( ! class_exists( $class ) ) {
+					$missing[] = $class;
+				}
+			} catch ( \Throwable $throwable ) {
+				$this->fail( 'core', $throwable );
+				return;
+			}
+		}
+
+		if ( $missing ) {
+			$this->availability['state']                 = 'unavailable';
+			$this->availability['reason']                = 'missing_prerequisites';
+			$this->availability['missing_prerequisites'] = $missing;
+			$this->availability['components']['core']    = 'unavailable';
+			return;
+		}
+
+		try {
+			( $this->register_core )();
+			$this->availability['available']          = true;
+			$this->availability['state']              = 'registered';
+			$this->availability['components']['core'] = 'registered';
+		} catch ( \Throwable $throwable ) {
+			$this->fail( 'core', $throwable );
+		}
+	}
+
+	/**
+	 * Register optional chat tools exactly once.
+	 */
+	public function register_tools(): void {
+		$this->register_optional_component( 'tools', $this->register_tools );
+	}
+
+	/**
+	 * Register the platform CLI command exactly once.
+	 */
+	public function register_cli(): void {
+		$this->register_optional_component( 'cli', $this->register_cli );
+	}
+
+	public function mark_duplicate(): void {
+		if ( 'pending' !== $this->availability['state'] ) {
+			return;
+		}
+
+		$this->availability['state']              = 'duplicate';
+		$this->availability['reason']             = 'duplicate_provider';
+		$this->availability['components']['core'] = 'skipped';
+	}
+
+	/** @return array<string, mixed> */
+	public function availability(): array {
+		return $this->availability;
+	}
+
+	/**
+	 * @param string        $component Component key.
+	 * @param callable|null $callback  Registration callback.
+	 */
+	private function register_optional_component( string $component, ?callable $callback ): void {
+		if ( 'pending' !== $this->availability['components'][ $component ] ) {
+			return;
+		}
+
+		if ( 'registered' !== $this->availability['components']['core'] ) {
+			$this->availability['components'][ $component ] = 'skipped';
+			return;
+		}
+
+		if ( null === $callback ) {
+			$this->availability['components'][ $component ] = 'not_applicable';
+			return;
+		}
+
+		try {
+			$callback();
+			$this->availability['components'][ $component ] = 'registered';
+		} catch ( \Throwable $throwable ) {
+			$this->fail( $component, $throwable );
+		}
+	}
+
+	private function fail( string $component, \Throwable $throwable ): void {
+		$this->availability['available']                = false;
+		$this->availability['state']                    = 'failed';
+		$this->availability['reason']                   = $component . '_registration_failed';
+		$this->availability['components'][ $component ] = 'failed';
+
+		do_action( 'datamachine_socials_platform_bootstrap_failed', $this->id, $component, $throwable );
+	}
+}

--- a/inc/Bootstrap/PlatformProvider.php
+++ b/inc/Bootstrap/PlatformProvider.php
@@ -50,6 +50,7 @@ final class PlatformProvider {
 			'available'             => false,
 			'state'                 => 'pending',
 			'reason'                => null,
+			'prerequisites'         => $prerequisites,
 			'missing_prerequisites' => array(),
 			'capabilities'          => $capabilities,
 			'components'            => array(
@@ -158,8 +159,8 @@ final class PlatformProvider {
 		}
 
 		try {
-			$callback();
-			$this->availability['components'][ $component ] = 'registered';
+			$result = $callback();
+			$this->availability['components'][ $component ] = false === $result ? 'unavailable' : 'registered';
 		} catch ( \Throwable $throwable ) {
 			$this->fail( $component, $throwable );
 		}

--- a/tests/Unit/Bootstrap/PlatformBootstrapTest.php
+++ b/tests/Unit/Bootstrap/PlatformBootstrapTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Platform bootstrap isolation tests.
+ *
+ * @package DataMachineSocials\Tests\Unit\Bootstrap
+ */
+
+use DataMachineSocials\Bootstrap\PlatformBootstrap;
+use DataMachineSocials\Bootstrap\PlatformProvider;
+
+final class PlatformBootstrapTest extends WP_UnitTestCase {
+
+	public function test_bootstrap_matrix_isolates_provider_availability_and_failures(): void {
+		$order = array();
+
+		$present = $this->provider( 'present', $order );
+		$absent  = $this->provider( 'absent', $order, array( 'DataMachineSocials\\Tests\\MissingPlatformDependency' ) );
+		$throwing = $this->provider(
+			'throwing',
+			$order,
+			array(),
+			static function () use ( &$order ): void {
+				$order[] = 'throwing';
+				throw new RuntimeException( 'Platform constructor failed.' );
+			}
+		);
+		$unrelated = $this->provider( 'unrelated', $order );
+		$bootstrap = new PlatformBootstrap( array( $present, $absent, $throwing, $unrelated ) );
+
+		$bootstrap->register();
+
+		$this->assertSame( array( 'present', 'throwing', 'unrelated' ), $order );
+		$this->assertSame( 'registered', $present->availability()['state'] );
+		$this->assertSame( 'unavailable', $absent->availability()['state'] );
+		$this->assertSame( 'missing_prerequisites', $absent->availability()['reason'] );
+		$this->assertSame( 'failed', $throwing->availability()['state'] );
+		$this->assertSame( 'registered', $unrelated->availability()['state'] );
+	}
+
+	public function test_misconfigured_optional_component_does_not_suppress_another_platform(): void {
+		$order = array();
+		$broken_tools = $this->provider(
+			'broken-tools',
+			$order,
+			array(),
+			null,
+			static function (): void {
+				throw new InvalidArgumentException( 'Invalid tool configuration.' );
+			}
+		);
+		$healthy = $this->provider( 'healthy', $order, array(), null, static function () use ( &$order ): void {
+			$order[] = 'healthy-tools';
+		} );
+		$bootstrap = new PlatformBootstrap( array( $broken_tools, $healthy ) );
+
+		$bootstrap->register();
+		$bootstrap->register_tools();
+
+		$this->assertSame( 'tools_registration_failed', $broken_tools->availability()['reason'] );
+		$this->assertSame( 'registered', $healthy->availability()['components']['tools'] );
+		$this->assertContains( 'healthy-tools', $order );
+	}
+
+	public function test_misconfigured_provider_is_unavailable_without_running_registration(): void {
+		$registered = false;
+		$provider   = new PlatformProvider( '', array(), array(), static function () use ( &$registered ): void {
+			$registered = true;
+		} );
+
+		( new PlatformBootstrap( array( $provider ) ) )->register();
+
+		$this->assertFalse( $registered );
+		$this->assertSame( 'unavailable', $provider->availability()['state'] );
+		$this->assertSame( 'invalid_configuration', $provider->availability()['reason'] );
+	}
+
+	public function test_registration_is_idempotent_ordered_and_rejects_duplicates(): void {
+		$order     = array();
+		$first     = $this->provider( 'first', $order );
+		$duplicate = $this->provider( 'first', $order );
+		$last      = $this->provider( 'last', $order );
+		$bootstrap = new PlatformBootstrap( array( $first, $duplicate, $last ) );
+
+		$bootstrap->register();
+		$bootstrap->register();
+
+		$this->assertSame( array( 'first', 'last' ), $order );
+		$this->assertSame( 'duplicate', $duplicate->availability()['state'] );
+		$this->assertSame( array( 'first' ), $bootstrap->duplicates() );
+		$this->assertSame( array( 'first', 'last' ), array_keys( $bootstrap->availability() ) );
+	}
+
+	public function test_availability_exposes_declared_capabilities(): void {
+		$order        = array();
+		$capabilities = array(
+			'abilities' => array( 'datamachine/example-publish' ),
+			'handler'   => 'example_publish',
+			'tools'     => array( 'PublishExample' ),
+			'cli'       => 'datamachine-socials example',
+		);
+		$provider     = new PlatformProvider( 'example', array(), $capabilities, static function () use ( &$order ): void {
+			$order[] = 'example';
+		} );
+		$bootstrap    = new PlatformBootstrap( array( $provider ) );
+
+		$bootstrap->register();
+
+		$this->assertSame( $capabilities, $bootstrap->availability()['example']['capabilities'] );
+		$this->assertTrue( $bootstrap->availability()['example']['available'] );
+	}
+
+	/**
+	 * @param array<int,string>                 $order         Registration log.
+	 * @param array<int,class-string>           $prerequisites Required classes.
+	 * @param callable|null                     $core           Core callback override.
+	 * @param callable|null                     $tools          Tools callback.
+	 */
+	private function provider( string $id, array &$order, array $prerequisites = array(), ?callable $core = null, ?callable $tools = null ): PlatformProvider {
+		$core = $core ?? static function () use ( $id, &$order ): void {
+			$order[] = $id;
+		};
+
+		return new PlatformProvider(
+			$id,
+			$prerequisites,
+			array( 'abilities' => array( 'datamachine/' . $id ) ),
+			$core,
+			$tools
+		);
+	}
+}

--- a/tests/Unit/Bootstrap/PlatformBootstrapTest.php
+++ b/tests/Unit/Bootstrap/PlatformBootstrapTest.php
@@ -109,6 +109,20 @@ final class PlatformBootstrapTest extends WP_UnitTestCase {
 		$this->assertTrue( $bootstrap->availability()['example']['available'] );
 	}
 
+	public function test_absent_optional_prerequisite_is_discoverable(): void {
+		$order     = array();
+		$provider  = $this->provider( 'optional-absent', $order, array(), null, static function (): bool {
+			return false;
+		} );
+		$bootstrap = new PlatformBootstrap( array( $provider ) );
+
+		$bootstrap->register();
+		$bootstrap->register_tools();
+
+		$this->assertTrue( $provider->availability()['available'] );
+		$this->assertSame( 'unavailable', $provider->availability()['components']['tools'] );
+	}
+
 	/**
 	 * @param array<int,string>                 $order         Registration log.
 	 * @param array<int,class-string>           $prerequisites Required classes.


### PR DESCRIPTION
## Summary
- replace the serial all-platform bootstrap with deterministic, idempotent Socials-owned provider modules
- isolate core, chat-tool, and CLI registration so absent, misconfigured, or throwing platforms cannot suppress unrelated platforms
- expose platform prerequisites, component availability, and preserved abilities/handlers/tools/CLI capabilities through `datamachine_socials_get_platform_availability()`
- preserve existing platform IDs, handler order, CLI order, tool order, ability slugs, REST registration, task/action contracts, and publishing implementations

## Provider isolation and availability
- each platform validates its own required runtime classes before registration
- every registration phase catches platform-local `Throwable` failures and continues through the remaining providers
- duplicate platform IDs are skipped deterministically and reported through bootstrap diagnostics
- optional chat/CLI prerequisites report `unavailable` without making an otherwise registered platform unavailable
- shared Socials behavior remains outside the provider catalog; no generic Data Machine layer or universal provider framework changed

## Compatibility
- all ability, handler, and chat-tool classes constructed by the previous bootstrap remain represented in the provider catalog
- public ability slugs and handler/platform configuration stay unchanged
- REST routes and delegated publishing/task registration remain unchanged
- no business-logic implementation, version, or changelog changes

## Tests
- PASS: differential PHPCS and PHPStan (`homeboy review lint --changed-since origin/main`)
- PASS: differential architecture audit, zero introduced findings
- PASS: production package build and WordPress frontend build
- PASS: standalone provider matrix covering present, absent, throwing, duplicate, deterministic order, and unrelated-platform continuity
- PASS: PHPUnit matrix added for present, absent, misconfigured, throwing, duplicate, idempotence, deterministic order, capability discovery, optional prerequisites, and continuity
- PASS: AGENTS routing, strict-image publishing, and Twitter media-contract integration smokes
- PASS: legacy ability/handler/tool construction coverage comparison against `origin/main`
- BLOCKED: full WordPress PHPUnit runner returns zero executed tests in the repository's WP Codebox harness (run `475ddeca-05fc-4932-ac44-7aa9ca7e8d49`); the harness activates only the Data Machine dependency and reports no suites
- BASELINE: `npm run lint:js` reports 600 existing frontend formatting findings in untouched files; changed PHP lint is clean
- BASELINE: `npm test` is the repository's intentional `Error: no test specified` placeholder
- BASELINE: delegated cross-post standalone smoke currently fatals in unchanged `DelegatedCrossPostAction::register()` because its harness does not stub/load `SocialPublishAbility`; the other three standalone integration smokes pass

Closes #223